### PR TITLE
Intl: BestAvailableLocale resolves a CultureInfo only when the available-locale set cannot answer

### DIFF
--- a/Jint.Tests/Runtime/IntlCultureCacheTests.cs
+++ b/Jint.Tests/Runtime/IntlCultureCacheTests.cs
@@ -43,6 +43,113 @@ public class IntlCultureCacheTests
     }
 
     /// <summary>
+    /// The <c>supportedLocalesOf</c> sweep <c>intl402</c> performs must not resolve a culture per candidate
+    /// prefix of every tag it asks about.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see href="https://github.com/sebastienros/jint/issues/3609">#3609</see>:
+    /// <c>intl402/supportedLocalesOf-unicode-extensions-ignored.js</c> asks every <c>Intl</c> constructor
+    /// about 640 generated tags with two matchers, three <c>supportedLocalesOf</c> calls each, and took two
+    /// seconds alone and thirty under a saturated build — a wall-clock timeout on work that had not changed.
+    /// <c>BestAvailableLocale</c> was resolving a <see cref="System.Globalization.CultureInfo"/> for every
+    /// candidate it tried, which is about 15 µs behind a cache bounded, on purpose, well below the number of
+    /// distinct tags such a sweep invents. Seventy thousand lookups, of which sixty-four thousand were that
+    /// probe, and it decided the answer in 0.8% of them.
+    /// </para>
+    /// <para>
+    /// <b>A count and not a duration</b>, which is the point: the defect only ever showed itself as a
+    /// timeout, so a timing test would be the same measurement that could not tell a regression from a busy
+    /// machine. The bound is one lookup per <c>supportedLocalesOf</c> call. This sweep makes <i>none at
+    /// all</i> now — every one of its tags is answered by the available-locale set, bare or truncated — and
+    /// made 6,913 before, so the bound has two orders of magnitude of room and still fails the moment the
+    /// per-candidate resolution comes back.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void ASupportedLocalesOfSweepDoesNotResolveACultureForEveryCandidate()
+    {
+        const int Tags = 640;
+        const int CallsPerTag = 3;
+
+        var engine = new Engine();
+
+        // Warm: the first pass resolves what it has to, and the assertion is about the sweep rather than
+        // about which tags this process had already seen.
+        engine.Execute(Sweep);
+
+        var before = IntlUtilities.CultureLookupCount;
+        engine.Execute(Sweep);
+        var lookups = IntlUtilities.CultureLookupCount - before;
+
+        lookups.Should().BeLessThan(
+            Tags * CallsPerTag,
+            "a sweep of {0} tags asking {1} times each must not resolve a culture per call, let alone per "
+            + "candidate prefix of one",
+            Tags,
+            CallsPerTag);
+    }
+
+    /// <summary>
+    /// The sweep from <c>intl402/supportedLocalesOf-unicode-extensions-ignored.js</c>, one constructor and
+    /// one matcher: the 640 generated tags, each asked about bare, with a valid Unicode extension sequence
+    /// and with an invalid one.
+    /// </summary>
+    private const string Sweep = """
+        var languages = ["zh", "es", "en", "hi", "ur", "ar", "ja", "pa"];
+        var scripts = ["Latn", "Hans", "Deva", "Arab", "Jpan", "Hant", "Guru"];
+        var countries = ["CN", "IN", "US", "PK", "JP", "TW", "HK", "SG", "419"];
+
+        var allTags = [];
+        for (var i = 0; i < languages.length; i++) {
+          var language = languages[i];
+          allTags.push(language);
+          for (var j = 0; j < scripts.length; j++) {
+            var script = scripts[j];
+            allTags.push(language + "-" + script);
+            for (var k = 0; k < countries.length; k++) {
+              allTags.push(language + "-" + script + "-" + countries[k]);
+            }
+          }
+          for (var c = 0; c < countries.length; c++) {
+            allTags.push(language + "-" + countries[c]);
+          }
+        }
+
+        var opt = { localeMatcher: "lookup" };
+        for (var t = 0; t < allTags.length; t++) {
+          var locale = allTags[t];
+          Intl.Collator.supportedLocalesOf([locale], opt);
+          Intl.Collator.supportedLocalesOf([locale + "-u-co-phonebk-nu-latn"], opt);
+          Intl.Collator.supportedLocalesOf([locale + "-u-nu-invalid"], opt);
+        }
+        """;
+
+    /// <summary>
+    /// Leaving the culture probe out of the first pass may not change what is reported as supported, which
+    /// is what the sweep above is actually asserting when test262 runs it.
+    /// </summary>
+    /// <remarks>
+    /// The three rows are the shapes the probe used to answer for: a tag the available set holds verbatim, a
+    /// tag carrying a Unicode extension sequence — which step 2.d's singleton rule truncates to the same
+    /// prefix the probe reached by stripping it — and a tag nothing can match, which still falls through to
+    /// the pass that resolves cultures.
+    /// </remarks>
+    [TestCase("en-US", true)]
+    [TestCase("en-US-u-co-phonebk-nu-latn", true)]
+    [TestCase("en-US-u-nu-invalid", true)]
+    [TestCase("zz-Zzzz-ZZ", false)]
+    public void AUnicodeExtensionSequenceDoesNotChangeWhetherALocaleIsSupported(string locale, bool supported)
+    {
+        var engine = new Engine();
+        engine.SetValue("locale", locale);
+
+        engine.Evaluate("Intl.Collator.supportedLocalesOf([locale]).length === 1").AsBoolean().Should().Be(supported);
+        engine.Evaluate("Intl.NumberFormat.supportedLocalesOf([locale]).length === 1").AsBoolean().Should().Be(supported);
+        engine.Evaluate("Intl.DateTimeFormat.supportedLocalesOf([locale]).length === 1").AsBoolean().Should().Be(supported);
+    }
+
+    /// <summary>
     /// The bound is not allowed to become a correctness problem: a tag resolved after the cache overflowed
     /// answers exactly as it did before, because the value is a total function of the key.
     /// </summary>

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Globalization;
+using System.Threading;
 using System.Text.RegularExpressions;
 using Jint.Native.Function;
 using Jint.Native.Intl.Data;
