### PR TITLE
A page tells its watcher the document is parsed and hands over the runtime, so the DOM bridge arms in one step

### DIFF
--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -24,7 +24,9 @@ target/runtime split and the manifest are there and none of it is repeated here.
   one of its calls turned into a protocol event. `DocumentCreated` runs after the window installer and
   before the parse, on the loop, which is what makes it the place to replace the engine, re-install the
   bindings and run `addScriptToEvaluateOnNewDocument` — all of which have to be in place before the
-  document's first inline script.
+  document's first inline script. `DocumentParsed` is the commit, with the runtime: it is the first moment
+  there is a tree, so it is where anything that watches a document arms itself, and why the mutation bridge
+  needs no field remembering an engine from before the parse.
 - **Every command runs on the page loop**, so it may touch the DOM directly — and one that waits
   (`Page.navigate`) waits by `await`ing, never by blocking: the loop it is on runs the commit it waits for.
 - **`DOM` and `Input` are where a client stops evaluating and starts driving.** A node reaches a client as a

--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Jint.Browser.Runtime;
 using Jint.DevTools;
 using Jint.DevTools.Domains;
@@ -35,7 +35,6 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     private readonly Action<PageTarget>? _closed;
 
     private PageDomain[] _domains = [];
-    private PageRuntime? _runtime;
 
     private PageTarget(Page page, string? browserContextId, bool waitForDebuggerOnStart, Action<PageTarget>? closed)
         : base(
@@ -241,7 +240,6 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
 
         // Before the swap, because the swap is what tells every DOM domain to announce documentUpdated and a
         // client that acted on it must find the identifiers already gone rather than resolving one more time.
-        _runtime = runtime;
         Nodes.DocumentReplaced();
 
         Replace(runtime.Engine);
@@ -249,15 +247,15 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// The first moment the document exists and the parse is over, which is when a client's view of the tree
+    /// can start being kept current. Idempotent, and a no-op while nobody has enabled the <c>DOM</c> domain.
+    /// </remarks>
+    void IPageObserver.DocumentParsed(PageRuntime runtime, string loaderId) => Nodes.Watch(runtime);
+
+    /// <inheritdoc/>
     void IPageObserver.Phase(NavigationPhase phase, string loaderId)
     {
-        if (phase == NavigationPhase.Committed && _runtime is { } runtime)
-        {
-            // The first moment the document exists and the parse is over, which is when a client's view of
-            // the tree can start being kept current. Idempotent, and a no-op while nobody has enabled DOM.
-            Nodes.Watch(runtime);
-        }
-
         foreach (var domain in Snapshot())
         {
             domain.Phase(phase, loaderId);

--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -1,4 +1,4 @@
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Text;
 using AngleSharp.Html.Dom;
 using Jint.Browser.Runtime;
@@ -747,6 +747,14 @@ public sealed partial class Page
         if (_observer is not { } observer)
         {
             return;
+        }
+
+        // Before the phase, because the phase is what a watcher forwards to a client and the tree has to be
+        // observable by the time one can act on it. The commit is the one point where the runtime is worth
+        // carrying: the other two are reported after a listener of this document could have navigated away.
+        if (phase == NavigationPhase.Committed)
+        {
+            observer.DocumentParsed(runtime, loaderId);
         }
 
         observer.Phase(phase, loaderId);

--- a/Jint.Browser/Runtime/IPageObserver.cs
+++ b/Jint.Browser/Runtime/IPageObserver.cs
@@ -1,4 +1,4 @@
-namespace Jint.Browser.Runtime;
+﻿namespace Jint.Browser.Runtime;
 
 /// <summary>
 /// What one watcher of a page is told, in the order a page does it.
@@ -43,6 +43,30 @@ internal interface IPageObserver
     /// <param name="runtime">The page runtime of the new engine.</param>
     /// <param name="loaderId">The identifier this document carries.</param>
     void DocumentCreated(PageRuntime runtime, string loaderId)
+    {
+    }
+
+    /// <summary>
+    /// The document exists and is parsed, and this is the runtime it belongs to.
+    /// </summary>
+    /// <param name="runtime">The page runtime of the parsed document.</param>
+    /// <param name="loaderId">The identifier this document carries.</param>
+    /// <remarks>
+    /// <para>
+    /// Raised immediately before <see cref="Phase"/> with <see cref="NavigationPhase.Committed"/>, which is
+    /// the same moment: what it adds is the runtime, which <see cref="Phase"/> cannot carry because the other
+    /// two phases are reported after a document may already have navigated away.
+    /// </para>
+    /// <para>
+    /// This is the first point at which a watcher can look at the tree, so it is where anything that observes
+    /// a document arms itself. The alternative is to remember the runtime from
+    /// <see cref="DocumentCreated"/> — which fires before the parse, when there is nothing to observe — and
+    /// then act on a phase; that is two steps and one field for one event, and the field is a second answer
+    /// to "which document is showing" that can disagree with the page's.
+    /// </para>
+    /// <para>Runs on the page loop thread, with the parsed document's engine.</para>
+    /// </remarks>
+    void DocumentParsed(PageRuntime runtime, string loaderId)
     {
     }
 

--- a/Jint.Tests.Browser/DevTools/DomDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/DomDomainTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Jint.Browser;
 
 namespace Jint.Tests.Browser.DevTools;
@@ -167,6 +167,37 @@ public class DomDomainTests
 
         (await session.EventAsync("DOM.childNodeRemoved", sessionId: attachment))
             .GetProperty("parentNodeId").GetInt32().Should().Be(inserted.GetProperty("parentNodeId").GetInt32());
+    }
+
+    /// <summary>
+    /// A client that enabled the domain before a document committed hears that document's mutations.
+    /// </summary>
+    /// <remarks>
+    /// The mutation bridge is armed per document, because a commit throws the previous document's observer
+    /// away with its node identifiers; the arming happens on the page's <c>DocumentParsed</c> call, the first
+    /// moment there is a tree to observe. Every other test here enables the domain after the content is in
+    /// place, which is the path <c>DOM.enable</c> arms for itself — this is the other order, and nothing
+    /// covered it.
+    /// </remarks>
+    [Test]
+    public async Task MutationsOfADocumentCommittedAfterEnableStillReachTheClient()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await session.OpenPageAsync();
+
+        // Enabled first, and only then does a document commit under it.
+        await session.ResultAsync("DOM.enable", "{}", attachment);
+        await Content(session, attachment, "<ul id='list'><li id='first'>one</li></ul>");
+
+        // The client walks the tree, so the list is a node it has been sent.
+        await session.ResultAsync("DOM.getDocument", """{"depth":-1}""", attachment);
+
+        await session.EvaluateAsync(
+            "document.getElementById('list').appendChild(document.createElement('li')) && true",
+            attachment);
+
+        var inserted = await session.EventAsync("DOM.childNodeInserted", sessionId: attachment);
+        inserted.GetProperty("node").GetProperty("nodeName").GetString().Should().Be("LI");
     }
 
     [Test]

--- a/Jint.Tests.Browser/Runtime/PageObserverTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageObserverTests.cs
@@ -1,0 +1,99 @@
+using AngleSharp.Dom;
+using Jint.Browser;
+using Jint.Browser.Runtime;
+
+namespace Jint.Tests.Browser.Runtime;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// What a page tells its one watcher, and when — the seam the whole protocol layer hangs off.
+/// </summary>
+public sealed class PageObserverTests
+{
+    /// <summary>
+    /// <c>DocumentParsed</c> hands a watcher the runtime of a document it can actually look at, and it
+    /// arrives before the commit phase that watcher forwards to a client.
+    /// </summary>
+    /// <remarks>
+    /// <c>DocumentCreated</c> fires before the parse, when there is no tree, and <c>Phase</c> carries no
+    /// runtime — so anything that wants to observe a document had to remember the runtime from the first and
+    /// act on the second, which is a field that is a second answer to "which document is showing". The order
+    /// asserted here is what makes the one call enough: parsed, then committed.
+    /// </remarks>
+    [Test]
+    public async Task DocumentParsedCarriesTheParsedDocumentAndComesBeforeTheCommitPhase()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        var recorder = new Recorder();
+
+        // Registered on the loop, the way a protocol target registers itself, so no commit can slip between
+        // taking the page and watching it.
+        await page.RunOnLoopAsync(_ =>
+        {
+            page.Observe(recorder);
+            return true;
+        });
+
+        await page.SetContentAsync("<p id='greeting'>hello</p>");
+
+        recorder.Calls.Should().ContainInOrder("DocumentCreated", "DocumentParsed", "Phase(Committed)");
+        recorder.Calls.Count(call => string.Equals(call, "DocumentParsed", StringComparison.Ordinal))
+            .Should().Be(1, "one document is parsed once");
+
+        // The runtime it carries is the document's, and the document is parsed: the element the markup
+        // declares is there, where at DocumentCreated there was no document at all.
+        recorder.CreatedGreeting.Should().BeNull("nothing of the document has been parsed yet");
+        recorder.ParsedGreeting.Should().Be("hello");
+
+        recorder.ParsedLoaderId.Should().Be(recorder.CreatedLoaderId, "it is the same document");
+        recorder.ParsedLoaderId.Should().Be(recorder.CommittedLoaderId);
+    }
+
+    /// <summary>Records what it is told, on the loop it is told it on.</summary>
+    private sealed class Recorder : IPageObserver
+    {
+        internal List<string> Calls { get; } = [];
+
+        internal string? CreatedGreeting { get; private set; }
+
+        internal string? ParsedGreeting { get; private set; }
+
+        internal string? CreatedLoaderId { get; private set; }
+
+        internal string? ParsedLoaderId { get; private set; }
+
+        internal string? CommittedLoaderId { get; private set; }
+
+        public void DocumentCreated(PageRuntime runtime, string loaderId)
+        {
+            Calls.Add("DocumentCreated");
+            CreatedLoaderId = loaderId;
+            CreatedGreeting = Greeting(runtime);
+        }
+
+        public void DocumentParsed(PageRuntime runtime, string loaderId)
+        {
+            Calls.Add("DocumentParsed");
+            ParsedLoaderId = loaderId;
+            ParsedGreeting = Greeting(runtime);
+        }
+
+        public void Phase(NavigationPhase phase, string loaderId)
+        {
+            Calls.Add("Phase(" + phase + ")");
+
+            if (phase == NavigationPhase.Committed)
+            {
+                CommittedLoaderId = loaderId;
+            }
+        }
+
+        private static string? Greeting(PageRuntime runtime)
+            => runtime.Document?.QuerySelector("#greeting")?.TextContent;
+    }
+}


