### PR TITLE
WptServer takes its overlays as a path-to-source map, so a third one is an entry rather than a parameter

### DIFF
--- a/Jint.Tests.Browser/Wpt/WptBrowserHarness.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserHarness.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -104,7 +104,7 @@ internal sealed class WptBrowserHarness : IDisposable
 
     private WptBrowserHarness()
     {
-        _server = new WptServer(HarnessReportOverlay, TestDriverVendorOverlay);
+        _server = new WptServer(Overlays);
 
         var options = new BrowserOptions
         {
@@ -292,15 +292,20 @@ internal sealed class WptBrowserHarness : IDisposable
     }
 
     /// <summary>
-    /// The lane's <c>testharnessreport.js</c>, embedded so the check reads the bytes the build compiled.
+    /// What this lane answers upstream's vendor slots with, keyed by the path the server serves each at.
     /// </summary>
-    private static string HarnessReportOverlay { get; } = ReadOverlay("testharnessreport.js");
-
-    /// <summary>
-    /// The lane's <c>testdriver-vendor.js</c> — the second slot upstream ships for a vendor to fill, and what
-    /// turns a document that drives input through <c>test_driver</c> into one that reports.
-    /// </summary>
-    private static string TestDriverVendorOverlay { get; } = ReadOverlay("testdriver-vendor.js");
+    /// <remarks>
+    /// Both are embedded rather than read from the tree, so the server sends the bytes the build compiled;
+    /// and both are entries in one map rather than parameters, so a third slot is a line here and nothing
+    /// else. <c>testharnessreport.js</c> is the script that posts a page's results back to the driver, and
+    /// <c>testdriver-vendor.js</c> is what turns a document that drives input through <c>test_driver</c>
+    /// into one that reports.
+    /// </remarks>
+    private static Dictionary<string, string> Overlays { get; } = new(StringComparer.Ordinal)
+    {
+        ["resources/testharnessreport.js"] = ReadOverlay("testharnessreport.js"),
+        ["resources/testdriver-vendor.js"] = ReadOverlay("testdriver-vendor.js"),
+    };
 
     private static string ReadOverlay(string name)
     {

--- a/Jint.Tests/Wpt/WptServer.cs
+++ b/Jint.Tests/Wpt/WptServer.cs
@@ -1,4 +1,4 @@
-#if NET8_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 #nullable enable
 
 using System.Collections.Concurrent;
@@ -75,42 +75,43 @@ internal sealed class WptServer : IDisposable
     private readonly ConcurrentDictionary<string, int> _stash = new(StringComparer.Ordinal);
 
     /// <summary>
-    /// What <c>/resources/testharnessreport.js</c> answers with. It is Jint's own file rather than a
-    /// vendored one — see <c>Prelude/testharnessreport.js</c> for why — and it is a constructor parameter so
-    /// that the browser lane can overlay it per server without a vendored file changing.
-    /// </summary>
-    private readonly string _harnessReport;
-
-    /// <summary>
-    /// What <c>/resources/testdriver-vendor.js</c> answers with, or <see langword="null"/> for the vendored
-    /// file — which is upstream's, and is empty.
+    /// What this server answers a path with instead of the corpus, keyed by the path exactly as a request
+    /// names it — <c>resources/testharnessreport.js</c>, with no leading slash — and empty for the shared
+    /// instance.
     /// </summary>
     /// <remarks>
-    /// The second slot upstream ships for a vendor to fill: <c>testdriver.js</c> declares every automation
-    /// call as a member of <c>window.test_driver_internal</c> that throws "not implemented by
-    /// testdriver-vendor.js", and this file is where an implementation replaces them. Unlike
-    /// <c>testharnessreport.js</c> the stub <i>is</i> vendored, because it is a real (empty) file in the tree
-    /// rather than one whose whole content is a placeholder, so the default here is to serve it.
+    /// One dictionary rather than a parameter per slot, because the slots are upstream's and there are more
+    /// of them than this lane has filled: <c>testharnessreport.js</c> and <c>testdriver-vendor.js</c> today,
+    /// and whatever the next suite wants a vendor implementation of. A parameter per slot makes each new one
+    /// a signature change that reaches every caller, and leaves adjacent <c>string?</c> parameters that can
+    /// be passed in the wrong order without a compiler noticing.
     /// </remarks>
-    private readonly string? _testDriverVendor;
+    private readonly Dictionary<string, string> _overlays;
 
     /// <summary>
     /// Starts a server on an ephemeral loopback port.
     /// </summary>
-    /// <param name="harnessReportOverlay">
-    /// What to answer <c>/resources/testharnessreport.js</c> with, or <see langword="null"/> for the stub in
-    /// <c>Prelude/</c>. The browser lane passes the script that posts a page's results back to its driver;
-    /// upstream's own file exists to be replaced exactly this way.
+    /// <param name="overlays">
+    /// What to answer named paths with instead of the corpus, or <see langword="null"/> for none. Every
+    /// value is served as a script, because what a caller overlays is one of the slots upstream ships for a
+    /// vendor to fill: <c>resources/testharnessreport.js</c>, whose vendored form is a placeholder and whose
+    /// default here is Jint's own copy in <c>Prelude/</c>, and <c>resources/testdriver-vendor.js</c>, whose
+    /// vendored form is a real and empty file. The browser lane fills both — the script that posts a page's
+    /// results back to its driver, and the one that maps <c>test_driver</c> onto the same dispatcher the
+    /// <c>Input</c> domain reaches.
     /// </param>
-    /// <param name="testDriverVendorOverlay">
-    /// What to answer <c>/resources/testdriver-vendor.js</c> with, or <see langword="null"/> for the vendored
-    /// empty file. The browser lane passes the script that maps <c>test_driver</c> onto the same dispatcher
-    /// the <c>Input</c> domain reaches.
-    /// </param>
-    internal WptServer(string? harnessReportOverlay = null, string? testDriverVendorOverlay = null)
+    internal WptServer(IReadOnlyDictionary<string, string>? overlays = null)
     {
-        _harnessReport = harnessReportOverlay ?? WptCorpus.HarnessReport;
-        _testDriverVendor = testDriverVendorOverlay;
+        _overlays = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        if (overlays is not null)
+        {
+            foreach (var overlay in overlays)
+            {
+                _overlays[overlay.Key] = overlay.Value;
+            }
+        }
+
         _listener = new TcpListener(IPAddress.Loopback, 0);
         _listener.Start();
         Port = ((IPEndPoint) _listener.LocalEndpoint).Port;
@@ -224,7 +225,19 @@ internal sealed class WptServer : IDisposable
         }
     }
 
-    private Task RespondAsync(Stream stream, WptServerRequest request, CancellationToken token) => request.Path switch
+    private Task RespondAsync(Stream stream, WptServerRequest request, CancellationToken token)
+    {
+        // An overlay answers before the corpus and before every handler below, which is what makes a third
+        // one a dictionary entry rather than a case here and a parameter on the constructor.
+        if (_overlays.TryGetValue(request.Path, out var overlay))
+        {
+            return WriteAsync(stream, Script(overlay), request, token);
+        }
+
+        return Dispatch(stream, request, token);
+    }
+
+    private Task Dispatch(Stream stream, WptServerRequest request, CancellationToken token) => request.Path switch
     {
         // wptserve answers the root with a directory listing. Nothing reads what is in it; what
         // xhr/responsetype.any.js reads is that a GET of "/" has a body at all, which is what its
@@ -254,28 +267,18 @@ internal sealed class WptServer : IDisposable
         // absolute path, and upstream keeps the same handler in both places.
         "fetch/api/resources/bad-chunk-encoding.py" => BadChunkEncoding(stream, request, token),
 
-        // The one harness file that does not come out of Vendor/. Upstream's is a stub whose whole purpose
-        // is to be replaced by whoever is running the tests, so vendoring it would put bytes in the tree
-        // that the server never sends; Jint's copy lives in Prelude/ beside the shim, and a caller can pass
-        // an overlay per server. Answered here rather than in the static path because there is no corpus
-        // entry to find.
-        "resources/testharnessreport.js" => WriteAsync(stream, HarnessReport(), request, token),
-
-        // The other vendor slot. Upstream's file is vendored and is empty, so unlike the one above this
-        // falls through to the corpus when no overlay was passed — a caller that supplies none gets
+        // The one harness file that does not come out of Vendor/, and so the one slot with a default of its
+        // own: upstream's is a stub whose whole purpose is to be replaced by whoever is running the tests,
+        // so vendoring it would put bytes in the tree the server never sends, and Jint's copy lives in
+        // Prelude/ beside the shim. Answered here rather than in the static path because there is no corpus
+        // entry to find. The other vendor slot needs no case at all — upstream's testdriver-vendor.js is
+        // vendored and is empty, so with no overlay it falls through to the corpus and a suite gets
         // testdriver.js's own "not implemented by testdriver-vendor.js" rejections, which is what a driver
         // with no automation should get.
-        "resources/testdriver-vendor.js" when _testDriverVendor is not null
-            => WriteAsync(stream, Script(_testDriverVendor), request, token),
+        "resources/testharnessreport.js" => WriteAsync(stream, Script(WptCorpus.HarnessReport), request, token),
 
         _ => StaticAsync(stream, request, token),
     };
-
-    /// <summary>
-    /// <c>resources/testharnessreport.js</c>, with the content type upstream's own
-    /// <c>testharnessreport.js.headers</c> sidecar gives it.
-    /// </summary>
-    private WptServerResponse HarnessReport() => Script(_harnessReport);
 
     /// <summary>One overlay script, with the content type upstream's <c>.headers</c> sidecars give it.</summary>
     private static WptServerResponse Script(string source)

--- a/Jint.Tests/Wpt/WptServerTests.cs
+++ b/Jint.Tests/Wpt/WptServerTests.cs
@@ -1,4 +1,4 @@
-#if NET8_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 #nullable enable
 
 using System.Globalization;
@@ -930,8 +930,8 @@ public class WptServerTests
     /// Upstream's file is a stub that exists to be replaced — "intended for vendors to implement code needed
     /// to integrate testharness.js tests with their own test systems" — so vendoring it would put bytes in
     /// the tree the server never sends. The overlay is the slot the browser lane fills with the script that
-    /// posts a page's results back to the driver; nothing supplies one yet, which is why this test starts
-    /// its own server.
+    /// posts a page's results back to the driver; the shared server here supplies none, which is why this
+    /// test starts one of its own.
     /// </remarks>
     [Test]
     public async Task TheHarnessReportComesFromThePreludeAndCanBeOverlaid()
@@ -946,13 +946,62 @@ public class WptServerTests
         WptCorpus.HarnessReport.Should().Contain("Jint's `resources/testharnessreport.js`");
         WptCorpus.Contains("resources/testharnessreport.js").Should().BeFalse();
 
-        using var overlaid = new WptServer("window.__jintReport = true;");
+        using var overlaid = new WptServer(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["resources/testharnessreport.js"] = "window.__jintReport = true;",
+        });
+
         using var fromOverlay = await _client.GetAsync(overlaid.Origin + "/resources/testharnessreport.js");
         (await fromOverlay.Content.ReadAsStringAsync()).Should().Be("window.__jintReport = true;");
 
         // And the overlay is per server: the shared one is untouched.
         using var again = await GetAsync("/resources/testharnessreport.js");
         (await again.Content.ReadAsStringAsync()).Should().Be(WptCorpus.HarnessReport);
