### PR TITLE
EventSource: a stream is reported to the fetch observer whole - the request, the response, every chunk

### DIFF
--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -75,8 +75,10 @@ target/runtime split and the manifest are there and none of it is repeated here.
 - **What is accepted and not effective says so, in place.** `Network.setCacheDisabled` (there is no cache)
   and `Audits.enable` are answered because a refusal fails an ordinary connection. Three whole lanes are
   absent with a reason rather than pending: the `Fetch` **response stage** and with it `IO` (an observer
-  cannot answer `OnResponse`, so a response-stage pause could only continue unchanged), the **WebSocket and
-  EventSource** events (the engine deliberately does not observe those two handshakes), and `Network`'s
+  cannot answer `OnResponse`, so a response-stage pause could only continue unchanged), the **WebSocket**
+  events and `eventSourceMessageReceived` (a socket's handshake is not a fetch and is not observed; a stream
+  *is*, but as bytes rather than as the events they decode into, so its requests are in the log as
+  `ResourceType: EventSource` and its messages are nowhere), and `Network`'s
   **timing** document (no phase of a request is measured). **`Emulation` is no longer among any of it**:
   every command of that domain is either effective or an accepted no-op whose summary says what there is
   none of.

--- a/Jint.Browser/DevTools/FetchDomain.cs
+++ b/Jint.Browser/DevTools/FetchDomain.cs
@@ -341,6 +341,7 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
         PageRequestKind.Stylesheet => ProtocolNetwork.ResourceTypeValues.Stylesheet,
         PageRequestKind.Xhr => ProtocolNetwork.ResourceTypeValues.XHR,
         PageRequestKind.Fetch => ProtocolNetwork.ResourceTypeValues.Fetch,
+        PageRequestKind.EventSource => ProtocolNetwork.ResourceTypeValues.EventSource,
         PageRequestKind.Image => ProtocolNetwork.ResourceTypeValues.Image,
         PageRequestKind.Frame => ProtocolNetwork.ResourceTypeValues.Document,
         _ => ProtocolNetwork.ResourceTypeValues.Other,

--- a/Jint.Browser/DevTools/NetworkDomain.Events.cs
+++ b/Jint.Browser/DevTools/NetworkDomain.Events.cs
@@ -217,6 +217,7 @@ internal sealed partial class NetworkDomain
         PageRequestKind.Stylesheet => ResourceTypeValues.Stylesheet,
         PageRequestKind.Xhr => ResourceTypeValues.XHR,
         PageRequestKind.Fetch => ResourceTypeValues.Fetch,
+        PageRequestKind.EventSource => ResourceTypeValues.EventSource,
         PageRequestKind.Image => ResourceTypeValues.Image,
         PageRequestKind.Frame => ResourceTypeValues.Document,
         _ => ResourceTypeValues.Other,

--- a/Jint.Browser/Runtime/PageNetworkListener.cs
+++ b/Jint.Browser/Runtime/PageNetworkListener.cs
@@ -30,6 +30,15 @@ internal enum PageRequestKind
     /// <summary>A <c>fetch()</c> a script made.</summary>
     Fetch,
 
+    /// <summary>An <c>EventSource</c> stream a script opened.</summary>
+    /// <remarks>
+    /// A page's own scripts cannot open one — the feature is not among the ones a page engine is built with
+    /// — so this names the streams of a host that granted it through <c>BrowserOptions.ConfigureEngine</c>.
+    /// The engine reports them like any other request, so the log would otherwise call a stream a
+    /// <c>fetch</c>.
+    /// </remarks>
+    EventSource,
+
     /// <summary>An image the document referenced, which this browser records and does not fetch.</summary>
     Image,
 

--- a/Jint.Browser/Runtime/PageNetworkRecorder.cs
+++ b/Jint.Browser/Runtime/PageNetworkRecorder.cs
@@ -270,6 +270,7 @@ internal sealed class PageNetworkRecorder : FetchObserver
         var kind = declaration?.Kind ?? request.Initiator switch
         {
             FetchInitiator.XmlHttpRequest => PageRequestKind.Xhr,
+            FetchInitiator.EventSource => PageRequestKind.EventSource,
             FetchInitiator.Host => PageRequestKind.Document,
             _ => PageRequestKind.Fetch,
         };

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -3066,6 +3066,7 @@ namespace Jint.WebApi.Fetch
         Script = 0,
         Host = 1,
         XmlHttpRequest = 2,
+        EventSource = 3,
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class FetchInterception

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -3066,6 +3066,7 @@ namespace Jint.WebApi.Fetch
         Script = 0,
         Host = 1,
         XmlHttpRequest = 2,
+        EventSource = 3,
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class FetchInterception