### PR DESCRIPTION
`IPageObserver` had no call that said "there is a tree now, and here is the engine it belongs to".
`DocumentCreated` fires before the parse, when there is nothing to observe, and `Phase` carries no runtime —
so the `DOM` domain's mutation bridge did it in two steps: remember the runtime in `DocumentCreated`, arm on
`Phase(Committed)`. That field was a second answer to "which document is showing", one that could disagree
with the target's own (every domain reads `_target.Runtime` per command), and nothing but the arming read it.

## What changed

- `IPageObserver.DocumentParsed(PageRuntime runtime, string loaderId)`, raised immediately before
  `Phase(NavigationPhase.Committed)` — which is the same moment; `Page.Navigation.cs`'s `Reached` already
  has the runtime in hand at every phase, so the seam costs nothing to add. Before the phase, because the
  phase is what a watcher forwards to a client and the tree has to be observable by the time one acts on it.
- The commit is the only phase worth carrying a runtime on: the other two are reported after a listener of
  this document could have navigated away.
- `PageTarget` implements it in one line, and its `_runtime` field is deleted — it had become write-only.

## Tests

- `Jint.Tests.Browser/Runtime/PageObserverTests.cs` (new): the order is `DocumentCreated`, `DocumentParsed`,
  `Phase(Committed)`; the runtime handed over is a document that is **parsed** — the element the markup
  declares is there, where at `DocumentCreated` there is no document at all — and all three calls carry one
  `loaderId`.
- `DomDomainTests.MutationsOfADocumentCommittedAfterEnableStillReachTheClient` (new): the order nothing
  covered — a client that enables `DOM` *before* a document commits still hears that document's mutations.
  With the arming dropped it fails and the rest of the domain's tests stay green, which is what it is for.

- `dotnet test Jint.Tests.Browser -c Release` — 1,202 (net8.0) and 1,205 (net10.0) passed
- `dotnet test Jint.Tests.DevTools -c Release` — 393 and 395 passed
- `dotnet test Jint.Tests -c Release -f net10.0 --filter "…WebApi|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests"` — 2,871 passed

Nothing public moves — `IPageObserver` is internal — so there is no `docs/v5-migration.md` row.

Part of #3698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