+    }
+
+    /// <summary>
+    /// An overlay is a path and a source, so a slot the constructor has never heard of is answered too — and
+    /// it wins over the vendored file at the same path.
+    /// </summary>
+    /// <remarks>
+    /// Upstream ships more than one file for a vendor to fill, and this lane has filled two of them. Both
+    /// were constructor parameters, so the third was going to be a third <c>string?</c> beside two others of
+    /// the same type that nothing but their order distinguishes. <c>testdriver-vendor.js</c> is the case
+    /// worth asserting, because unlike <c>testharnessreport.js</c> it really is in the corpus: the answer
+    /// with no overlay is upstream's empty file, and the answer with one is the overlay rather than a merge
+    /// or a 404.
+    /// </remarks>
+    [Test]
+    public async Task AnOverlayAnswersAnyPathItNames()
+    {
+        // With no overlay, both vendor slots answer what they answered before: the prelude's report file,
+        // and the vendored (empty) testdriver-vendor.js.
+        using var vendored = await GetAsync("/resources/testdriver-vendor.js");
+        ((int) vendored.StatusCode).Should().Be(200);
+        (await vendored.Content.ReadAsStringAsync()).Should().BeEmpty();
+        WptCorpus.Contains("resources/testdriver-vendor.js").Should().BeTrue("upstream vendors an empty stub");
+
+        using var overlaid = new WptServer(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["resources/testdriver-vendor.js"] = "window.__jintDriver = true;",
+            ["common/get-host-info.sub.js"] = "window.__jintHostInfo = true;",
+        });
+
+        // The slot that has a vendored file behind it: the overlay wins.
+        using var driver = await _client.GetAsync(overlaid.Origin + "/resources/testdriver-vendor.js");
+        ((int) driver.StatusCode).Should().Be(200);
+        driver.Content.Headers.ContentType!.ToString().Should().Be("text/javascript; charset=utf-8");
+        (await driver.Content.ReadAsStringAsync()).Should().Be("window.__jintDriver = true;");
+
+        // And a path no version of this server has ever special-cased, which is the whole point: a third
+        // overlay is an entry in the map and nothing else.
+        using var hostInfo = await _client.GetAsync(overlaid.Origin + "/common/get-host-info.sub.js");
+        ((int) hostInfo.StatusCode).Should().Be(200);
+        (await hostInfo.Content.ReadAsStringAsync()).Should().Be("window.__jintHostInfo = true;");
+
+        // The one it was not given still comes from the prelude.
+        using var report = await _client.GetAsync(overlaid.Origin + "/resources/testharnessreport.js");
+        (await report.Content.ReadAsStringAsync()).Should().Be(WptCorpus.HarnessReport);
     }
 
     /// <summary>