--- a/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
@@ -1,5 +1,6 @@
 #if NET8_0_OR_GREATER
 #nullable enable
+#pragma warning disable JINT0002 // the fetch observer is a preview surface; a stream is one of the lanes it watches
 
 using System.Net;
 using System.Net.Http;
@@ -7,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Jint.WebApi.Fetch;
 
 namespace Jint.Tests.Runtime.WebApi;
 
@@ -243,6 +245,180 @@ public class EventSourceTests
 
     private static void PumpUntilLogHas(Engine engine, int entries, string expectation)
         => Pump(engine, () => engine.Evaluate("log.length").AsNumber() >= entries, expectation);
+
+    /// <summary>
+    /// A <see cref="FetchObserver"/> that writes down what it was told, in the order it was told.
+    /// </summary>
+    /// <remarks>
+    /// Every callback arrives on a transport thread, so the list is guarded and a test waits for a count
+    /// rather than assuming the hand-over has happened; <see cref="Take"/> answers a prefix so that a
+    /// terminal call a test is not about — the failure a closed stream reports — cannot race into an
+    /// assertion.
+    /// </remarks>
+    private sealed class RecordingObserver : FetchObserver
+    {
+        private readonly List<string> _events = new();
+
+        public override ValueTask<FetchInterception?> OnRequestAsync(ObservedFetchRequest request, CancellationToken cancellationToken)
+        {
+            Add($"request {request.Id} {request.Method} {request.Url} redirects={request.RedirectCount} initiator={request.Initiator}");
+            return new ValueTask<FetchInterception?>((FetchInterception?) null);
+        }
+
+        public override void OnResponse(ObservedFetchResponse response)
+            => Add($"response {response.Id} {response.Status} redirect={response.IsRedirect}");
+
+        public override void OnData(FetchRequestId id, ReadOnlySpan<byte> chunk)
+            => Add($"data {id} {chunk.Length}");
+
+        public override void OnCompleted(FetchRequestId id, long bodyLength)
+            => Add($"completed {id} {bodyLength}");
+
+        public override void OnFailed(FetchRequestId id, string reason, Exception? exception)
+            => Add($"failed {id} {reason}");
+
+        /// <summary>Waits for <paramref name="count"/> notifications and answers exactly those.</summary>
+        internal IReadOnlyList<string> Take(int count)
+        {
+            var deadline = DateTime.UtcNow + TransportSignalCeiling;
+            while (DateTime.UtcNow < deadline)
+            {
+                lock (_events)
+                {
+                    if (_events.Count >= count)
+                    {
+                        return _events.GetRange(0, count);
+                    }
+                }
+
+                Thread.Sleep(2);
+            }
+
+            lock (_events)
+            {
+                Assert.Fail($"the observer should have been told {count} things; it was told: {string.Join(" | ", _events)}");
+                return _events.ToArray();
+            }
+        }
+
+        private void Add(string entry)
+        {
+            lock (_events)
+            {
+                _events.Add(entry);
+            }
+        }
+    }
+
+    /// <summary>
+    /// An observer sees a stream the way it sees a fetch: the request, the response, a chunk at a time as
+    /// the bytes arrive, and one terminal call.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The initiator is <c>FetchInitiator.EventSource</c>, because a host reporting this to a tool has to
+    /// name the interface that asked — the Chrome DevTools Protocol has a resource type of its own for a
+    /// stream.
+    /// </para>
+    /// <para>
+    /// <b>The chunks are what make this whole rather than partial.</b> An <c>EventSource</c> reads its own
+    /// body, so nothing in the transport can hand them over; without the call in the read loop an observer
+    /// would be told a stream was asked for and answered and never that a byte of it arrived, which is why
+    /// this lane was left unobserved until there was somewhere to put them
+    /// ([#3621](https://github.com/sebastienros/jint/issues/3621)).
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void AnObserverSeesTheRequestTheResponseAndEveryChunk()
+    {
+        var stream = new PushStream();
+        var handler = new StubHandler { Responder = _ => Answer(stream) };
+        var observer = new RecordingObserver();
+        var (engine, _) = SseEngine(handler, net => net.Observer = observer);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+
+        stream.Push("data: one\n\n");
+        PumpUntilLogHas(engine, 2, "the open event and the first message");
+
+        stream.Push("data: two\n\n");
+        PumpUntilLogHas(engine, 3, "the second message");
+
+        var events = observer.Take(4);
+        var id = events[0].Split(' ')[1];
+
+        events.Should().Equal(
+            $"request {id} GET {StreamUrl} redirects=0 initiator=EventSource",
+            $"response {id} 200 redirect=False",
+            $"data {id} 11",
+            $"data {id} 11");
+
+        engine.Execute("es.close();");
+        stream.Complete();
+    }
+
+    /// <summary>
+    /// A stream the server ends completes, and the reconnect that follows is a request of its own with its
+    /// own identifier — which is what it is on the wire, and what a network panel shows.
+    /// </summary>
+    [Test]
+    public void EachConnectionIsItsOwnObservedRequestAndTheEndCompletesIt()
+    {
+        var second = new PushStream();
+        var handler = new StubHandler
+        {
+            Responder = attempt => attempt == 0 ? Answer("data: one\n\n") : Answer(second),
+        };
+
+        var observer = new RecordingObserver();
+        var (engine, clock) = SseEngine(handler, net => net.Observer = observer);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 3, "open, the message, and the error the ended stream queues");
+
+        // The reconnect is a timer entry on the engine's own queue, so it takes the clock and a pump.
+        clock.Advance(5000);
+        Pump(engine, () => handler.Requests.Count == 2, "the reconnect");
+
+        var events = observer.Take(6);
+        var first = events[0].Split(' ')[1];
+        var next = events[4].Split(' ')[1];
+
+        next.Should().NotBe(first, "a reconnect is a second request, not a second hop of the first");
+        events.Should().Equal(
+            $"request {first} GET {StreamUrl} redirects=0 initiator=EventSource",
+            $"response {first} 200 redirect=False",
+            $"data {first} 11",
+            $"completed {first} 11",
+            $"request {next} GET {StreamUrl} redirects=0 initiator=EventSource",
+            $"response {next} 200 redirect=False");
+
+        engine.Execute("es.close();");
+        second.Complete();
+    }
+
+    /// <summary>
+    /// A response the standard fails the connection over reaches the observer as the response it was and
+    /// then as a failure, so the terminal call is never left unmade.
+    /// </summary>
+    [Test]
+    public void AResponseTheStandardRefusesIsReportedAsAFailure()
+    {
+        var handler = new StubHandler { Responder = _ => Answer("", "text/plain") };
+        var observer = new RecordingObserver();
+        var (engine, _) = SseEngine(handler, net => net.Observer = observer);
+
+        engine.Execute($"var es = watch(new EventSource('{StreamUrl}'));");
+        PumpUntilLogHas(engine, 1, "the error event");
+
+        var events = observer.Take(3);
+        var id = events[0].Split(' ')[1];
+
+        events.Should().Equal(
+            $"request {id} GET {StreamUrl} redirects=0 initiator=EventSource",
+            $"response {id} 200 redirect=False",
+            $"failed {id} The response is not a text/event-stream.");
+    }
 
     [Test]
     public void DispatchesAMessageEventForEachBlankLineTerminatedBlock()

