### PR TITLE
Generated DOM prototypes carry Symbol.iterator, because a JsObjectShape can now declare a symbol-keyed member

### DIFF
--- a/Jint.Browser/Dom/AGENTS.md
+++ b/Jint.Browser/Dom/AGENTS.md
@@ -92,8 +92,13 @@ Divergences from a browser that are **ours** and deliberate:
 
 - **`length` on a collection is an own property**, not a prototype accessor, because `ArrayLikeObject` owns
   it; `list.hasOwnProperty('length')` answers `true`. `Jint/Native/Object/AGENTS.md` says why it cannot move.
-- **`Symbol.iterator` is on the instance**, not the interface prototype, because `JsObjectShape` has no
-  symbol-keyed member yet. The value is the same function object; nothing a script does can tell.
+- **`Symbol.iterator` is declared by the interface that *supports* indexed properties**, never by one that
+  merely inherits the getter, which is where a browser has it too: `NodeList.prototype` and
+  `HTMLCollection.prototype` carry it, `HTMLOptionsCollection.prototype` does not. The value is a per-realm
+  slot naming `%Array.prototype.values%` itself, per
+  [WebIDL](https://webidl.spec.whatwg.org/#js-iterable), so `NodeList.prototype[Symbol.iterator] ===
+  Array.prototype[Symbol.iterator]`. `DomIterator.ArrayValues` is the factory the emitter names, and it reads
+  `DomRealm.PrincipalRealm` for the reason everything else here does.
 - **`(Node or DOMString)...` takes only the `Node` half**: `append('text')` is a `TypeError` where a browser
   inserts a text node, because a static member body has no document to create one against.
 - **`select.add` and `HTMLOptionsCollection.add` take one of their two overloads**, because HTML's union type

--- a/Jint.Browser/Dom/Collections/DomCollectionBase.cs
+++ b/Jint.Browser/Dom/Collections/DomCollectionBase.cs
@@ -3,8 +3,8 @@ using Jint.Native.Object;
 namespace Jint.Browser.Dom.Collections;
 
 /// <summary>
-/// What every DOM collection wrapper shares: the AngleSharp object, the realm, the interface it was given a
-/// prototype from, and the <c>Symbol.iterator</c> wiring.
+/// What every DOM collection wrapper shares: the AngleSharp object, the realm, and the interface it was
+/// given a prototype from.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -32,7 +32,6 @@ internal abstract class DomCollectionBase : ArrayLikeObject, IDomWrapper
         Definition = definition;
         DomTarget = target;
         Prototype = realm.PrototypeOf(definition);
-        DomIterator.Install(realm, this);
     }
 
     /// <inheritdoc />

--- a/Jint.Browser/Dom/Collections/DomIterator.cs
+++ b/Jint.Browser/Dom/Collections/DomIterator.cs
@@ -1,35 +1,36 @@
+using Jint.Native;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
-using Jint.Runtime.Descriptors;
 
 namespace Jint.Browser.Dom.Collections;
 
 /// <summary>
-/// Wires <c>Symbol.iterator</c> onto a collection instance.
+/// The value of <c>Symbol.iterator</c> on a collection's interface prototype.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <c>ArrayLikeObject</c> deliberately installs no iterator and its class remarks prescribe this exact wiring:
-/// point <c>Symbol.iterator</c> at <c>Array.prototype[Symbol.iterator]</c> — which is what WHATWG
-/// specifications do for <c>NodeList</c> — and <c>for..of</c>, spread, <c>Array.from</c> and array
-/// destructuring all route through the engine's array-like iterator against <c>TryGetIndex</c>.
+/// https://webidl.spec.whatwg.org/#js-iterable — an interface that supports indexed properties has
+/// <c>@@iterator</c>, and its value is the realm's <c>%Array.prototype.values%</c> itself rather than a
+/// function wrapping it, which is what makes <c>NodeList.prototype[Symbol.iterator] ===
+/// Array.prototype[Symbol.iterator]</c> hold in a browser and here. <c>ArrayLikeObject</c> deliberately
+/// installs no iterator of its own and its class remarks prescribe exactly this value: <c>for..of</c>,
+/// spread, <c>Array.from</c> and array destructuring then route through the engine's array-like iterator
+/// against <c>TryGetIndex</c>.
 /// </para>
 /// <para>
-/// It goes on the <em>instance</em> rather than on the interface prototype, which is a divergence worth
-/// naming: a browser puts it on <c>NodeList.prototype</c> as an <c>iterable&lt;&gt;</c> declaration, so
-/// <c>NodeList.prototype[Symbol.iterator]</c> answers there and answers <c>undefined</c> here. The value is
-/// the same function object either way, and nothing a script does with a collection can tell the difference;
-/// moving it to the shape means giving <c>JsObjectShape</c> a symbol-keyed member, which is additive and can
-/// happen later.
+/// It is declared on the shape as a per-realm slot rather than written onto each wrapper, so it is one
+/// unmaterialized descriptor on the prototype instead of an own property on every collection a page ever
+/// touches — and the value is read from <see cref="DomRealm.PrincipalRealm"/> rather than from the running
+/// realm, so a collection first reached inside a <c>ShadowRealm</c> callback still iterates with the array
+/// iterator its own object belongs to.
 /// </para>
 /// </remarks>
 internal static class DomIterator
 {
-    internal static void Install(DomRealm realm, ObjectInstance collection)
-    {
-        var iterator = realm.PrincipalRealm.Intrinsics.Array.PrototypeObject.Get(GlobalSymbolRegistry.Iterator);
-        collection.DefineOwnPropertyUnchecked(
-            GlobalSymbolRegistry.Iterator,
-            new PropertyDescriptor(iterator, PropertyFlag.NonEnumerable));
-    }
+    /// <summary>
+    /// The array iterator of the realm <paramref name="prototype"/> belongs to. Shaped as a
+    /// <c>JsObjectShape</c> per-realm slot factory, which is how the generated shapes name it.
+    /// </summary>
+    internal static JsValue ArrayValues(ObjectInstance prototype)
+        => DomRealm.Of(prototype.Engine).PrincipalRealm.Intrinsics.Array.PrototypeObject.Get(GlobalSymbolRegistry.Iterator);
 }

--- a/Jint.Browser/Dom/DomManualShapes.cs
+++ b/Jint.Browser/Dom/DomManualShapes.cs
@@ -25,6 +25,13 @@ internal static class DomManualShapes
         => new JsObjectShape.Builder()
             .ToStringTag("HTMLCollection")
             .PerRealmSlot("constructor", enumerable: false)
+
+            // https://webidl.spec.whatwg.org/#js-iterable — the interface supports indexed properties, so its
+            // prototype carries @@iterator; the generated collection shapes get the same line from the
+            // emitter, and this one is hand-written only because the whole shape is.
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                DomIterator.ArrayValues)
             .Method(
                 "item",
                 static (thisObj, args) =>

--- a/Jint.Browser/Dom/Generated/DomShapes.Css.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Css.g.cs
@@ -888,6 +888,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("CSSPseudoElementList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("getByType",
                 global::Jint.Browser.Dom.DomFailures.Guard("CSSPseudoElementList.getByType", static (thisObj, args) =>
                 {
@@ -909,6 +912,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("CSSRuleList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("item",
                 global::Jint.Browser.Dom.DomFailures.Guard("CSSRuleList.item", static (thisObj, args) =>
                 {
@@ -948,6 +954,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("CSSStyleDeclaration")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Accessor("accelerator",
                 global::Jint.Browser.Dom.DomFailures.Guard("CSSStyleDeclaration.accelerator", static (thisObj, args) =>
                 {
@@ -3657,6 +3666,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("MediaList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("appendMedium",
                 global::Jint.Browser.Dom.DomFailures.Guard("MediaList.appendMedium", static (thisObj, args) =>
                 {

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -506,6 +506,9 @@ internal static partial class DomInterfaces
         var builder = new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("DOMTokenList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("add",
                 global::Jint.Browser.Dom.DomFailures.Guard("DOMTokenList.add", static (thisObj, args) =>
                 {
@@ -590,6 +593,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("DOMStringList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("contains",
                 global::Jint.Browser.Dom.DomFailures.Guard("DOMStringList.contains", static (thisObj, args) =>
                 {
@@ -2039,6 +2045,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("NamedNodeMap")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("getNamedItem",
                 global::Jint.Browser.Dom.DomFailures.Guard("NamedNodeMap.getNamedItem", static (thisObj, args) =>
                 {
@@ -2160,6 +2169,9 @@ internal static partial class DomInterfaces
         var builder = new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("NodeList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("item",
                 global::Jint.Browser.Dom.DomFailures.Guard("NodeList.item", static (thisObj, args) =>
                 {
@@ -2465,6 +2477,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("StyleSheetList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("item",
                 global::Jint.Browser.Dom.DomFailures.Guard("StyleSheetList.item", static (thisObj, args) =>
                 {

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -4902,6 +4902,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("TouchList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("item",
                 global::Jint.Browser.Dom.DomFailures.Guard("TouchList.item", static (thisObj, args) =>
                 {

--- a/Jint.Browser/Dom/Generated/DomShapes.Io.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Io.g.cs
@@ -77,6 +77,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("FileList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("item",
                 global::Jint.Browser.Dom.DomFailures.Guard("FileList.item", static (thisObj, args) =>
                 {

--- a/Jint.Browser/Dom/Generated/DomShapes.Media.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Media.g.cs
@@ -61,6 +61,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("AudioTrackList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("getTrackById",
                 global::Jint.Browser.Dom.DomFailures.Guard("AudioTrackList.getTrackById", static (thisObj, args) =>
                 {
@@ -494,6 +497,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("TextTrackList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Build();
 
     /// <summary>The members of <c>TimeRanges</c>.</summary>
@@ -570,6 +576,9 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("VideoTrackList")
             .PerRealmSlot("constructor", enumerable: false)
+            .PerRealmSlot(
+                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)
             .Method("getTrackById",
                 global::Jint.Browser.Dom.DomFailures.Guard("VideoTrackList.getTrackById", static (thisObj, args) =>
                 {

--- a/Jint.Tests.Browser/DomCollectionTests.cs
+++ b/Jint.Tests.Browser/DomCollectionTests.cs
@@ -97,6 +97,54 @@ public sealed class DomCollectionTests
     }
 
     [Test]
+    public void SymbolIteratorIsOnTheInterfacePrototypeAndIsTheArrayIterator()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        // https://webidl.spec.whatwg.org/#js-iterable — an interface that supports indexed properties has
+        // @@iterator on its prototype, and its value is the realm's own %Array.prototype.values%.
+        fixture.Bool("NodeList.prototype[Symbol.iterator] === Array.prototype[Symbol.iterator]").Should().BeTrue();
+        fixture.Bool("HTMLCollection.prototype[Symbol.iterator] === Array.prototype[Symbol.iterator]").Should().BeTrue();
+        fixture.Bool("DOMTokenList.prototype[Symbol.iterator] === Array.prototype[Symbol.iterator]").Should().BeTrue();
+        fixture.Bool("CSSStyleDeclaration.prototype[Symbol.iterator] === Array.prototype[Symbol.iterator]").Should().BeTrue();
+        fixture.Bool("NamedNodeMap.prototype[Symbol.iterator] === Array.prototype[Symbol.iterator]").Should().BeTrue();
+
+        // And on the prototype only: a collection instance carries no own symbol, which is what a browser
+        // answers and what the instance-level workaround this replaced could not.
+        fixture.Bool("document.querySelectorAll('input').hasOwnProperty(Symbol.iterator)").Should().BeFalse();
+        fixture.Number("Object.getOwnPropertySymbols(document.querySelector('#f').childNodes).length").Should().Be(0);
+
+        // https://webidl.spec.whatwg.org/#es-iterator — { writable: true, enumerable: false, configurable: true }.
+        fixture.Bool("Object.getOwnPropertyDescriptor(NodeList.prototype, Symbol.iterator).writable").Should().BeTrue();
+        fixture.Bool("Object.getOwnPropertyDescriptor(NodeList.prototype, Symbol.iterator).enumerable").Should().BeFalse();
+        fixture.Bool("Object.getOwnPropertyDescriptor(NodeList.prototype, Symbol.iterator).configurable").Should().BeTrue();
+
+        // An interface that only *inherits* the indexed getter inherits the iterator with it, which is also
+        // what a browser answers.
+        fixture.Bool("HTMLOptionsCollection.prototype.hasOwnProperty(Symbol.iterator)").Should().BeFalse();
+        fixture.Bool("HTMLFormControlsCollection.prototype.hasOwnProperty(Symbol.iterator)").Should().BeFalse();
+        fixture.Bool("document.querySelector('#s').options[Symbol.iterator] === Array.prototype[Symbol.iterator]").Should().BeTrue();
+
+        // The prototypes are still shaped: a symbol key never disturbs the shared string-keyed layout.
+        fixture.Engine.Advanced.HasSharedShape(fixture.Evaluate("NodeList.prototype").AsObject()).Should().BeTrue();
+    }
+
+    [Test]
+    public void IterationStillReachesEveryCollectionKind()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Number("[...document.querySelectorAll('input')].length").Should().Be(2);
+        fixture.Text("[...document.querySelector('#d').classList].join(',')").Should().Be("x,y,z");
+        fixture.Text("[...document.querySelector('#s').options].map(o => o.value).join(',')").Should().Be("a,b");
+        fixture.Number("[...document.querySelector('#f').elements].length").Should().Be(2);
+
+        // for..of and destructuring take the same lane.
+        fixture.Text("(() => { let n = ''; for (const o of document.querySelector('#s').options) { n += o.value; } return n; })()").Should().Be("ab");
+        fixture.Text("(() => { const [first] = document.querySelector('#s').options; return first.value; })()").Should().Be("a");
+    }
+
+    [Test]
     public void ASelectsOptionsAreAnHtmlCollectionOfOptions()
     {
         using var fixture = DomTestFixture.Create(Page);

--- a/Jint.Tests.Browser/WebIdlPropertyAttributeTests.cs
+++ b/Jint.Tests.Browser/WebIdlPropertyAttributeTests.cs
@@ -32,6 +32,10 @@ namespace Jint.Tests.Browser;
 ///     <term><c>Symbol.toStringTag</c></term>
 ///     <description><c>{ writable: false, enumerable: false, configurable: true }</c></description>
 ///   </item>
+///   <item>
+///     <term><a href="https://webidl.spec.whatwg.org/#js-iterable"><c>Symbol.iterator</c></a></term>
+///     <description><c>{ writable: true, enumerable: false, configurable: true }</c>, on the prototype of an interface that supports indexed properties</description>
+///   </item>
 /// </list>
 /// <para>
 /// It walks every interface rather than a sample, because the attributes come from one call site per kind in
@@ -59,7 +63,11 @@ public sealed class WebIdlPropertyAttributeTests
 
                 if (key.IsSymbol())
                 {
-                    Check(violations, name, descriptor, writable: false, enumerable: false, configurable: true);
+                    // Two symbol-keyed members are emitted and they differ in one attribute: @@iterator is a
+                    // writable data property (Web IDL gives it an operation's writability), @@toStringTag is
+                    // not.
+                    var writableSymbol = ReferenceEquals(key, GlobalSymbolRegistry.Iterator);
+                    Check(violations, name, descriptor, writable: writableSymbol, enumerable: false, configurable: true);
                     continue;
                 }
 

--- a/Jint.Tests.PublicInterface/HostPrototypeShapeTests.cs
+++ b/Jint.Tests.PublicInterface/HostPrototypeShapeTests.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using Jint.Native;
 using Jint.Native.Object;
+using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -79,6 +80,126 @@ public class HostPrototypeShapeTests
         engine.SetValue("proto", prototype);
         engine.Execute("var el = Object.create(proto);");
         return engine;
+    }
+
+    // One member of every symbol-keyed kind. A host declares these for the same reason it declares the
+    // string-keyed ones — so that `NodeList.prototype[Symbol.iterator]` is a property of the prototype rather
+    // than of every instance — and the three forms differ in what produces the value: a function this shape
+    // owns, an accessor pair, and a value that is whatever the *engine* has (the shape of Web IDL's
+    // `iterable<>`, whose @@iterator is the realm's own %Array.prototype.values%).
+    private static readonly JsObjectShape SymbolKeyedShape = new JsObjectShape.Builder()
+        .Method("plain", static (thisObject, args) => new JsString("plain"))
+        .Method(GlobalSymbolRegistry.Iterator, static (thisObject, args) => new JsString("iterated"), length: 1)
+        .Accessor(GlobalSymbolRegistry.ToPrimitive, getter: static (thisObject, args) => new JsString("primitive"))
+        .PerRealmSlot(GlobalSymbolRegistry.AsyncIterator, static owner => new JsObject(owner.Engine))
+        .ToStringTag("SymbolKeyed")
+        .Build();
+
+    private static Engine EngineWithSymbolKeyedPrototype()
+    {
+        var engine = new Engine();
+        engine.SetValue("proto", SymbolKeyedShape.Instantiate(engine));
+        engine.Execute("var obj = Object.create(proto);");
+        return engine;
+    }
+
+    // ---- symbol-keyed members ----
+
+    [Test]
+    public void SymbolKeyedMembersLiveOnThePrototype()
+    {
+        var engine = EngineWithSymbolKeyedPrototype();
+
+        engine.Evaluate("typeof proto[Symbol.iterator]").Should().Be("function");
+        engine.Evaluate("proto[Symbol.iterator]()").Should().Be("iterated");
+        engine.Evaluate("proto[Symbol.toPrimitive]").Should().Be("primitive");
+        engine.Evaluate("typeof proto[Symbol.asyncIterator]").Should().Be("object");
+
+        // Inherited, which is the whole point: an instance carries none of them of its own.
+        engine.Evaluate("obj[Symbol.iterator]()").Should().Be("iterated");
+        engine.Evaluate("Object.getOwnPropertySymbols(obj).length").Should().Be(0);
+
+        // And the object is still on the shared layout: symbols are orthogonal to the string-keyed one.
+        engine.Evaluate("proto.plain()").Should().Be("plain");
+        engine.Advanced.HasSharedShape(engine.Evaluate("proto").AsObject()).Should().BeTrue();
+    }
+
+    [Test]
+    public void ASymbolKeyedMemberCarriesTheDeclaredAttributes()
+    {
+        var engine = EngineWithSymbolKeyedPrototype();
+
+        // https://webidl.spec.whatwg.org/#js-iterable and ECMAScript both make a symbol-keyed member
+        // non-enumerable — the one attribute rule the two agree on.
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.iterator).enumerable").Should().Be(false);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.iterator).writable").Should().Be(true);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.iterator).configurable").Should().Be(true);
+
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.toPrimitive).enumerable").Should().Be(false);
+        engine.Evaluate("typeof Object.getOwnPropertyDescriptor(proto, Symbol.toPrimitive).get").Should().Be("function");
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.toPrimitive).set").Should().Be(JsValue.Undefined);
+
+        // https://tc39.es/ecma262/#sec-setfunctionname — a function under a symbol key is named with the
+        // description in brackets.
+        engine.Evaluate("proto[Symbol.iterator].name").Should().Be("[Symbol.iterator]");
+        engine.Evaluate("proto[Symbol.iterator].length").Should().Be(1);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(proto, Symbol.toPrimitive).get.name").Should().Be("get [Symbol.toPrimitive]");
+
+        // Every one of them enumerates as an own symbol of the prototype, alongside Symbol.toStringTag.
+        engine.Evaluate("Object.getOwnPropertySymbols(proto).length").Should().Be(4);
+    }
+
+    [Test]
+    public void ASymbolKeyedMemberHasAStableIdentityWithinAnEngineAndIsPerEngineAcrossThem()
+    {
+        var engine = EngineWithSymbolKeyedPrototype();
+
+        engine.Evaluate("proto[Symbol.iterator] === proto[Symbol.iterator]").Should().Be(true);
+        engine.Evaluate("proto[Symbol.asyncIterator] === proto[Symbol.asyncIterator]").Should().Be(true);
+
+        // A second engine instantiating the same process-shared shape gets its own function and its own
+        // per-realm value; nothing engine-affine is stored in the shape.
+        var other = EngineWithSymbolKeyedPrototype();
+        ReferenceEquals(
+            engine.Evaluate("proto[Symbol.iterator]"),
+            other.Evaluate("proto[Symbol.iterator]")).Should().BeFalse();
+        ReferenceEquals(
+            engine.Evaluate("proto[Symbol.asyncIterator]"),
+            other.Evaluate("proto[Symbol.asyncIterator]")).Should().BeFalse();
+    }
+
+    [Test]
+    public void ASymbolKeyedMemberIsAnOrdinaryPropertyScriptCanRedefineOrDelete()
+    {
+        var engine = EngineWithSymbolKeyedPrototype();
+
+        engine.Execute("proto[Symbol.iterator] = 42;");
+        engine.Evaluate("proto[Symbol.iterator]").Should().Be(42);
+
+        engine.Evaluate("delete proto[Symbol.toPrimitive]").Should().Be(true);
+        engine.Evaluate("proto[Symbol.toPrimitive]").Should().Be(JsValue.Undefined);
+
+        // Deleting a symbol never disturbs the string-keyed layout, so the object keeps its shape.
+        engine.Evaluate("proto.plain()").Should().Be("plain");
+        engine.Advanced.HasSharedShape(engine.Evaluate("proto").AsObject()).Should().BeTrue();
+    }
+
+    [Test]
+    public void BuilderRejectsADuplicateSymbolKey()
+    {
+        Invoking(() => new JsObjectShape.Builder()
+                .Method(GlobalSymbolRegistry.Iterator, static (t, a) => JsValue.Undefined)
+                .Accessor(GlobalSymbolRegistry.Iterator, getter: static (t, a) => JsValue.Undefined))
+            .Should().Throw<ArgumentException>().WithMessage("*already been declared*");
+
+        // ToStringTag declares one too, so the two spellings cannot disagree about the same key.
+        Invoking(() => new JsObjectShape.Builder()
+                .ToStringTag("A")
+                .Method(GlobalSymbolRegistry.ToStringTag, static (t, a) => JsValue.Undefined))
+            .Should().Throw<ArgumentException>().WithMessage("*already been declared*");
+
+        Invoking(() => new JsObjectShape.Builder().Method((JsSymbol) null!, static (t, a) => JsValue.Undefined))
+            .Should().Throw<ArgumentNullException>();
     }
 
     // ---- reachability and representation witness ----
@@ -836,7 +957,7 @@ public class HostPrototypeShapeTests
     [Test]
     public void BuilderRejectsInvalidNames()
     {
-        Invoking(() => new JsObjectShape.Builder().Method(null!, static (t, a) => JsValue.Undefined))
+        Invoking(() => new JsObjectShape.Builder().Method((string) null!, static (t, a) => JsValue.Undefined))
             .Should().Throw<ArgumentException>().WithMessage("*non-empty*");
         Invoking(() => new JsObjectShape.Builder().Method("", static (t, a) => JsValue.Undefined))
             .Should().Throw<ArgumentException>().WithMessage("*non-empty*");
@@ -911,6 +1032,12 @@ public class HostPrototypeShapeTests
         Invoking(() => builder.PerRealmSlot("y"))
             .Should().Throw<InvalidOperationException>();
         Invoking(() => builder.ToStringTag("y"))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.Method(GlobalSymbolRegistry.Iterator, static (t, a) => JsValue.Undefined))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.Accessor(GlobalSymbolRegistry.Iterator, getter: static (t, a) => JsValue.Undefined))
+            .Should().Throw<InvalidOperationException>();
+        Invoking(() => builder.PerRealmSlot(GlobalSymbolRegistry.Iterator, static o => JsValue.Undefined))
             .Should().Throw<InvalidOperationException>();
         Invoking(() => builder.Build())
             .Should().Throw<InvalidOperationException>();

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -1175,11 +1175,14 @@ namespace Jint.Native
         public sealed class Builder
         {
             public Builder() { }
+            public Jint.Native.JsObjectShape.Builder Accessor(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = false, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Accessor(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape Build() { }
             public Jint.Native.JsObjectShape.Builder Constant(string name, Jint.Native.JsValue value, bool enumerable = true) { }
+            public Jint.Native.JsObjectShape.Builder Method(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Method(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = true, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, bool enumerable = false, bool writable = true, bool configurable = true) { }
+            public Jint.Native.JsObjectShape.Builder PerRealmSlot(Jint.Native.JsSymbol key, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder ToStringTag(string value) { }
         }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net472.verified.txt
@@ -991,11 +991,14 @@ namespace Jint.Native
         public sealed class Builder
         {
             public Builder() { }
+            public Jint.Native.JsObjectShape.Builder Accessor(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = false, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Accessor(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape Build() { }
             public Jint.Native.JsObjectShape.Builder Constant(string name, Jint.Native.JsValue value, bool enumerable = true) { }
+            public Jint.Native.JsObjectShape.Builder Method(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Method(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = true, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, bool enumerable = false, bool writable = true, bool configurable = true) { }
+            public Jint.Native.JsObjectShape.Builder PerRealmSlot(Jint.Native.JsSymbol key, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder ToStringTag(string value) { }
         }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -1175,11 +1175,14 @@ namespace Jint.Native
         public sealed class Builder
         {
             public Builder() { }
+            public Jint.Native.JsObjectShape.Builder Accessor(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = false, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Accessor(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape Build() { }
             public Jint.Native.JsObjectShape.Builder Constant(string name, Jint.Native.JsValue value, bool enumerable = true) { }
+            public Jint.Native.JsObjectShape.Builder Method(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Method(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = true, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, bool enumerable = false, bool writable = true, bool configurable = true) { }
+            public Jint.Native.JsObjectShape.Builder PerRealmSlot(Jint.Native.JsSymbol key, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder ToStringTag(string value) { }
         }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.0.verified.txt
@@ -991,11 +991,14 @@ namespace Jint.Native
         public sealed class Builder
         {
             public Builder() { }
+            public Jint.Native.JsObjectShape.Builder Accessor(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = false, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Accessor(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape Build() { }
             public Jint.Native.JsObjectShape.Builder Constant(string name, Jint.Native.JsValue value, bool enumerable = true) { }
+            public Jint.Native.JsObjectShape.Builder Method(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Method(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = true, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, bool enumerable = false, bool writable = true, bool configurable = true) { }
+            public Jint.Native.JsObjectShape.Builder PerRealmSlot(Jint.Native.JsSymbol key, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder ToStringTag(string value) { }
         }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_netstandard2.1.verified.txt
@@ -991,11 +991,14 @@ namespace Jint.Native
         public sealed class Builder
         {
             public Builder() { }
+            public Jint.Native.JsObjectShape.Builder Accessor(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = false, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Accessor(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? getter, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue>? setter = null, bool enumerable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape Build() { }
             public Jint.Native.JsObjectShape.Builder Constant(string name, Jint.Native.JsValue value, bool enumerable = true) { }
+            public Jint.Native.JsObjectShape.Builder Method(Jint.Native.JsSymbol key, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder Method(string name, System.Func<Jint.Native.JsValue, Jint.Native.JsValue[], Jint.Native.JsValue> implementation, int length = 0, bool enumerable = true, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, bool enumerable = false, bool writable = true, bool configurable = true) { }
+            public Jint.Native.JsObjectShape.Builder PerRealmSlot(Jint.Native.JsSymbol key, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder PerRealmSlot(string name, System.Func<Jint.Native.Object.ObjectInstance, Jint.Native.JsValue> factory, bool enumerable = false, bool writable = true, bool configurable = true) { }
             public Jint.Native.JsObjectShape.Builder ToStringTag(string value) { }
         }

--- a/Jint.Tests/Runtime/SharedObjectShapeTests.cs
+++ b/Jint.Tests/Runtime/SharedObjectShapeTests.cs
@@ -27,6 +27,19 @@ public class SharedObjectShapeTests
         .Method("c", static (t, args) => new JsString("c"))
         .Build();
 
+    private static int _symbolSlotFactoryCalls;
+
+    private static readonly JsObjectShape LazySymbolShape = new JsObjectShape.Builder()
+        .Method("touch", static (t, args) => new JsString("touch"))
+        .PerRealmSlot(
+            Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,
+            static _ =>
+            {
+                Interlocked.Increment(ref _symbolSlotFactoryCalls);
+                return new JsString("late");
+            })
+        .Build();
+
     private static readonly JsObjectShape MixedShape = new JsObjectShape.Builder()
         .Method("m", static (t, args) => new JsString("m"))
         .Accessor("acc", getter: static (t, args) => new JsString("acc"))
@@ -475,6 +488,31 @@ public class SharedObjectShapeTests
         }
     }
 
+    [Test]
+    public void ASymbolKeyedSlotStaysUnmaterializedUntilTheMemberIsRead()
+    {
+        // The DOM bindings declare @@iterator on fifteen collection prototypes, so a declaration that ran its
+        // factory at initialization would cost every one of them a value nothing had asked for. It runs on the
+        // first read of that member and never again.
+        Volatile.Write(ref _symbolSlotFactoryCalls, 0);
+
+        var engine = new Engine();
+        var proto = LazySymbolShape.Instantiate(engine);
+
+        // Initializes the object — the symbol dictionary is built here — without reading the member.
+        proto.Get("touch");
+        Volatile.Read(ref _symbolSlotFactoryCalls).Should().Be(0, "declaring a per-realm symbol slot must cost nothing");
+
+        proto.Get(GlobalSymbolRegistryIterator(engine)).Should().Be(new JsString("late"));
+        Volatile.Read(ref _symbolSlotFactoryCalls).Should().Be(1);
+
+        proto.Get(GlobalSymbolRegistryIterator(engine)).Should().Be(new JsString("late"));
+        Volatile.Read(ref _symbolSlotFactoryCalls).Should().Be(1, "the value is memoized into the descriptor, as PropertyDescriptor.CreateLazy promises");
+    }
+
     private static JsValue GlobalSymbolRegistryToStringTag(Engine engine)
         => engine.Evaluate("Symbol.toStringTag");
+
+    private static JsValue GlobalSymbolRegistryIterator(Engine engine)
+        => engine.Evaluate("Symbol.iterator");
 }

--- a/Jint/Native/JsObjectShape.cs
+++ b/Jint/Native/JsObjectShape.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Jint.Native.Object;
+using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -67,18 +68,18 @@ public sealed class JsObjectShape
     private readonly BuiltinShape _layout;
     private readonly FunctionEntry[] _functions;
     private readonly PerRealmValueSlot[] _perRealmValueSlots;
-    private readonly JsString? _toStringTag;
+    private readonly SymbolMember[] _symbolMembers;
 
     private JsObjectShape(
         BuiltinShape layout,
         FunctionEntry[] functions,
         PerRealmValueSlot[] perRealmValueSlots,
-        JsString? toStringTag)
+        SymbolMember[] symbolMembers)
     {
         _layout = layout;
         _functions = functions;
         _perRealmValueSlots = perRealmValueSlots;
-        _toStringTag = toStringTag;
+        _symbolMembers = symbolMembers;
     }
 
     /// <summary>The number of string-keyed members this shape declares.</summary>
@@ -220,8 +221,11 @@ public sealed class JsObjectShape
     /// </summary>
     internal PerRealmValueSlot[] PerRealmValueSlots => _perRealmValueSlots;
 
-    /// <summary>The declared <c>Symbol.toStringTag</c> value, or <c>null</c> when none was declared.</summary>
-    internal JsString? ToStringTagValue => _toStringTag;
+    /// <summary>
+    /// The symbol-keyed members, in declaration order. Symbols are orthogonal to the shared string-keyed
+    /// layout, so these are applied per instantiated object rather than through it.
+    /// </summary>
+    internal SymbolMember[] SymbolMembers => _symbolMembers;
 
     /// <summary>
     /// Creates the function object for a method slot or an accessor half, in <paramref name="realm"/>.
@@ -232,6 +236,66 @@ public sealed class JsObjectShape
         var entry = _functions[slot];
         return new ClrFunction(engine, realm, entry.Name, entry.Implementation, entry.Length);
     }
+
+    /// <summary>
+    /// The descriptor one instantiated object gets for symbol member <paramref name="index"/>. Built per
+    /// object, never shared: a symbol member is configurable or writable in every shape WebIDL and
+    /// ECMAScript give one, and one shared mutable descriptor would let one engine rewrite what another
+    /// reads — the hazard <see cref="Builder.Constant"/> states in full for the string-keyed case.
+    /// </summary>
+    /// <remarks>
+    /// A method and a per-realm slot are lazy through <see cref="PropertyDescriptor.CreateLazy{TState}"/>,
+    /// so declaring one costs an unmaterialized descriptor and nothing else until a script reads the member.
+    /// An accessor pair is not: <c>Object.getOwnPropertyDescriptor</c> has to observe a settled pair, so both
+    /// halves are created together, here.
+    /// </remarks>
+    internal PropertyDescriptor MakeSymbolDescriptor(ObjectInstance owner, Engine engine, Realm realm, int index)
+    {
+        var member = _symbolMembers[index];
+        switch (member.Kind)
+        {
+            case SymbolMemberKind.Constant:
+                return new PropertyDescriptor(member.Constant!, member.Flags);
+
+            case SymbolMemberKind.Method:
+                return PropertyDescriptor.CreateLazy(
+                    (Shape: this, Engine: engine, Realm: realm, member.GetterSlot),
+                    static state => state.Shape.MakeFunction(state.Engine, state.Realm, state.GetterSlot),
+                    member.Flags);
+
+            case SymbolMemberKind.PerRealmFactory:
+                return PropertyDescriptor.CreateLazy(
+                    (Owner: owner, Factory: member.Factory!),
+                    static state => state.Factory(state.Owner) ?? JsValue.Undefined,
+                    member.Flags);
+
+            default:
+                return new GetSetPropertyDescriptor(
+                    member.GetterSlot == BuiltinShape.NotAFunction ? null : MakeFunction(engine, realm, member.GetterSlot),
+                    member.SetterSlot == BuiltinShape.NotAFunction ? null : MakeFunction(engine, realm, member.SetterSlot),
+                    member.Flags);
+        }
+    }
+
+    /// <summary>What a symbol-keyed member is; the symbol siblings of the string-keyed member kinds.</summary>
+    internal enum SymbolMemberKind : byte
+    {
+        Constant,
+        Method,
+        Accessor,
+        PerRealmFactory,
+    }
+
+    /// <summary>One symbol-keyed member: its key, its kind, its attributes and whichever payload it needs.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    internal readonly record struct SymbolMember(
+        JsSymbol Key,
+        SymbolMemberKind Kind,
+        PropertyFlag Flags,
+        JsValue? Constant,
+        ushort GetterSlot,
+        ushort SetterSlot,
+        Func<ObjectInstance, JsValue>? Factory);
 
     /// <summary>One entry of the shape's process-shared function table: everything a per-realm function needs.</summary>
     [StructLayout(LayoutKind.Auto)]
@@ -256,7 +320,9 @@ public sealed class JsObjectShape
         private readonly List<MemberDeclaration> _members = [];
         private readonly List<FunctionEntry> _functions = [];
         private readonly HashSet<string> _declaredNames = new(StringComparer.Ordinal);
-        private JsString? _toStringTag;
+        private readonly List<SymbolMember> _symbolMembers = [];
+        private readonly HashSet<JsSymbol> _declaredSymbols = [];
+        private bool _toStringTagDeclared;
         private bool _built;
 
         /// <summary>Creates an empty builder.</summary>
@@ -329,7 +395,8 @@ public sealed class JsObjectShape
         /// <c>"set name"</c> per spec convention. Defaults follow Web IDL attributes
         /// (<c>{ enumerable: true, configurable: true }</c>).
         /// <para>
-        /// The delegates carry the same engine-independence contract as <see cref="Method"/>.
+        /// The delegates carry the same engine-independence contract as
+        /// <see cref="Method(string, Func{JsValue, JsValue[], JsValue}, int, bool, bool, bool)"/>.
         /// </para>
         /// </summary>
         /// <param name="name">The property name.</param>
@@ -536,13 +603,177 @@ public sealed class JsObjectShape
         }
 
         /// <summary>
+        /// Declares a symbol-keyed method — <c>Symbol.iterator</c>, <c>Symbol.hasInstance</c>,
+        /// <c>Symbol.toPrimitive</c> — whose function is created per engine on first access of the member.
+        /// Attribute defaults are the ones both Web IDL and ECMAScript give a symbol-keyed operation
+        /// (<c>{ writable: true, enumerable: false, configurable: true }</c>): a symbol-keyed member is
+        /// <em>not</em> enumerable, which is the one place Web IDL agrees with ECMAScript rather than
+        /// diverging from it.
+        /// <para>
+        /// The materialized function is named the way
+        /// <see href="https://tc39.es/ecma262/#sec-setfunctionname">SetFunctionName</see> names one under a
+        /// symbol key — <c>"[Symbol.iterator]"</c> — so nothing has to be passed for it.
+        /// <paramref name="implementation"/> carries the same engine-independence contract as
+        /// <see cref="Method(string, Func{JsValue, JsValue[], JsValue}, int, bool, bool, bool)"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="key">The symbol key. Well-known symbols are process-shared and are the intended use.</param>
+        /// <param name="implementation">The method body.</param>
+        /// <param name="length">The function's <c>length</c> — its declared parameter count.</param>
+        /// <param name="enumerable">Whether the property is enumerable.</param>
+        /// <param name="writable">Whether the property is writable.</param>
+        /// <param name="configurable">Whether the property is configurable.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> or <paramref name="implementation"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is already declared.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is negative.</exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public Builder Method(
+            JsSymbol key,
+            Func<JsValue, JsValue[], JsValue> implementation,
+            int length = 0,
+            bool enumerable = false,
+            bool writable = true,
+            bool configurable = true)
+        {
+            DeclareSymbol(key);
+
+            if (implementation is null)
+            {
+                Throw.ArgumentNullException(nameof(implementation));
+            }
+
+            if (length < 0)
+            {
+                Throw.ArgumentOutOfRangeException(nameof(length), "A function's length must not be negative.");
+            }
+
+            var slot = AddFunction(FunctionName(key), implementation, length);
+            _symbolMembers.Add(new SymbolMember(
+                key,
+                SymbolMemberKind.Method,
+                DataFlags(enumerable, writable, configurable),
+                Constant: null,
+                slot,
+                BuiltinShape.NotAFunction,
+                Factory: null));
+            return this;
+        }
+
+        /// <summary>
+        /// Declares a symbol-keyed accessor property — <c>Symbol.toStringTag</c> as a getter,
+        /// <c>Symbol.species</c>. Both halves are created together when the object initializes, so that
+        /// <c>Object.getOwnPropertyDescriptor</c> observes a settled pair; an absent half surfaces as
+        /// <c>undefined</c>, per spec. Defaults are <c>{ enumerable: false, configurable: true }</c>.
+        /// <para>
+        /// The delegates carry the same engine-independence contract as
+        /// <see cref="Method(string, Func{JsValue, JsValue[], JsValue}, int, bool, bool, bool)"/>, and the
+        /// materialized functions are named <c>"get [Symbol.x]"</c> / <c>"set [Symbol.x]"</c>.
+        /// </para>
+        /// </summary>
+        /// <param name="key">The symbol key.</param>
+        /// <param name="getter">The getter body, or <c>null</c> for a set-only property.</param>
+        /// <param name="setter">The setter body, or <c>null</c> for a get-only property.</param>
+        /// <param name="enumerable">Whether the property is enumerable.</param>
+        /// <param name="configurable">Whether the property is configurable.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="key"/> is already declared, or both <paramref name="getter"/> and
+        /// <paramref name="setter"/> are <c>null</c>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public Builder Accessor(
+            JsSymbol key,
+            Func<JsValue, JsValue[], JsValue>? getter,
+            Func<JsValue, JsValue[], JsValue>? setter = null,
+            bool enumerable = false,
+            bool configurable = true)
+        {
+            DeclareSymbol(key);
+
+            if (getter is null && setter is null)
+            {
+                Throw.ArgumentException(
+                    $"Accessor '{key}' declares neither a getter nor a setter; at least one half is required.",
+                    nameof(getter));
+            }
+
+            var name = FunctionName(key);
+            var getterSlot = getter is null ? BuiltinShape.NotAFunction : AddFunction("get " + name, getter, 0);
+            var setterSlot = setter is null ? BuiltinShape.NotAFunction : AddFunction("set " + name, setter, 1);
+
+            // GetSetPropertyDescriptor owns the writable bits (an accessor has none), so only the
+            // enumerable/configurable claims travel with the member.
+            var flags = (enumerable ? PropertyFlag.Enumerable : PropertyFlag.EnumerableSet)
+                        | (configurable ? PropertyFlag.Configurable : PropertyFlag.ConfigurableSet);
+
+            _symbolMembers.Add(new SymbolMember(
+                key,
+                SymbolMemberKind.Accessor,
+                flags,
+                Constant: null,
+                getterSlot,
+                setterSlot,
+                Factory: null));
+            return this;
+        }
+
+        /// <summary>
+        /// Declares a symbol-keyed data property whose value differs per engine, produced by
+        /// <paramref name="factory"/> on the first access of that member in that engine. This is what a
+        /// member whose value is an <em>intrinsic</em> needs: Web IDL's
+        /// <see href="https://webidl.spec.whatwg.org/#es-iterable-entries">iterable&lt;&gt;</see> declaration
+        /// makes <c>@@iterator</c> the very <c>%Array.prototype.values%</c> function object of the realm, not
+        /// a wrapper around it, and only a per-realm value can be that.
+        /// <para>
+        /// The factory receives the instantiated object (reach the engine through
+        /// <see cref="ObjectInstance.Engine"/>) and must itself be engine-independent — a static lambda, with
+        /// all per-engine state coming from the argument.
+        /// </para>
+        /// </summary>
+        /// <param name="key">The symbol key.</param>
+        /// <param name="factory">Produces the value for one instantiated object.</param>
+        /// <param name="enumerable">Whether the property is enumerable.</param>
+        /// <param name="writable">Whether the property is writable.</param>
+        /// <param name="configurable">Whether the property is configurable.</param>
+        /// <returns>This builder, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> or <paramref name="factory"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is already declared.</exception>
+        /// <exception cref="InvalidOperationException">The shape has already been built.</exception>
+        public Builder PerRealmSlot(
+            JsSymbol key,
+            Func<ObjectInstance, JsValue> factory,
+            bool enumerable = false,
+            bool writable = true,
+            bool configurable = true)
+        {
+            DeclareSymbol(key);
+
+            if (factory is null)
+            {
+                Throw.ArgumentNullException(nameof(factory));
+            }
+
+            _symbolMembers.Add(new SymbolMember(
+                key,
+                SymbolMemberKind.PerRealmFactory,
+                DataFlags(enumerable, writable, configurable),
+                Constant: null,
+                BuiltinShape.NotAFunction,
+                BuiltinShape.NotAFunction,
+                factory));
+            return this;
+        }
+
+        /// <summary>
         /// Declares the <c>Symbol.toStringTag</c> value (non-writable, non-enumerable, configurable — the
-        /// intrinsic convention), which is what <c>Object.prototype.toString.call(obj)</c> reports.
+        /// intrinsic convention), which is what <c>Object.prototype.toString.call(obj)</c> reports. Sugar for
+        /// the one symbol-keyed constant every host prototype wants.
         /// <para>
         /// Symbols are stored per object — the shared string-keyed layout is orthogonal to them — so this
         /// costs one descriptor per instantiated object, applied on first touch along with the rest of the
-        /// object's initialization. Other symbol-keyed members are added per object after instantiation with
-        /// <c>DefineOwnProperty</c>; symbol keys never disturb the shared layout.
+        /// object's initialization, and the same is true of every other symbol-keyed member declared here.
         /// </para>
         /// </summary>
         /// <param name="value">The tag, e.g. the Web IDL interface name.</param>
@@ -560,12 +791,21 @@ public sealed class JsObjectShape
                 Throw.ArgumentNullException(nameof(value));
             }
 
-            if (_toStringTag is not null)
+            if (_toStringTagDeclared)
             {
                 Throw.InvalidOperationException("Symbol.toStringTag has already been declared on this shape.");
             }
 
-            _toStringTag = JsString.Create(value);
+            _toStringTagDeclared = true;
+            DeclareSymbol(GlobalSymbolRegistry.ToStringTag);
+            _symbolMembers.Add(new SymbolMember(
+                GlobalSymbolRegistry.ToStringTag,
+                SymbolMemberKind.Constant,
+                PropertyFlag.Configurable,
+                JsString.Create(value),
+                BuiltinShape.NotAFunction,
+                BuiltinShape.NotAFunction,
+                Factory: null));
             return this;
         }
 
@@ -619,7 +859,7 @@ public sealed class JsObjectShape
                 layoutBuilder.Build(),
                 _functions.ToArray(),
                 perRealmValueSlots.Count > 0 ? perRealmValueSlots.ToArray() : [],
-                _toStringTag);
+                _symbolMembers.Count > 0 ? _symbolMembers.ToArray() : []);
         }
 
         private ushort AddFunction(string name, JsCallDelegate implementation, int length)
@@ -656,6 +896,28 @@ public sealed class JsObjectShape
                 Throw.ArgumentException($"Member '{name}' has already been declared; member names must be distinct.", nameof(name));
             }
         }
+
+        private void DeclareSymbol(JsSymbol key)
+        {
+            ThrowIfBuilt();
+
+            if (key is null)
+            {
+                Throw.ArgumentNullException(nameof(key));
+            }
+
+            if (!_declaredSymbols.Add(key))
+            {
+                Throw.ArgumentException($"Member '{key}' has already been declared; member keys must be distinct.", nameof(key));
+            }
+        }
+
+        /// <summary>
+        /// <see href="https://tc39.es/ecma262/#sec-setfunctionname">SetFunctionName</see> for a symbol key:
+        /// the description in brackets, or the empty string for a symbol that has none.
+        /// </summary>
+        private static string FunctionName(JsSymbol key)
+            => key._value.IsUndefined() ? "" : "[" + key._value.AsString() + "]";
 
         private void ThrowIfBuilt()
         {

--- a/Jint/Native/Object/SharedShapeObject.cs
+++ b/Jint/Native/Object/SharedShapeObject.cs
@@ -1,4 +1,3 @@
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -26,7 +25,7 @@ namespace Jint.Native.Object;
 /// <para>
 /// Nothing is materialized at construction. <see cref="Initialize"/> — which the base class runs on the first
 /// property access of any kind — installs the shared layout, pre-fills the value-form per-realm slots and
-/// applies <c>Symbol.toStringTag</c>; each method, accessor and factory slot then produces its descriptor on
+/// applies the symbol-keyed members; each method, accessor and factory slot then produces its descriptor on
 /// the first access of that member and caches it, so identity is stable from then on.
 /// </para>
 /// </summary>
@@ -74,12 +73,18 @@ internal sealed class SharedShapeObject : ObjectInstance, IBuiltinShaped
             SetBuiltinInstanceDescriptor(valueSlots[i].Slot, Undefined, valueSlots[i].Flags);
         }
 
-        var toStringTag = _shape.ToStringTagValue;
-        if (toStringTag is not null)
+        var symbolMembers = _shape.SymbolMembers;
+        if (symbolMembers.Length > 0)
         {
-            // Symbols live outside the shared string-keyed layout, so this is one descriptor per object.
-            var symbols = new SymbolDictionary(1);
-            symbols[GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor(toStringTag, PropertyFlag.Configurable);
+            // Symbols live outside the shared string-keyed layout, so these are one descriptor per object —
+            // and unmaterialized ones for every kind but an accessor pair, so declaring `Symbol.iterator` on
+            // a prototype costs nothing until a script reaches for it.
+            var symbols = new SymbolDictionary(symbolMembers.Length);
+            for (var i = 0; i < symbolMembers.Length; i++)
+            {
+                symbols[symbolMembers[i].Key] = _shape.MakeSymbolDescriptor(this, _engine, _realm, i);
+            }
+
             SetSymbols(symbols);
         }
     }

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -6308,6 +6308,48 @@ constructor body are declined rather than attributed to the script that ran them
 
 `Jint.DevTools` resolves `[[FunctionLocation]]`'s `scriptId` through it, which was the last thing in that
 package still matching a script by name.
+### 5.29 A shaped prototype can carry symbol-keyed members ([#3636](https://github.com/sebastienros/jint/issues/3636))
+
+`JsObjectShape.Builder` declared string-keyed members only, plus the one `ToStringTag` shorthand, so a host
+prototype could not carry `Symbol.iterator` at all — the value had to be written onto every *instance*, where
+a browser has none. Three overloads take a `JsSymbol` key instead of a name and cover the same three kinds:
+
+```csharp
+private static readonly JsObjectShape NodeListShape = new JsObjectShape.Builder()
+    .Method("item", static (t, args) => Dom.Item(t, args), length: 1)
+
+    // a function this shape owns
+    .Method(GlobalSymbolRegistry.HasInstance, static (t, args) => Dom.IsNodeList(args), length: 1)
+
+    // an accessor pair
+    .Accessor(GlobalSymbolRegistry.ToPrimitive, getter: static (t, _) => Dom.Describe(t))
+
+    // a value that is whatever the engine has - Web IDL's iterable<> declaration makes @@iterator the
+    // realm's own %Array.prototype.values%, and only a per-realm slot can be that
+    .PerRealmSlot(
+        GlobalSymbolRegistry.Iterator,
+        static owner => owner.Engine.Realm.Intrinsics.Array.PrototypeObject.Get(GlobalSymbolRegistry.Iterator))
+
+    .ToStringTag("NodeList")
+    .Build();
+```
+
+The defaults are the ones both Web IDL and ECMAScript give a symbol-keyed member — `{ writable: true,
+enumerable: false, configurable: true }` for a method or a slot, `{ enumerable: false, configurable: true }`
+for an accessor — which is the one attribute rule where Web IDL agrees with ECMAScript rather than diverging
+from it. A materialized function is named the way
+[SetFunctionName](https://tc39.es/ecma262/#sec-setfunctionname) names one under a symbol key:
+`[Symbol.iterator]`, `get [Symbol.toPrimitive]`.
+
+**Nothing about an existing shape changes.** Symbols live outside the shared string-keyed layout, so
+declaring one neither disturbs the layout nor costs the object its shape, and a method or per-realm slot is
+lazy: the descriptor exists from initialization, the function or value appears on the first read of that
+member. `ToStringTag` is now shorthand for one such member and behaves exactly as before, except that it and
+an explicit `Symbol.toStringTag` declaration now refuse each other rather than both applying.
+
+**One source-level nuisance.** `Method`, `Accessor` and `PerRealmSlot` are overloaded on their first
+parameter, so a call passing a bare `null` literal for the name — `Method(null, impl)` — is now ambiguous.
+Write `Method((string) null, impl)`, or, as any real call already does, pass the name.
 
 ### 5.29 An observed response says when its hop went out and when its headers came back ([#3701](https://github.com/sebastienros/jint/issues/3701))
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -6308,49 +6308,6 @@ constructor body are declined rather than attributed to the script that ran them
 
 `Jint.DevTools` resolves `[[FunctionLocation]]`'s `scriptId` through it, which was the last thing in that
 package still matching a script by name.
-### 5.29 A shaped prototype can carry symbol-keyed members ([#3636](https://github.com/sebastienros/jint/issues/3636))
-
-`JsObjectShape.Builder` declared string-keyed members only, plus the one `ToStringTag` shorthand, so a host
-prototype could not carry `Symbol.iterator` at all — the value had to be written onto every *instance*, where
-a browser has none. Three overloads take a `JsSymbol` key instead of a name and cover the same three kinds:
-
-```csharp
-private static readonly JsObjectShape NodeListShape = new JsObjectShape.Builder()
-    .Method("item", static (t, args) => Dom.Item(t, args), length: 1)
-
-    // a function this shape owns
-    .Method(GlobalSymbolRegistry.HasInstance, static (t, args) => Dom.IsNodeList(args), length: 1)
-
-    // an accessor pair
-    .Accessor(GlobalSymbolRegistry.ToPrimitive, getter: static (t, _) => Dom.Describe(t))
-
-    // a value that is whatever the engine has - Web IDL's iterable<> declaration makes @@iterator the
-    // realm's own %Array.prototype.values%, and only a per-realm slot can be that
-    .PerRealmSlot(
-        GlobalSymbolRegistry.Iterator,
-        static owner => owner.Engine.Realm.Intrinsics.Array.PrototypeObject.Get(GlobalSymbolRegistry.Iterator))
-
-    .ToStringTag("NodeList")
-    .Build();
-```
-
-The defaults are the ones both Web IDL and ECMAScript give a symbol-keyed member — `{ writable: true,
-enumerable: false, configurable: true }` for a method or a slot, `{ enumerable: false, configurable: true }`
-for an accessor — which is the one attribute rule where Web IDL agrees with ECMAScript rather than diverging
-from it. A materialized function is named the way
-[SetFunctionName](https://tc39.es/ecma262/#sec-setfunctionname) names one under a symbol key:
-`[Symbol.iterator]`, `get [Symbol.toPrimitive]`.
-
-**Nothing about an existing shape changes.** Symbols live outside the shared string-keyed layout, so
-declaring one neither disturbs the layout nor costs the object its shape, and a method or per-realm slot is
-lazy: the descriptor exists from initialization, the function or value appears on the first read of that
-member. `ToStringTag` is now shorthand for one such member and behaves exactly as before, except that it and
-an explicit `Symbol.toStringTag` declaration now refuse each other rather than both applying.
-
-**One source-level nuisance.** `Method`, `Accessor` and `PerRealmSlot` are overloaded on their first
-parameter, so a call passing a bare `null` literal for the name — `Method(null, impl)` — is now ambiguous.
-Write `Method((string) null, impl)`, or, as any real call already does, pass the name.
-
 ### 5.29 An observed response says when its hop went out and when its headers came back ([#3701](https://github.com/sebastienros/jint/issues/3701))
 
 `ObservedFetchResponse` carried the identifier, the URL, the status and the headers, and nothing at all about
@@ -6431,6 +6388,49 @@ thread's `Dispose`; or subscribe to `Disposed` and stop posting from the handler
 the flag is already set when it runs. A caller that genuinely cannot know — a wake posted from a thread-pool
 continuation, say — catches `ObjectDisposedException` and does nothing, which is what `Jint.DevTools` and
 `Jint.Browser` now do at the three call sites that can lose that race.
+### 5.31 A shaped prototype can carry symbol-keyed members ([#3636](https://github.com/sebastienros/jint/issues/3636))
+
+`JsObjectShape.Builder` declared string-keyed members only, plus the one `ToStringTag` shorthand, so a host
+prototype could not carry `Symbol.iterator` at all — the value had to be written onto every *instance*, where
+a browser has none. Three overloads take a `JsSymbol` key instead of a name and cover the same three kinds:
+
+```csharp
+private static readonly JsObjectShape NodeListShape = new JsObjectShape.Builder()
+    .Method("item", static (t, args) => Dom.Item(t, args), length: 1)
+
+    // a function this shape owns
+    .Method(GlobalSymbolRegistry.HasInstance, static (t, args) => Dom.IsNodeList(args), length: 1)
+
+    // an accessor pair
+    .Accessor(GlobalSymbolRegistry.ToPrimitive, getter: static (t, _) => Dom.Describe(t))
+
+    // a value that is whatever the engine has - Web IDL's iterable<> declaration makes @@iterator the
+    // realm's own %Array.prototype.values%, and only a per-realm slot can be that
+    .PerRealmSlot(
+        GlobalSymbolRegistry.Iterator,
+        static owner => owner.Engine.Realm.Intrinsics.Array.PrototypeObject.Get(GlobalSymbolRegistry.Iterator))
+
+    .ToStringTag("NodeList")
+    .Build();
+```
+
+The defaults are the ones both Web IDL and ECMAScript give a symbol-keyed member — `{ writable: true,
+enumerable: false, configurable: true }` for a method or a slot, `{ enumerable: false, configurable: true }`
+for an accessor — which is the one attribute rule where Web IDL agrees with ECMAScript rather than diverging
+from it. A materialized function is named the way
+[SetFunctionName](https://tc39.es/ecma262/#sec-setfunctionname) names one under a symbol key:
+`[Symbol.iterator]`, `get [Symbol.toPrimitive]`.
+
+**Nothing about an existing shape changes.** Symbols live outside the shared string-keyed layout, so
+declaring one neither disturbs the layout nor costs the object its shape, and a method or per-realm slot is
+lazy: the descriptor exists from initialization, the function or value appears on the first read of that
+member. `ToStringTag` is now shorthand for one such member and behaves exactly as before, except that it and
+an explicit `Symbol.toStringTag` declaration now refuse each other rather than both applying.
+
+**One source-level nuisance.** `Method`, `Accessor` and `PerRealmSlot` are overloaded on their first
+parameter, so a call passing a bare `null` literal for the name — `Method(null, impl)` — is now ambiguous.
+Write `Method((string) null, impl)`, or, as any real call already does, pass the name.
+
 
 ## 6. AOT and trimming
 

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/Emitter.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/Emitter.cs
@@ -159,6 +159,17 @@ internal sealed class Emitter
             // object it names belongs to one engine.
             builder.Append("            .PerRealmSlot(\"constructor\", enumerable: false)\n");
 
+            if (DeclaresIndexedProperties(model))
+            {
+                // https://webidl.spec.whatwg.org/#js-iterable — an interface that supports indexed properties
+                // has @@iterator, and its value is the realm's own %Array.prototype.values% rather than a
+                // function wrapping it, which is why the slot is per-realm rather than a method.
+                // { writable: true, enumerable: false, configurable: true }, PerRealmSlot's symbol defaults.
+                builder.Append("            .PerRealmSlot(\n")
+                    .Append("                global::Jint.Native.Symbol.GlobalSymbolRegistry.Iterator,\n")
+                    .Append("                global::Jint.Browser.Dom.Collections.DomIterator.ArrayValues)\n");
+            }
+
             foreach (var constant in model.Constants)
             {
                 // https://webidl.spec.whatwg.org/#es-constants — { writable: false, enumerable: true,
@@ -358,6 +369,17 @@ internal sealed class Emitter
 
         return builder.ToString();
     }
+
+    /// <summary>
+    /// Whether this interface is where the indexed property support is <em>declared</em>, which is what
+    /// https://webidl.spec.whatwg.org/#js-iterable hangs <c>@@iterator</c> off. An interface that merely
+    /// inherits the getter inherits the iterator with it — a browser answers <c>false</c> for
+    /// <c>HTMLFormControlsCollection.prototype.hasOwnProperty(Symbol.iterator)</c> — so the kind alone is not
+    /// the test; the parent has to be asked too.
+    /// </summary>
+    private static bool DeclaresIndexedProperties(InterfaceModel model)
+        => model.Kind is WrapperKind.Collection or WrapperKind.HtmlCollection
+           && model.Parent?.Kind is not (WrapperKind.Collection or WrapperKind.HtmlCollection);
 
     private static int Depth(InterfaceModel model)
     {


### PR DESCRIPTION
## What was wrong

`JsObjectShape.Builder` could declare string-keyed members and one hard-wired `Symbol.toStringTag`, and nothing else. A generated DOM collection therefore had `Symbol.iterator` written onto the **instance** at wrap time, which is observably wrong in three ways:

```js
NodeList.prototype[Symbol.iterator]                             // undefined  (a browser: a function)
document.querySelectorAll('p').hasOwnProperty(Symbol.iterator)  // true       (a browser: false)
Object.getOwnPropertySymbols(el.childNodes).length              // 1          (a browser: 0)
```

and it cost one descriptor on every collection a page ever touches.

## What changed

**Engine — three overloads on `JsObjectShape.Builder` taking a `JsSymbol` key** (`Method`, `Accessor`, `PerRealmSlot`), covering the same three kinds a string key already had. The per-realm one is what Web IDL's `iterable<>` needs: [§3.7.10](https://webidl.spec.whatwg.org/#js-iterable) makes `@@iterator` the realm's own `%Array.prototype.values%` rather than a function wrapping it, and only a value produced per engine can be that.

Defaults are the attributes both Web IDL and ECMAScript give a symbol-keyed member — `{ writable: true, enumerable: false, configurable: true }` — the one rule where the two agree. A materialized function is named the way [SetFunctionName](https://tc39.es/ecma262/#sec-setfunctionname) names one under a symbol key (`[Symbol.iterator]`, `get [Symbol.toPrimitive]`).

**It is additive to a hot engine type, deliberately so.** Symbols live in `_symbols`, orthogonal to the shared string-keyed layout, so the inline cache, the property-key fast lanes and the `IBuiltinShaped` storage protocol are untouched, and a shaped object stays shaped. A method and a per-realm slot are lazy through `PropertyDescriptor.CreateLazy`, so declaring `@@iterator` on fifteen DOM prototypes costs fifteen unmaterialized descriptors and nothing else. `ToStringTag` becomes shorthand for one such member and keeps its exact previous attributes and descriptor shape. **No benchmark was run — that is the lead's to take if the touched type warrants one; the string-keyed paths are byte-identical and `Jint.Tests.SourceGenerators` is unchanged.**

**Generator** — the emitter writes the slot for every interface that *declares* indexed property support and not for one that merely inherits the getter, which is where a browser has it too. Fourteen generated interfaces (`NodeList`, `DOMTokenList`, `NamedNodeMap`, `CSSStyleDeclaration`, `CSSRuleList`, `StyleSheetList`, `MediaList`, `DOMStringList`, `FileList`, `TouchList`, `CSSPseudoElementList`, the three track lists) plus the hand-written `HTMLCollection` shape; `HTMLOptionsCollection`, `HTMLFormControlsCollection`, `HTMLAllCollection` and `DOMSettableTokenList` inherit theirs. `DomIterator` stops writing onto instances and becomes the factory the emitter names.

**`Symbol.toStringTag` needed nothing.** The issue asks for it as a real property; `Builder.ToStringTag` already emitted one on every interface prototype and `WebIdlPropertyAttributeTests`/`DomPrototypeTests` already pinned it. Only `@@iterator` moved.

## Tests

- `Jint.Tests.PublicInterface/HostPrototypeShapeTests` — five new tests from outside the assembly (no `InternalsVisibleTo`, so green means an embedder can reach it): the members live on the prototype and not on instances, the attributes and function names, identity stable within an engine and distinct across two, redefinition and `delete` behave ordinarily and keep the shape, and the builder's refusals.
- `Jint.Tests/Runtime/SharedObjectShapeTests.ASymbolKeyedSlotStaysUnmaterializedUntilTheMemberIsRead` — the laziness claim, by counting factory invocations.
- `Jint.Tests.Browser/DomCollectionTests` — `NodeList.prototype[Symbol.iterator] === Array.prototype[Symbol.iterator]`, no own symbol on an instance, the Web IDL attributes, the inherit-don't-redeclare rule, and that spread / `for..of` / destructuring still reach every collection kind.
- `WebIdlPropertyAttributeTests` gained the `@@iterator` row; it walks every interface, so it is what proves the emitter got the attributes right everywhere at once.
- Regenerated with `JINT_DOM_BINDINGS=update`; staleness test green, the two pinned generator diagnostics unchanged.
- Full `Jint.Tests` (12218), `Jint.Tests.Browser` (1211 net10.0 + 1208 net8.0), `Jint.Tests.SourceGenerators` (71), `Jint.Tests.PublicInterface` (3608) all green. The public-API baselines gained the three overloads; `docs/v5-migration.md` §5.27 records them.

## What was left out

- `Symbol.unscopables`, mentioned in passing by the issue — nothing needs it, and it is a plain symbol-keyed member now that the builder has one.
- The obstacle course and client suites are unchanged, and the browser lane's exclusion table and census were not touched.
- One source-level nuisance, in the migration guide: `Method(null, impl)` with a bare `null` literal is now ambiguous; write `Method((string) null, impl)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