@@ -103,6 +104,26 @@ internal static class IntlUtilities
 
     /// <summary>Number of cached locale tags. Exists so the growth test can assert on the bound.</summary>
     internal static int CultureCacheCount => _cultureCache.Count;
+
+    private static long _cultureLookups;
+
+    /// <summary>
+    /// How many times a locale tag has been turned into a <see cref="CultureInfo"/>, cache hits included.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Exists so a test can bound the number of lookups a sweep of locales performs, which is a count rather
+    /// than a duration and so says the same thing on a loaded machine as on an idle one. That distinction is
+    /// the whole of <see href="https://github.com/sebastienros/jint/issues/3609">#3609</see>: the cost it
+    /// records was only ever visible as a wall-clock timeout under full-suite load.
+    /// </para>
+    /// <para>
+    /// The increment is one interlocked add on a path that already costs a dictionary lookup at best and a
+    /// <c>new CultureInfo</c> at worst, and — since this change — one no <c>supportedLocalesOf</c> of an
+    /// available locale reaches at all.
+    /// </para>
+    /// </remarks>
+    internal static long CultureLookupCount => Volatile.Read(ref _cultureLookups);
 
     /// <summary>The bound <see cref="CultureCacheCount"/> can never exceed for long.</summary>
     internal static int CultureCacheBound => CultureCacheCapacity;
