### PR TITLE
An attachment observes the domains its target added, so registration and release are the same list

### DIFF
--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -175,20 +175,15 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
             .Register(jint);
 
         AddDomain(page);
-
-        // The DOM domain hears about the engine being replaced under the target the way the built-in five do,
-        // and is unobserved again with them when the attachment detaches.
-        Observe(dom);
         Nodes.Add(dom);
 
-        return domains with
-        {
-            Extra =
-            [
-                page, dom, input, emulation, network, fetch, storage, performance, audits, accessibility, css,
-                security, overlay, jint,
-            ],
-        };
+        // Every one of these that listens -- the DOM domain hears about the engine being replaced under the
+        // target the way the built-in five do -- is observed by `With` and unobserved again by `Detach`.
+        return domains.With(
+        [
+            page, dom, input, emulation, network, fetch, storage, performance, audits, accessibility, css,
+            security, overlay, jint,
+        ]);
     }
 
     /// <inheritdoc/>

--- a/Jint.DevTools/Domains/BuiltInDomains.cs
+++ b/Jint.DevTools/Domains/BuiltInDomains.cs
@@ -1,4 +1,4 @@
-using Jint.DevTools.Protocol.Browser;
+﻿using Jint.DevTools.Protocol.Browser;
 using Jint.DevTools.Session;
 
 namespace Jint.DevTools.Domains;
@@ -132,9 +132,37 @@ internal readonly record struct TargetDomains(
     /// <summary>Gets whatever the target registered next to the built-in five, or <see langword="null"/>.</summary>
     /// <remarks>
     /// Every one of them is observed and released with the rest; the property exists so that a target's own
-    /// domains are part of the attachment rather than a second lifetime nothing tracks.
+    /// domains are part of the attachment rather than a second lifetime nothing tracks. It is set through
+    /// <see cref="With"/> and nowhere else, which is what makes registration and release symmetric.
     /// </remarks>
-    internal IReadOnlyList<DevToolsDomain>? Extra { get; init; }
+    internal IReadOnlyList<DevToolsDomain>? Extra { get; private init; }
+
+    /// <summary>
+    /// The same attachment with the domains a target registered beside the built-in five, each of them now
+    /// observing the target if it listens.
+    /// </summary>
+    /// <param name="extra">The target's own domains.</param>
+    /// <remarks>
+    /// <b>The observing belongs here because the unobserving does.</b> <see cref="Detach"/> walks
+    /// <see cref="Extra"/> and unobserves every <see cref="ITargetObserver"/> among them without being told
+    /// which; if registration does not do the mirror image, a target has to remember to call
+    /// <see cref="DevToolsTarget.Observe"/> by hand for each one, and the one it forgets is a domain that
+    /// hears nothing about the engine being replaced under it and is released anyway. Setting
+    /// <see cref="Extra"/> is private for the same reason: there is no way to build an attachment whose
+    /// domains are released but were never registered.
+    /// </remarks>
+    internal TargetDomains With(IReadOnlyList<DevToolsDomain> extra)
+    {
+        foreach (var domain in extra)
+        {
+            if (domain is ITargetObserver observer)
+            {
+                Target.Observe(observer);
+            }
+        }
+
+        return this with { Extra = extra };
+    }
 
     /// <summary>Releases everything this attachment holds of its target, and stops it hearing anything.</summary>
     /// <remarks>

--- a/Jint.Tests.Browser/DevTools/PageTargetDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/PageTargetDomainTests.cs
@@ -1,0 +1,61 @@
+using Jint.Browser.DevTools;
+using Jint.DevTools;
+using Jint.DevTools.Domains;
+using Jint.DevTools.Transport;
+
+namespace Jint.Tests.Browser.DevTools;
+
+/// <summary>
+/// What an attachment to a page target registers, and what it gives back again.
+/// </summary>
+public class PageTargetDomainTests
+{
+    /// <summary>
+    /// Every page-level domain that listens to its target is observing it after registration, and none of
+    /// them is after the attachment detaches.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The two halves used to be written in different places. <c>TargetDomains.Detach</c> walks the extra
+    /// domains and unobserves every <c>ITargetObserver</c> among them without being told which, while
+    /// registration observed nothing — so <c>PageTarget.RegisterDomains</c> called <c>Observe</c> by hand for
+    /// the one domain that needed it. A second one added without that line is released without ever having
+    /// been registered, and what it silently stops hearing is the engine being replaced under it, which is
+    /// the one thing a page-level domain most needs to know.
+    /// </para>
+    /// <para>
+    /// The set is taken from the registration rather than named here, so a page-level domain that starts
+    /// listening is covered the day it does.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task EveryExtraDomainThatListensIsObservedByRegistrationAndReleasedByDetach()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        var target = await PageTarget.CreateAsync(page, browserContextId: null);
+
+        var server = new DevToolsServer();
+        server.AddTarget(target);
+
+        var client = server.OpenBrowserSession(new InProcessConnection());
+        var attachment = client.Session.CreateChild("S1");
+
+        var domains = target.RegisterDomains(attachment, client);
+
+        var listeners = domains.Extra!.OfType<ITargetObserver>().ToArray();
+        listeners.Should().NotBeEmpty("at least one page-level domain hears about the engine being replaced");
+
+        foreach (var listener in listeners)
+        {
+            target.Observers.Should().Contain(listener, "registration is what observes a domain that listens");
+        }
+
+        domains.Detach();
+
+        foreach (var listener in listeners)
+        {
+            target.Observers.Should().NotContain(listener, "detaching gives back exactly what registering took");
+        }
+    }
+}


### PR DESCRIPTION
`TargetDomains.Detach` walks `Extra` and unobserves every `ITargetObserver` among them without being told
which of them listens. Registration did no such thing, so `PageTarget.RegisterDomains` called `Observe` by
hand for the one page-level domain that needs it. The next domain added without that line is one the
attachment releases although it was never registered, and what it silently never hears is the engine being
replaced under it — for a page-level domain, the one thing it most needs to know — with no compiler error
and no failing test.

## What changed

- `TargetDomains.With(IReadOnlyList<DevToolsDomain> extra)` observes every listener among them and returns
  the attachment with `Extra` set. `Extra`'s `init` accessor is now `private`, so there is no way to build
  an attachment whose domains are released but were never registered.
- `PageTarget.RegisterDomains` drops the hand-written `Observe(dom)` and returns `domains.With([…])`.

## Tests

`Jint.Tests.Browser/DevTools/PageTargetDomainTests.cs` (new) pins it from the page side, and takes the set
from the registration rather than naming it, so a page-level domain that starts listening is covered the day
it does: every extra domain that is an `ITargetObserver` is observing the target after `RegisterDomains`,
and none of them is after `Detach`.

Run against the change with the observing removed from `With`, it fails — and so does the existing
`DomDomainTests.ANavigationClearsEveryNodeIdAndSaysSo`, which is the behaviour the hand-written line was
holding up.

- `dotnet test Jint.Tests.Browser -c Release` — 1,201 (net8.0) and 1,204 (net10.0) passed
- `dotnet test Jint.Tests.DevTools -c Release` — 393 and 395 passed
- `dotnet test Jint.Tests -c Release -f net10.0 --filter "…WebApi|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests"` — 2,871 passed

Everything moved is internal, so there is no `docs/v5-migration.md` row.

Part of #3698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