--- a/Jint/WebApi/Fetch/AGENTS.md
+++ b/Jint/WebApi/Fetch/AGENTS.md
@@ -63,6 +63,15 @@ fetch, because that is the callback that was asked to decide. Two ordering facts
 onto a protocol: **a refusal before the transport** (a `UrlFilter` denial, the concurrency cap, an
 already-aborted signal) reports `OnFailed` with no `OnRequest` before it, because `fetch`'s synchronous half
 cannot await one; and **a body nobody reads never completes**, because it is only pulled when script consumes
-it. `EventSource` and `WebSocket` reach `FetchTransport` too and are deliberately **not** observed:
-`EventSource` reads its own stream, so it would produce `OnResponse` and then silence, and partial
-observation is worse than none.
+it. **`EventSource` is observed whole; a `WebSocket` is not observed at all, and the line between them is
+whether the observer can be told everything.** A stream reaches `FetchTransport`, so the request and every
+redirect hop cost nothing to report — but it reads its own body, which is why it was left unobserved until
+`EventSourceConnection` paid the same two debts a document fetch pays: `FinalResponse`, which every caller of
+`SendForStreamAsync` owes, and `Data` per chunk from inside the read loop. Each connection is its own
+observation, so a reconnect is a second request with its own id, and the terminal call is `OnCompleted` for a
+stream the server ended and `OnFailed` for every other ending, an abandoned one included. A socket is the
+case that stays refused: its handshake never reaches this transport (`ClientWebSocket` makes its own HTTP
+request, and the headers that matter — `Sec-WebSocket-Key`, the negotiated extensions — are added inside it
+and cannot be enumerated), an interception's `Fulfill` could not be honoured at all, and the frames afterwards
+are not a body. That is a `WebSocketObserver` of its own, not this one
+([#3621](https://github.com/sebastienros/jint/issues/3621)).

--- a/Jint/WebApi/Fetch/FetchObserver.cs
+++ b/Jint/WebApi/Fetch/FetchObserver.cs
@@ -33,8 +33,9 @@ public readonly record struct FetchRequestId(long Value)
 /// What asked for a request.
 /// </summary>
 /// <remarks>
-/// Only <see cref="Script"/> and <see cref="XmlHttpRequest"/> are produced by the engine itself; the rest
-/// name the callers a host layer above Jint adds, and new members may appear, so switch with a default arm.
+/// Only <see cref="Script"/>, <see cref="XmlHttpRequest"/> and <see cref="EventSource"/> are produced by the
+/// engine itself; the rest name the callers a host layer above Jint adds, and new members may appear, so
+/// switch with a default arm.
 /// </remarks>
 public enum FetchInitiator
 {
@@ -51,6 +52,15 @@ public enum FetchInitiator
     /// and another for <c>XMLHttpRequest</c>, and nothing on the wire distinguishes the two.
     /// </remarks>
     XmlHttpRequest = 2,
+
+    /// <summary>An <c>EventSource</c> connection made by script.</summary>
+    /// <remarks>
+    /// One per connection rather than one per <c>EventSource</c>: a reconnect is a second request with its
+    /// own identifier, which is what it is on the wire and what a network panel shows. The Chrome DevTools
+    /// Protocol has its own resource type for one, for the same reason <see cref="XmlHttpRequest"/> is told
+    /// apart from <see cref="Script"/>.
+    /// </remarks>
+    EventSource = 3,
 }
 
 /// <summary>

--- a/Jint/WebApi/ServerSentEvents/EventSourceConnection.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourceConnection.cs
@@ -95,6 +95,21 @@ internal sealed class EventSourceConnection
 
     private readonly EventStreamParser _parser;
 
+    /// <summary>
+    /// The host's observer, or <see langword="null"/> when it set none.
+    /// </summary>
+    /// <remarks>
+    /// <b>A stream is observed whole, not partially.</b> The transport reports the request and every redirect
+    /// hop, and this class owes the rest — the final response, because every caller of
+    /// <c>SendForStreamAsync</c> does, and the body, because the read loop below is the only thing that ever
+    /// sees these bytes. Without both, an observer would be shown a stream that was asked for and answered
+    /// and never a byte of what it carried.
+    /// </remarks>
+    private FetchObservation? _observation;
+
+    /// <summary>How many bytes of the stream have been read, for the observer's terminal call.</summary>
+    private long _observedBytes;
+
     private int _finished;
 
     internal EventSourceConnection(JsEventSource source, Engine engine, Realm realm, long maxEventLength, string lastEventId)
@@ -113,8 +128,10 @@ internal sealed class EventSourceConnection
     /// Starts the request. Returns as soon as the transport goes asynchronous, so the constructor that
     /// ultimately called this does not wait for a socket.
     /// </summary>
-    internal void Start(HttpClient client, FetchRequestSnapshot request, FetchPolicy policy)
+    internal void Start(HttpClient client, FetchRequestSnapshot request, FetchPolicy policy, FetchObservation? observation)
     {
+        _observation = observation;
+
         // Fire and forget by design: every outcome the loop can reach, including a synchronous throw from a
         // host's own handler, is turned into an engine-thread job inside it.
         _ = RunAsync(client, request, policy);
@@ -125,16 +142,20 @@ internal sealed class EventSourceConnection
         try
         {
             using var exchange = await FetchTransport
-                .SendForStreamAsync(client, request, policy, _token)
+                .SendForStreamAsync(client, request, policy, _token, _observation)
                 .ConfigureAwait(false);
 
             var response = exchange.Response;
+
+            // The debt every SendForStreamAsync caller owes its observer; see FetchObservation.FinalResponse.
+            _observation?.FinalResponse(exchange);
 
             // Constructor step 15.iii: "if res's status is not 200, or if res's Content-Type is not
             // text/event-stream, then fail the connection" — a failure the standard deliberately does not
             // reconnect from, because retrying an answer the server meant would only repeat it.
             if ((int) response.StatusCode != 200 || !IsEventStream(response))
             {
+                _observation?.Failed(FailureReason(response), null);
                 Finish(EventSourceOutcome.Fail);
                 return;
             }
@@ -147,18 +168,23 @@ internal sealed class EventSourceConnection
         catch (OperationCanceledException)
         {
             // close(), a restore, or the engine's own cancellation: the only three things that cancel this
-            // token. None of them announces anything, and none of them reconnects.
+            // token. None of them announces anything, and none of them reconnects — and to an observer a
+            // stream nobody will read again is a request that ended without its answer, which is what an
+            // abandoned fetch reports too.
+            _observation?.Failed("The event stream was closed.", null);
             Finish(EventSourceOutcome.Abandoned);
         }
         catch (FetchFailureException failure) when (failure.Kind is FetchFailureKind.ResponseTooLarge or FetchFailureKind.PolicyDenied or FetchFailureKind.RedirectLimit)
         {
             // The host's own limits, all three of which a reconnect would run straight back into.
+            _observation?.Failed(failure.Message, failure);
             Finish(EventSourceOutcome.Fail);
         }
         catch (Exception exception) when (!ConstraintFailure.MustPropagate(exception))
         {
             // Constructor step 15.ii: a network error reestablishes the connection. A DNS failure, a refused
             // connection and a stream the server dropped are the ordinary life of a long-lived stream.
+            _observation?.Failed(exception.Message, exception);
             Finish(EventSourceOutcome.Reestablish);
         }
     }
@@ -179,10 +205,17 @@ internal sealed class EventSourceConnection
                 if (read == 0)
                 {
                     // processResponseEndOfBody: "if res is not a network error, then reestablish the
-                    // connection". A server closing the stream is how it asks to be polled again.
+                    // connection". A server closing the stream is how it asks to be polled again — and to an
+                    // observer this connection is a request that completed, the reconnect being another one.
+                    _observation?.Completed(_observedBytes);
                     Finish(EventSourceOutcome.Reestablish);
                     return;
                 }
+
+                // Handed over before the parser sees them, which is what "as it is read off the wire" means:
+                // an observer is watching the transfer, not the events the bytes happen to decode into.
+                _observedBytes += read;
+                _observation?.Data(buffer.AsSpan(0, read));
 
                 Deliver(buffer, read, origin);
             }
@@ -211,6 +244,17 @@ internal sealed class EventSourceConnection
 
         Enqueue(() => _source.DeliverMessages(this, reconnectionTime, messages, origin));
     }
+
+    /// <summary>
+    /// Why a response the standard refuses failed, in the observer's vocabulary rather than the script's —
+    /// which is told nothing at all, because https://html.spec.whatwg.org/multipage/server-sent-events.html
+    /// fires a bare <c>error</c> event and a script that could tell one refusal from another could map the
+    /// network it runs in.
+    /// </summary>
+    private static string FailureReason(HttpResponseMessage response)
+        => (int) response.StatusCode != 200
+            ? "The event stream answered " + ((int) response.StatusCode).ToString(System.Globalization.CultureInfo.InvariantCulture) + "."
+            : "The response is not a text/event-stream.";
 
     /// <summary>
     /// https://mimesniff.spec.whatwg.org/#mime-type-essence of the response's <c>Content-Type</c>, compared

--- a/Jint/WebApi/ServerSentEvents/JsEventSource.cs
+++ b/Jint/WebApi/ServerSentEvents/JsEventSource.cs
@@ -119,6 +119,12 @@ internal sealed class JsEventSource : JsEventTarget
     {
         var urlFilter = _options.UrlFilter ?? (static _ => true);
 
+        // One observation per connection, created before the three refusals below so that a stream the host
+        // never let out is reported as a failure rather than as nothing at all — the same shape a fetch
+        // refused before the transport has, and the same reason: fetch's synchronous half cannot await an
+        // OnRequest either.
+        var observation = FetchObservation.Create(_state.FetchNetwork.Observer, FetchInitiator.EventSource);
+
         var policy = new FetchPolicy
         {
             AllowedSchemes = [.. _options.AllowedSchemes],
@@ -132,6 +138,7 @@ internal sealed class JsEventSource : JsEventTarget
         // redirect hop is re-checked inside the transport, and every reconnect comes back through here.
         if (!policy.Allows(Url, out _))
         {
+            observation?.Failed("The fetch policy refused '" + Url.Serialize() + "'.", null);
             FailConnectionLater();
             return;
         }
@@ -140,6 +147,10 @@ internal sealed class JsEventSource : JsEventTarget
         // separately, the event streams open, because a stream holds its socket for as long as it lives.
         if (_state.ActiveEventSourceCount >= _options.MaxConcurrentRequests)
         {
+            observation?.Failed(
+                "The engine already has " + _options.MaxConcurrentRequests.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                + " event streams open.",
+                null);
             FailConnectionLater();
             return;
         }
@@ -159,6 +170,7 @@ internal sealed class JsEventSource : JsEventTarget
 
         if (client is null)
         {
+            observation?.Failed("The host's HttpClient factory did not answer with a client.", null);
             FailConnectionLater();
             return;
         }
@@ -168,7 +180,7 @@ internal sealed class JsEventSource : JsEventTarget
         var connection = new EventSourceConnection(this, _engine, _realm, _options.MaxResponseBytes, LastEventId);
         _connection = connection;
         _state.RegisterEventSource(connection);
-        connection.Start(client, BuildRequest(), policy);
+        connection.Start(client, BuildRequest(), policy, observation);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -1589,6 +1589,12 @@ something different for a stream:
 - **`MaxConcurrentRequests` bounds the streams one engine may have open**, counted separately from the
   fetches in flight, because a stream holds its socket for as long as it lives.
 
+`Observer` reads the same way it does for a fetch, and a stream is reported whole: the request (with
+`FetchInitiator.EventSource`, so a tool can name the interface that asked), the response, every chunk as it
+comes off the wire, and one terminal call — `OnCompleted` when the server ends the stream, `OnFailed` when
+the connection is refused, fails or is closed. **Each connection is its own request**: a reconnect has an
+identifier of its own, which is what it is on the wire.
+
 **Reconnection rides the timer queue**, so it too happens only while you are pumping, and it counts against
 `MaxActiveTimers`. A stream that ends, or a network error, sets `readyState` back to `CONNECTING`, fires
 `error`, waits the server's `retry:` value (3 seconds by default) and connects again — re-running the URL
@@ -2687,7 +2693,7 @@ recorded in `Page.Requests` with the reason instead — `integrity` is accepted 
 | What is missing | Tracked by |
 | --- | --- |
 | `Fetch`'s **response** stage, and with it the `IO` domain: an observer is told about a response and cannot answer it, so a response-stage pause could only ever continue unchanged | [#3701](https://github.com/sebastienros/jint/issues/3701) |
-| `Network`'s WebSocket and EventSource events — the engine deliberately does not observe those two handshakes — and its **timing** document, since no phase of a request is measured and a document of zeros would read as a page that loaded instantly | [#3701](https://github.com/sebastienros/jint/issues/3701) |
+| `Network`'s WebSocket events — a socket's handshake is not a fetch, so the engine does not observe it — its `eventSourceMessageReceived` event, since what an observer is handed is the stream's bytes rather than the events they decode into, and its **timing** document, since no phase of a request is measured and a document of zeros would read as a page that loaded instantly | [#3701](https://github.com/sebastienros/jint/issues/3701) |
 | A page's `@media` rules are evaluated against the page's viewport and emulated media type, but not against the emulated **preferences** — AngleSharp.Css's render device models none of them — so a themed page reads `matchMedia` rather than `getComputedStyle` to find out whether the scheme is dark | [#3707](https://github.com/sebastienros/jint/issues/3707) |
 | `ElementInternals`, so a `static formAssociated` custom element is recorded and takes part in no form; and no scoped custom element registries | [#3714](https://github.com/sebastienros/jint/issues/3714) |
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5223,6 +5223,36 @@ effect beyond cancelling the event: it is HTML's *notHandled*, so a handler atta
 There is no option that restores the old timing. A host that wants the report where the rejection happened
 can subscribe to `PromiseRejectionTracker` and read `Operation`, which still names the two
 `HostPromiseRejectionTracker` operations — what changed is *when* the event is raised, not what it carries.
+<<<<<<< HEAD
+=======
+### 4.123 A `FetchObserver` sees an `EventSource` stream ([#3621](https://github.com/sebastienros/jint/issues/3621))
+
+`EventSource` reached the same transport every other request does and was reported to
+`Options.WebApi.Fetch.Observer` not at all, so a host watching its engine's network saw every `fetch` and
+every `XMLHttpRequest` and nothing of a stream. It is now reported like anything else: the request under the
+new `FetchInitiator.EventSource`, the response, every chunk through `OnData` as it comes off the wire, and
+one terminal call.
+
+```csharp
+public override ValueTask<FetchInterception?> OnRequestAsync(ObservedFetchRequest request, CancellationToken token)
+{
+    // 5.0: never called for an EventSource.
+    // 5.x: called per connection, with Initiator == FetchInitiator.EventSource.
+    return new((FetchInterception?) null);
+}
+```
+
+**Each connection is its own request.** A reconnect has an identifier of its own, so an observer that keys
+state on `FetchRequestId` sees one request end and another begin rather than a single long-lived one. The
+terminal call is `OnCompleted` for a stream the server ended and `OnFailed` for everything else — a refusal
+before the transport, a network error, and `close()`, which reports `"The event stream was closed."`.
+
+**What could break:** an observer that counts requests, or one that keeps every `OnData` chunk, now sees a
+lane it did not before — a long-lived stream at that, so an observer that buffers bodies without a bound of
+its own is the one to look at. The enum's own documentation already said new members may appear and that a
+`switch` over it wants a default arm.
+
+>>>>>>> 735042b8c (EventSource: a stream is reported to the fetch observer whole — the request, the response, every chunk)
 ### 4.123 An error is rendered without running its `name` or `message` accessor ([#3598](https://github.com/sebastienros/jint/issues/3598))
 
 `console.log(err)` and `console.error(err)` rendered an error through `Error.prototype.toString`, which is

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5223,36 +5223,6 @@ effect beyond cancelling the event: it is HTML's *notHandled*, so a handler atta
 There is no option that restores the old timing. A host that wants the report where the rejection happened
 can subscribe to `PromiseRejectionTracker` and read `Operation`, which still names the two
 `HostPromiseRejectionTracker` operations — what changed is *when* the event is raised, not what it carries.
-<<<<<<< HEAD
-=======
-### 4.123 A `FetchObserver` sees an `EventSource` stream ([#3621](https://github.com/sebastienros/jint/issues/3621))
-
-`EventSource` reached the same transport every other request does and was reported to
-`Options.WebApi.Fetch.Observer` not at all, so a host watching its engine's network saw every `fetch` and
-every `XMLHttpRequest` and nothing of a stream. It is now reported like anything else: the request under the
-new `FetchInitiator.EventSource`, the response, every chunk through `OnData` as it comes off the wire, and
-one terminal call.
-
-```csharp
-public override ValueTask<FetchInterception?> OnRequestAsync(ObservedFetchRequest request, CancellationToken token)
-{
-    // 5.0: never called for an EventSource.
-    // 5.x: called per connection, with Initiator == FetchInitiator.EventSource.
-    return new((FetchInterception?) null);
-}
-```
-
-**Each connection is its own request.** A reconnect has an identifier of its own, so an observer that keys
-state on `FetchRequestId` sees one request end and another begin rather than a single long-lived one. The
-terminal call is `OnCompleted` for a stream the server ended and `OnFailed` for everything else — a refusal
-before the transport, a network error, and `close()`, which reports `"The event stream was closed."`.
-
-**What could break:** an observer that counts requests, or one that keeps every `OnData` chunk, now sees a
-lane it did not before — a long-lived stream at that, so an observer that buffers bodies without a bound of
-its own is the one to look at. The enum's own documentation already said new members may appear and that a
-`switch` over it wants a default arm.
-
->>>>>>> 735042b8c (EventSource: a stream is reported to the fetch observer whole — the request, the response, every chunk)
 ### 4.123 An error is rendered without running its `name` or `message` accessor ([#3598](https://github.com/sebastienros/jint/issues/3598))
 
 `console.log(err)` and `console.error(err)` rendered an error through `Error.prototype.toString`, which is
@@ -5378,6 +5348,33 @@ request that sets `User-Agent` itself still wins, because the standard's own con
 **What could break:** a server or a test double that asserts on the exact set of request headers, and a
 host that deliberately made anonymous requests. `fetch.UserAgent = null` restores the 4.16 behaviour for
 every lane at once.
+
+### 4.126 A `FetchObserver` sees an `EventSource` stream ([#3621](https://github.com/sebastienros/jint/issues/3621))
+
+`EventSource` reached the same transport every other request does and was reported to
+`Options.WebApi.Fetch.Observer` not at all, so a host watching its engine's network saw every `fetch` and
+every `XMLHttpRequest` and nothing of a stream. It is now reported like anything else: the request under the
+new `FetchInitiator.EventSource`, the response, every chunk through `OnData` as it comes off the wire, and
+one terminal call.
+
+```csharp
+public override ValueTask<FetchInterception?> OnRequestAsync(ObservedFetchRequest request, CancellationToken token)
+{
+    // 5.0: never called for an EventSource.
+    // 5.x: called per connection, with Initiator == FetchInitiator.EventSource.
+    return new((FetchInterception?) null);
+}
+```
+
+**Each connection is its own request.** A reconnect has an identifier of its own, so an observer that keys
+state on `FetchRequestId` sees one request end and another begin rather than a single long-lived one. The
+terminal call is `OnCompleted` for a stream the server ended and `OnFailed` for everything else — a refusal
+before the transport, a network error, and `close()`, which reports `"The event stream was closed."`.
+
+**What could break:** an observer that counts requests, or one that keeps every `OnData` chunk, now sees a
+lane it did not before — a long-lived stream at that, so an observer that buffers bodies without a bound of
+its own is the one to look at. The enum's own documentation already said new members may appear and that a
+`switch` over it wants a default arm.
 
 ## 5. New in v5
 


### PR DESCRIPTION
Part of #3621 — its item 2, with the decision it asked for.

## What was wrong

`Options.WebApi.Fetch.Observer` sees every `fetch` and every `XMLHttpRequest` an engine makes, and saw nothing at all of an `EventSource` stream — though the stream reaches the very same `FetchTransport`. That was deliberate, and `Jint/WebApi/Fetch/AGENTS.md` said so: an `EventSource` reads its own body, so wiring only what the transport knows would have produced an `OnResponse` and then silence, and a partial observation is worse than none.

```
the observer should have been told 4 things; it was told:
the observer should have been told 3 things; it was told:
the observer should have been told 6 things; it was told:
```

— the three new tests, against unfixed code: nothing at all, three times.

## The decision

**`EventSource` is observed whole. A `WebSocket` is not observed at all.** The line between them is whether the observer can be told everything, which is the same standard the original refusal was written against.

A stream can be. What was missing was the two debts a document fetch already pays: `FinalResponse`, which [every caller of `SendForStreamAsync` owes](https://github.com/sebastienros/jint/blob/main/Jint/WebApi/Fetch/FetchObservation.cs), and `Data` per chunk — from inside the read loop, because that loop is the only thing that ever sees these bytes. With both, an observer is told about a stream exactly what it is told about a fetch.

A socket cannot be, and the reason is now written down where the old claim was:

- its handshake never reaches this transport — `ClientWebSocket` makes its own HTTP request, and the headers that decide it (`Sec-WebSocket-Key`, `Sec-WebSocket-Version`, the negotiated extensions) are added inside it and cannot be enumerated, so the request an observer would be shown is not the request that goes out;
- an interception's `Fulfill` could not be honoured at all and `Continue`'s rewrites only partly, so the seam would be answering "I decided" to a decision nothing acts on;
- and the frames afterwards — which are what a client actually wants from CDP's `Network.webSocket*` — are not a body, so `OnData` is the wrong shape for them.

That is a `WebSocketObserver` of its own (created / handshake / frame sent / frame received / closed), not this one, and nothing consumes it yet: `Jint.Browser` does not grant pages the `WebSocket` feature, so the browser lane could not read one today.

## What changed

- `FetchInitiator.EventSource` (3), for the reason `XmlHttpRequest` was added: a host reporting a request to a tool has to name the interface that asked, and CDP has a resource type of its own for a stream.
- `JsEventSource.Connect` creates one observation per **connection**, before its three refusals — so a stream the host's own policy, concurrency cap or client factory refused is an `OnFailed` with no `OnRequest`, which is the shape a `fetch` refused before the transport already has.
- `EventSourceConnection` reports the final response, every chunk as it is read, and one terminal call: `OnCompleted(bytes)` when the server ends the stream, `OnFailed` for a status or content type the standard refuses, for a network error, for the host's own limits, and for `close()` (`"The event stream was closed."`).
- A reconnect is a second observation with its own id.
- `Jint.Browser` learns `PageRequestKind.EventSource` and maps it to Chrome's `EventSource` resource type in both the `Network` and `Fetch` domains, so a page whose host granted the feature through `ConfigureEngine` logs a stream as a stream instead of as a `fetch`.

## The tests that pin it

`EventSourceTests`, with a `RecordingObserver` that waits for a count and answers a prefix, so a terminal call a case is not about cannot race into its assertion:

- `AnObserverSeesTheRequestTheResponseAndEveryChunk` — request (`initiator=EventSource`), response, and one `data` per pushed chunk, in that order.
- `EachConnectionIsItsOwnObservedRequestAndTheEndCompletesIt` — the ended stream completes, the reconnect is a **different** id, and the order across both connections is pinned.
- `AResponseTheStandardRefusesIsReportedAsAFailure` — a `text/plain` answer is reported as the response it was and then as a failure, so the terminal call is never left unmade.

`Jint.Tests` (`WebApi|Wpt|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests`, net10.0) 3546 passed, `Jint.Tests.PublicInterface` (net10.0) 3590 passed with the new enum member in the approved baseline, `Jint.Tests.Browser` 1200 / 1203 passed on both frameworks, solution builds clean in Release.

**web-platform-tests: no change in either direction.** No exclusion row retired, none added — `eventsource/` is not vendored (its suites are `.window.js` documents against a wptserve `.py` stream handler, which is a corpus question rather than an observer one), so the pin is the unit suite above.

Docs moved with it: `docs/v5-migration.md` §4.123 in the shape §4.119 set for the same surface, the `EventSource` section of `README.md`, the "absent for now" row (which named both lanes and now names the socket and `eventSourceMessageReceived`), `Jint/WebApi/Fetch/AGENTS.md` where the refusal was recorded, and `Jint.Browser/DevTools/AGENTS.md`.

## What was left out

`Network.eventSourceMessageReceived` — what an observer is handed is the stream's bytes, not the events they decode into, and putting the parsed messages on the observer would make it a protocol rather than a transport seam. The socket lane, as argued above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