### PR DESCRIPTION
`WptServer` took the two files upstream ships for a vendor to fill — `resources/testharnessreport.js` and
`resources/testdriver-vendor.js` — as two `string?` constructor parameters, with a case each in the dispatch
switch and a `when` clause on one of them. That shape costs twice: a third slot is a signature change that
reaches every caller and a third case, and two adjacent nullable strings that nothing but their order tells
apart is a call site that compiles when it is wrong.

## What changed

- The constructor takes one `IReadOnlyDictionary<string, string>?` keyed by the path a request names
  (`resources/testharnessreport.js`, no leading slash), and the lookup happens once in `RespondAsync`,
  before the corpus and before every handler.
- `testharnessreport.js` keeps its case, because it is the one slot with a default of its own — upstream's
  is a placeholder that would put bytes in the tree the server never sends, so Jint's copy lives in
  `Prelude/`. `testdriver-vendor.js` needs no case at all now: upstream's is a real and empty vendored file,
  and no overlay falls through to it, which is exactly what a driver with no automation should get.
- `WptBrowserHarness` builds the map where it already read the two embedded scripts, so a third overlay for
  the browser lane is one more line there too.

This is the lane's **server and overlay wiring only** — no exclusion table, census or corpus file is
touched, so it should not collide with the `dom/nodes` vendoring in flight.

## Tests

`WptServerTests.AnOverlayAnswersAnyPathItNames` is new, and it asserts what the old shape could not express:
an overlay on `common/get-host-info.sub.js` — a path no version of this server has special-cased, which
*is* vendored and which the template pipeline would otherwise substitute — is answered with the overlay,
while the slot the map does not name still comes from the prelude. With the overlay lookup disabled it
fails, together with `TheHarnessReportComesFromThePreludeAndCanBeOverlaid`.

- `dotnet test Jint.Tests -c Release -f net10.0 --filter "…WebApi|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests|Wpt"` — 3,546 passed
- `dotnet test Jint.Tests.Browser -c Release` — 1,200 (net8.0) and 1,203 (net10.0) passed

Part of #3706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