@@ -1692,7 +1713,39 @@ internal static class IntlUtilities
     /// <summary>
     /// https://tc39.es/ecma402/#sec-bestavailablelocale
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two passes, and the split is what <see href="https://github.com/sebastienros/jint/issues/3609">#3609</see>
+    /// is about. The spec's own algorithm is a set lookup and a truncation, and that is the first pass. The
+    /// second adds what .NET knows: it resolves each candidate to a <see cref="CultureInfo"/> and tries that
+    /// culture's name, which is how a tag the set does not hold verbatim can still be matched.
+    /// </para>
+    /// <para>
+    /// <b>Why the second pass may not run first.</b> Resolving a tag costs a <c>new CultureInfo</c> — about
+    /// 15 µs, and the cache in front of it is bounded on purpose, so a sweep over more distinct tags than it
+    /// holds resolves nearly every one. Interleaving the two made every iteration of the truncation pay it:
+    /// <c>intl402/supportedLocalesOf-unicode-extensions-ignored.js</c>, which asks six constructors about 640
+    /// tags with two matchers, made <b>70,000</b> lookups of which <b>64,000</b> were this probe, and spent
+    /// about a second of its two doing it. The probe decided the answer in 0.8% of those, and in every one of
+    /// them it was stripping a Unicode extension sequence — <c>en-US-u-nu-invalid</c> to <c>en-US</c> — which
+    /// step 2.d's singleton rule reaches by truncation anyway, one iteration later and for the price of a
+    /// hash lookup.
+    /// </para>
+    /// <para>
+    /// <b>Why the answer cannot move.</b> The truncation visits prefixes longest-first, and a name the probe
+    /// returns is either a prefix of the candidate — in which case the first pass reaches that same prefix,
+    /// and no longer one can be available because <see cref="GetAvailableLocales"/> holds .NET culture names
+    /// and none of those carries a <c>-u-</c> sequence — or it is not a prefix, which
+    /// <see href="https://tc39.es/ecma402/#sec-bestavailablelocale">the algorithm does not admit</see> as an
+    /// answer at all, and which the second pass still produces exactly as before for the tags that reach it.
+    /// Casing is not one of the cases either: the set compares ordinal-ignore-case.
+    /// </para>
+    /// </remarks>
     internal static string? BestAvailableLocale(HashSet<string> availableLocales, string locale)
+        => BestAvailableLocale(availableLocales, locale, resolveCultures: false)
+           ?? BestAvailableLocale(availableLocales, locale, resolveCultures: true);
+
+    private static string? BestAvailableLocale(HashSet<string> availableLocales, string locale, bool resolveCultures)
     {
         // 1. Let candidate be locale.
         var candidate = locale;
@@ -1706,14 +1759,18 @@ internal static class IntlUtilities
                 return candidate;
             }
 
-            // Also try matching via CultureInfo
-            var culture = GetCultureInfo(candidate);
-            if (culture != null)
+            // Also try matching via CultureInfo, on the second pass only: see the remarks above for why the
+            // first pass may not pay for this and why leaving it out of that pass cannot change the answer.
+            if (resolveCultures)
             {
-                var cultureName = culture.Name;
-                if (availableLocales.Contains(cultureName))
+                var culture = GetCultureInfo(candidate);
+                if (culture != null)
                 {
-                    return cultureName;
+                    var cultureName = culture.Name;
+                    if (availableLocales.Contains(cultureName))
+                    {
+                        return cultureName;
+                    }
                 }
             }
 
@@ -1787,6 +1844,8 @@ internal static class IntlUtilities
         {
             return null;
         }
+
+        Interlocked.Increment(ref _cultureLookups);
 
         if (_cultureCache.TryGetValue(locale, out var cached))
         {


### PR DESCRIPTION
Fixes #3609.

## What was wrong

`intl402/supportedLocalesOf-unicode-extensions-ignored.js` passed in ~2 s alone and hit the harness's 30-second wall-clock timeout under a saturated build, on unmodified `main`, in the verification reports of eight recent pull requests. Nothing about the test had changed. What it does is ask six `Intl` constructors about 640 generated tags with two matchers, three `supportedLocalesOf` calls each — 7,680 constructions and 23,040 `supportedLocalesOf` calls.

`BestAvailableLocale` is a set lookup and a truncation, and it was interleaving a second thing with them: resolving *each candidate* to a `CultureInfo` and trying that culture's name, which is how a tag the available set does not hold verbatim can still be matched. Resolving one costs a `new CultureInfo` — ~15 µs measured — and the cache in front of it is bounded at 256 entries on purpose (#3-era memory fix, pinned by `IntlCultureCacheTests`), so a sweep over more distinct tags than that resolves nearly every one.

Counted, with a counter on `GetCultureInfo`, for one pass of that test's workload:

| | |
| --- | ---: |
| culture lookups | **70,000** |
| …of them from `BestAvailableLocale`'s probe | **64,000** (91%) |
| …probes that decided the answer | **1,536** (0.8%) |
| cache misses | 60,000 (86%) |
| distinct tags asked about | 4,352 |

And every one of the 1,536 that decided was stripping a Unicode extension sequence — `en-US-u-nu-invalid` → `en-US`, `zh-Hant-TW-u-co-phonebk-nu-latn` → `zh-Hant-TW` — which step 2.d's singleton rule reaches by truncation anyway, one iteration later and for the price of a hash lookup.

## What changed

The culture probe is a **second pass**, run only when the spec's own algorithm has failed outright. Nothing that resolved before stops resolving.

The answer cannot move, either. The truncation visits prefixes longest-first, and a name the probe returns is either

- a prefix of the candidate — in which case the first pass reaches that same prefix, and no *longer* one can be available, because `GetAvailableLocales` holds .NET culture names and none of those carries a `-u-` sequence; or
- not a prefix, which [the algorithm](https://tc39.es/ecma402/#sec-bestavailablelocale) does not admit as an answer at all (the `zh-Hant` expansion branch beside it already says so in as many words) — and which the second pass still produces exactly as it did.

Casing is not a third case: the available-locale set compares ordinal-ignore-case.

## Measured

| | before | after |
| --- | ---: | ---: |
| culture resolutions, `supportedLocalesOf` sweep (640 tags × 3) | 6,913 | **0** |
| culture lookups, whole workload | 70,000 | 8,960 |
| the test262 file, alone | ~2 s | **~1 s** |
| `Intl.Collator`, 640 distinct tags | 177 ms | 59 ms |
| `Collator.supportedLocalesOf`, 640 × 3 | 149 ms | 15 ms |

## What is left, and it is not Jint's

Half of the remainder is `Intl.NumberFormat` construction: 238 ms for 1,280 constructions **even with a culture cache big enough to hold the whole sweep**, which is ~300 µs per *distinct locale* spent materializing a `NumberFormatInfo` from .NET's globalization data. That is a one-off per locale per `CultureInfo` instance and there is nothing here to cache that is not already cached — raising `CultureCacheCapacity` from 256 to 4,096 buys 21% of the workload and moves the cliff rather than removing it, so this PR does not do it.

So: the base cost is halved, and if the flake ever returns at ~1 s the honest next moves are a per-file allowance in the harness or an argued `intl402` banner entry — **not** a larger global timeout, which is the measurement the defect hid behind in the first place.

## The test that pins it

`ASupportedLocalesOfSweepDoesNotResolveACultureForEveryCandidate` in `IntlCultureCacheTests` (the fixture that already owns this static, `[NonParallelizable]` for that reason) runs the sweep and bounds `IntlUtilities.CultureLookupCount`.

**A count and not a duration**, which is the point: the defect only ever showed itself as a timeout, so a timing test would be the same measurement that could not tell a regression from a busy machine. It reads **0** against a bound of one lookup per call (1,920), and **6,913** with the fix reverted — verified by reverting it.

`AUnicodeExtensionSequenceDoesNotChangeWhetherALocaleIsSupported` covers the three shapes the probe used to answer for, plus a tag nothing matches, across the three original constructors.

## Runs

- `Jint.Tests.Test262 --filter intl402` — **6,642 passed, 0 failed**, 72 skipped.
- `Jint.Tests --filter Intl` — 482 passed.
- `Jint.Tests -f net10.0 --filter "Wpt|Intl|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests"` — 1,172 passed, 1 skipped (the opt-in wpt census).
- Full-solution `dotnet build -c Release`, clean.

No benchmark: the numbers above are counts and single-file durations, not BenchmarkDotNet rows, and this box had four other agents building on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
