### PR TITLE
DOM bindings: a union parameter takes both its arms, and a form and a select answer by index and by name

### DIFF
--- a/Jint.Browser/Dom/AGENTS.md
+++ b/Jint.Browser/Dom/AGENTS.md
@@ -44,7 +44,7 @@ version of AngleSharp nobody references.
 | --- | --- |
 | `excludedInterfaces` | An interface the runtime owns instead. Today: `IWindow` (campaign item R1). |
 | `manual` | An interface whose shape is hand-written in `DomManualShapes`. Today: `IHtmlCollection<T>`, whose generic invariance keeps a member body from naming its receiver. A manual interface contributes no members to any closure — its children inherit them through the prototype chain. |
-| `skip` | A member whose AngleSharp implementation must not be projected: navigation (`location.assign`, `location.href`'s setter), the parser (`document.open`/`close`/`load`), `document.createEvent` whose AngleSharp `Event` must never reach script, `DOMImplementation.createHTMLDocument` whose title AngleSharp makes required, and the six the events bridge re-declares because AngleSharp's own do nothing — see the divergence table. Every one of them is re-declared in `additions`, so a skip here is a *replacement* and not an absence. `half: "setter"` skips the write half only. |
+| `skip` | A member whose AngleSharp implementation must not be projected: HTML's two union-typed operations (`select.add`, `HTMLOptionsCollection.add`, whose `(HTMLOptionElement or HTMLOptGroupElement)` AngleSharp models as two overloads sharing one `[DomName]`, so one arm always lost — `DomUnionMembers` dispatches on both, and the entry is also what turns the collision from a diagnostic into a decision), navigation (`location.assign`, `location.href`'s setter), the parser (`document.open`/`close`/`load`), `document.createEvent` whose AngleSharp `Event` must never reach script, `DOMImplementation.createHTMLDocument` whose title AngleSharp makes required, and the six the events bridge re-declares because AngleSharp's own do nothing — see the divergence table. Every one of them is re-declared in `additions`, so a skip here is a *replacement* and not an absence. `half: "setter"` skips the write half only. |
 | `hooks` | A member routed through `DomHostHooks` so the package can replace its body: the `innerHTML` and `outerHTML` setters, `insertAdjacentHTML`, `document.write`/`writeln`, and `setAttribute`/`removeAttribute` — the one write of an attribute this package can see, and therefore where a handler content attribute takes its position in the element's listener list. The default implementations *are* the AngleSharp call, so the seam costs nothing until R3 uses it. `"half": "getter"` replaces the *read* of an attribute, which is what a member whose value the host has and AngleSharp does not needs: `document.currentScript`, `readyState`, `URL`, `documentURI`, `referrer`, `cookie` and `Node.baseURI` are accessors on their prototypes because of it, where they used to be own properties written onto the document wrapper. `"returns": true` is the form for a member whose *answer* belongs to the host rather than its effect, which is `document.createElement`, `createElementNS` and `Node.cloneNode`: with the synchronous custom elements flag set the element a defined name produces is the constructor's and not AngleSharp's. **Reach for it before `skip` + `additions`** — a hook stands in front of a generated member, so the member keeps its arity and its name, and a member AngleSharp later grows under that name is still reported rather than shadowed. The same class carries `WrapperCreated`, which is the other direction — a member the generator could not emit at all, added to one wrapper; it is also where the events bridge registers an element's handler content attributes. |
 | `additions` | A member the **standard** puts on a generated interface and AngleSharp's metadata cannot express: a callback parameter, a stringifier with no `[DomName]`, a Shadow DOM v0 spelling, a missing `[DomName]`, the whole of CSSOM View's box model (`getBoundingClientRect` and its `client*`/`scroll*`/`offset*` family, answered from the flat layout — [`../Runtime/AGENTS.md`](../Runtime/AGENTS.md)), the legacy event-creation surface (`document.createEvent`), and the operations whose body is an event rather than a DOM call (`click`/`focus`/`blur`, `form.submit`/`requestSubmit`/`reset`, `document.activeElement`/`hasFocus`). Two forms, and an entry uses exactly one: **reach for the member form**, which names one member and goes through the model like any projected member, so the generated file names it and a member AngleSharp later grows under that name is reported rather than shadowed; the `"extend"` form hands the builder to a method and exists only for a *family* whose member list is computed, which today is HTML's event handler IDL attributes. `Overrides.AdditionEntry` has the whole of why, including what the extend form gives up. Either way it adds rather than replaces, so the interface stays **one** shape — the only way to add a member to a class rather than to one object without costing the prototype its shape. |
 | `reflected` | The **standard's** half of the table rather than AngleSharp's: which of [HTML §2.6.1](https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes)'s thirteen reflection algorithms one IDL attribute takes, plus its keywords, its invalid and missing value defaults and its range. None of that is in a CLR signature — a `long` and a `long` limited to only non-negative numbers are the same `Int32` property, and `<col span>` defaulting to 1 while `<select size>` defaults to 0 is nowhere in the metadata — which is why it is a table and not a heuristic. An entry **replaces** the member AngleSharp projects under that name, the opposite of `additions`, because most reflected attributes *are* projected already, from a property that hands back the raw attribute value or parses it with the wrong default; neither presence nor absence is an error, and the generated report says which each entry was. The bodies are one shared `ReflectedAttribute` descriptor per member in `DomReflected.g.cs`, process-shared and immutable, so HTML's rules for parsing integers, non-negative integers and floating-point number values exist once rather than once per emitted member. |
@@ -114,11 +114,6 @@ Divergences from a browser that are **ours** and deliberate:
   [WebIDL](https://webidl.spec.whatwg.org/#js-iterable), so `NodeList.prototype[Symbol.iterator] ===
   Array.prototype[Symbol.iterator]`. `DomIterator.ArrayValues` is the factory the emitter names, and it reads
   `DomRealm.PrincipalRealm` for the reason everything else here does.
-- **`(Node or DOMString)...` takes only the `Node` half**: `append('text')` is a `TypeError` where a browser
-  inserts a text node, because a static member body has no document to create one against.
-- **`select.add` and `HTMLOptionsCollection.add` take one of their two overloads**, because HTML's union type
-  is two CLR methods sharing a `[DomName]`. Two diagnostics say so and `DomBindingsStalenessTests` pins them
-  at exactly two, so a third means something new turned up.
 - **The ARIA mixin's element-reflection half is not projected.** `role` and the forty-three `aria-*`
   IDL attributes are, through `AriaReflection` and the `additions` extend form, and each is a view of
   its content attribute rather than stored state — which is what makes the two directions agree by
@@ -126,13 +121,14 @@ Divergences from a browser that are **ours** and deliberate:
   `ariaControlsElements` and their five siblings reflect an element or a frozen array of elements and
   carry an explicitly-set value that survives the target leaving the tree; that is bookkeeping, not a
   view, and it is [#3773](https://github.com/sebastienros/jint/issues/3773)'s remainder.
-- **A node's indexed and named getters are dropped** (`form[0]`, `form.username`, `select[0]`): a node wrapper
-  is a `JsEventTarget` rather than an `ArrayLikeObject`, so it carries no property projection.
-  `form.elements[0]` and `form.elements.namedItem('username')` are the same values.
 - **`el.tabIndex` answers 0 when the attribute is absent**, where HTML's default is −1 for anything not
   inherently focusable. It was AngleSharp's answer and is this binding's now, because `reflected` took the
   member over to get HTML's integer parsing (`tabindex="5%"` is 5, not 0); what is still missing is a
   focusability model rather than a parse, so `tabIndex` cannot decide focusability.
+- **A form's supported property names are computed rather than read from metadata.** HTML makes them the
+  `name` content attributes and the ids of the form's listed elements, and `name` is not an IDL member of
+  `IElement` at all, so no `[DomName]` heuristic could find it. It is the one named getter over elements in
+  the surface, so `ModelBuilder.AppendNamedHalf` writes the rule once instead of the table carrying it.
 
 ### Every member body goes through one invoker, and that is where a refusal is converted
 
@@ -189,6 +185,12 @@ The wrappers deliberately do **not** share a base class, and `IDomWrapper` is wh
 - **`Collections/DomCollectionObject : ArrayLikeObject`** — so `list[i]`, `for..of`, spread, `Array.from` and
   the `Array.prototype` generics reach the engine's one-callback-per-element lane with no `Reference`, no key
   object and no descriptor. Its interface-specific half is the generated accessor.
+- **`Collections/DomIndexedNodeObject : DomNodeObject`** — a node whose interface *also* supports indexed or
+  named properties (`form[0]`, `form.username`, `select[0]`). It is a node wrapper with the same generated
+  accessor projected on top, and it has to be: the tree-dispatch lane keys on the node wrapper and the cache
+  keeps one per node, so a form that became an `ArrayLikeObject` would stop being an `EventTarget` the
+  dispatcher can walk. Three overrides, all reading the accessor at the same instant, which is what keeps
+  `hasOwnProperty` and `Object.getOwnPropertyNames` agreeing about one object.
 - **`Collections/DomNamedMapObject : NamedPropertyObject`** — `dataset`, whose whole model is a named getter.
 - **`DomObject : ObjectInstance`** — everything else, overriding nothing, which is what keeps it on the
   engine's ordinary access lane.

--- a/Jint.Browser/Dom/Collections/DomIndexedNodeObject.cs
+++ b/Jint.Browser/Dom/Collections/DomIndexedNodeObject.cs
@@ -1,0 +1,169 @@
+using AngleSharp.Dom;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Browser.Dom.Collections;
+
+/// <summary>
+/// The wrapper for a node whose interface also supports indexed or named properties: <c>form[0]</c>,
+/// <c>form.username</c>, <c>select[0]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why it is a node wrapper with a projection rather than a collection.</b> A node's wrapper is what the
+/// engine's tree-dispatch lane keys on, and the wrapper cache keeps exactly one per node, so a form cannot be
+/// an <c>ArrayLikeObject</c> without ceasing to be an <c>EventTarget</c> the dispatcher can walk. The
+/// projection therefore rides on top: three overrides, kept consistent by construction because all three read
+/// the same generated <see cref="DomCollectionAccessor"/> at the same instant.
+/// </para>
+/// <para>
+/// <b>What that costs, and what it does not.</b> Overriding <c>GetOwnProperty</c> and not <c>Get</c> keeps the
+/// receiver on the engine's <em>ordinary</em> property-access lane, so an inherited member still resolves in
+/// one probe and the prototype-method inline cache still serves it; only an own read consults the projection.
+/// The elements are read-only and configurable, which is what Web IDL gives a supported index with no setter,
+/// so an assignment to <c>form[0]</c> is refused by <c>[[Set]]</c> without this class overriding it.
+/// </para>
+/// <para>
+/// <b>The coherence obligation is the one <c>Jint/Native/Object/AGENTS.md</c> states.</b> A name
+/// <see cref="GetOwnProperty"/> answers has to be a name <see cref="GetOwnPropertyKeys"/> lists, or
+/// <c>hasOwnProperty</c> and <c>Object.getOwnPropertyNames</c> disagree about the same object. Both read
+/// <c>SupportedNames</c>, so the only way to break it is to give the accessor a named getter whose supported
+/// names do not include what it answers.
+/// </para>
+/// </remarks>
+internal sealed class DomIndexedNodeObject : DomNodeObject
+{
+    private readonly DomCollectionAccessor _accessor;
+
+    internal DomIndexedNodeObject(DomRealm realm, DomInterfaceDefinition definition, INode node, DomCollectionAccessor accessor)
+        : base(realm, definition, node)
+    {
+        _accessor = accessor;
+    }
+
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    {
+        if (TryProject(property, out var value, out var enumerable))
+        {
+            // https://webidl.spec.whatwg.org/#legacy-platform-object-getownproperty - a supported index or
+            // name is { writable: false, configurable: true }, and the enumerability is the interface's.
+            return new PropertyDescriptor(
+                value,
+                enumerable
+                    ? PropertyFlag.NonWritable
+                    : PropertyFlag.OnlyConfigurable);
+        }
+
+        return base.GetOwnProperty(property);
+    }
+
+    protected internal override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        if (TryProject(property, out _, out var enumerable))
+        {
+            return enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
+        }
+
+        return base.ProbeOwnProperty(property);
+    }
+
+    public override List<JsValue> GetOwnPropertyKeys(Types types = Types.Empty | Types.String | Types.Symbol)
+    {
+        var keys = base.GetOwnPropertyKeys(types);
+
+        if ((types & Types.String) == Types.Empty)
+        {
+            return keys;
+        }
+
+        // https://tc39.es/ecma262/#sec-ordinaryownpropertykeys - the integer-index keys come first and in
+        // ascending order, so they are inserted ahead of everything the base listed rather than appended.
+        var length = _accessor.Length(Node);
+        var indices = new List<JsValue>((int) System.Math.Min(length, int.MaxValue));
+        for (var i = 0u; i < length; i++)
+        {
+            indices.Add(JsString.Create(i));
+        }
+
+        foreach (var name in _accessor.SupportedNames(Node))
+        {
+            // A name the object already carries - an expando, or an inherited member shadowed by one - is the
+            // base list's, and listing it twice would make Object.getOwnPropertyNames report a duplicate.
+            if (!keys.Contains(JsString.Create(name)))
+            {
+                indices.Add(JsString.Create(name));
+            }
+        }
+
+        indices.AddRange(keys);
+        return indices;
+    }
+
+    /// <summary>
+    /// The one place the projection is read, so the three overrides above can never disagree about it. An
+    /// own property the object really has wins, which is what makes an expando assigned over a supported name
+    /// behave the way it does on any other object.
+    /// </summary>
+    private bool TryProject(JsValue property, out JsValue value, out bool enumerable)
+    {
+        value = JsValue.Undefined;
+        enumerable = true;
+
+        if (!property.IsString())
+        {
+            return false;
+        }
+
+        var key = property.ToString();
+
+        if (IsArrayIndex(key, out var index))
+        {
+            return _accessor.TryGetIndex(DomRealm, Node, index, out value);
+        }
+
+        if (!_accessor.HasNamedGetter)
+        {
+            return false;
+        }
+
+        enumerable = _accessor.AreNamesEnumerable;
+        return _accessor.TryGetNamed(DomRealm, Node, key, out value);
+    }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#dfn-supported-property-indices - an index is ECMAScript's array
+    /// index: a canonical numeric string below 2^32-1. Anything else is a <em>name</em>, which is what keeps
+    /// <c>form['01']</c> and <c>form['-1']</c> out of the indexed half.
+    /// </summary>
+    private static bool IsArrayIndex(string key, out uint index)
+    {
+        index = 0;
+
+        if (key.Length == 0 || key.Length > 10 || (key.Length > 1 && key[0] == '0'))
+        {
+            return false;
+        }
+
+        ulong value = 0;
+        for (var i = 0; i < key.Length; i++)
+        {
+            var digit = key[i];
+            if (digit < '0' || digit > '9')
+            {
+                return false;
+            }
+
+            value = (value * 10) + (uint) (digit - '0');
+        }
+
+        if (value >= uint.MaxValue)
+        {
+            return false;
+        }
+
+        index = (uint) value;
+        return true;
+    }
+}

--- a/Jint.Browser/Dom/DomConvert.cs
+++ b/Jint.Browser/Dom/DomConvert.cs
@@ -242,16 +242,54 @@ internal static class DomConvert
     }
 
     /// <summary>
-    /// A variadic interface-typed parameter — <c>(Node or DOMString)...</c> in IDL, where this binding
-    /// deliberately takes only the <c>Node</c> half.
+    /// https://dom.spec.whatwg.org/#converting-nodes-into-a-node {EM} the <c>(Node or DOMString)...</c> of
+    /// <c>append</c>, <c>prepend</c>, <c>before</c>, <c>after</c> and <c>replaceWith</c>: an argument that is
+    /// not a node is stringified and becomes a <c>Text</c> node in <paramref name="owner"/>'s node document.
     /// </summary>
     /// <remarks>
-    /// <c>append</c>, <c>prepend</c>, <c>before</c>, <c>after</c> and <c>replaceWith</c> all accept strings in
-    /// the DOM, which are converted to text nodes. AngleSharp's signature is <c>INode[]</c> and there is no
-    /// document to create a text node against inside a static member body, so a string argument is a
-    /// <c>TypeError</c> here where a browser inserts text. It is recorded as a divergence rather than
-    /// approximated, and closing it is a hand-written override once the runtime owns node creation.
+    /// AngleSharp's signature is <c>INode[]</c>, so the string half of the union has to be converted before
+    /// the call. It needs a document to create the text node against, which is why this takes the receiver:
+    /// a node's node document is its <c>Owner</c>, or itself when the receiver <em>is</em> the document.
     /// </remarks>
+    internal static AngleSharp.Dom.INode[] NodeOrTextRest(DomRealm realm, AngleSharp.Dom.INode owner, JsValue[] arguments, int from, string member)
+    {
+        if (arguments.Length <= from)
+        {
+            return [];
+        }
+
+        var document = owner as AngleSharp.Dom.IDocument ?? owner.Owner;
+        var values = new AngleSharp.Dom.INode[arguments.Length - from];
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            var value = arguments[from + i];
+
+            if (value is IDomWrapper wrapper && wrapper.DomTarget is AngleSharp.Dom.INode node)
+            {
+                values[i] = node;
+                continue;
+            }
+
+            if (document is null)
+            {
+                // A node with no node document cannot make a text node, and inventing a document to make one
+                // in would put the result in a tree nothing else can reach. Only a detached DocumentType gets
+                // here, which is why this is a TypeError rather than a silent drop.
+                values[i] = DomBindings.Argument<AngleSharp.Dom.INode>(arguments, from + i, member);
+                continue;
+            }
+
+            values[i] = document.CreateTextNode(TypeConverter.ToString(value));
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// A variadic interface-typed parameter whose element type is <em>not</em> a node, and so has no string
+    /// half to convert.
+    /// </summary>
     internal static T[] ObjectRest<T>(JsValue[] arguments, int from, string member) where T : class
     {
         if (arguments.Length <= from)

--- a/Jint.Browser/Dom/DomRealm.cs
+++ b/Jint.Browser/Dom/DomRealm.cs
@@ -226,8 +226,18 @@ internal sealed class DomRealm
         }
 
         var definition = DomManualInterfaces.For(node) ?? DomTypeMap.For(node.GetType()) ?? DomInterfaces.Node;
-        return (DomNodeObject) Cache(node, new DomNodeObject(this, definition, node));
+        return (DomNodeObject) Cache(node, NewNode(definition, node));
     }
+
+    /// <summary>
+    /// The node wrapper an interface asks for: a plain one, or one carrying the interface's indexed and named
+    /// property projection (<c>form[0]</c>, <c>form.username</c>, <c>select[0]</c>). Both are node wrappers,
+    /// because a node's wrapper is what the engine's tree-dispatch lane keys on.
+    /// </summary>
+    private DomNodeObject NewNode(DomInterfaceDefinition definition, INode node)
+        => definition.WrapperKind == DomWrapperKind.IndexedNode && definition.CollectionAccessor is { } accessor
+            ? new DomIndexedNodeObject(this, definition, node, accessor)
+            : new DomNodeObject(this, definition, node);
 
     /// <summary>
     /// Projects an <c>IHtmlCollection&lt;T&gt;</c>, whose element type the calling generated member knows.
@@ -250,9 +260,9 @@ internal sealed class DomRealm
 
     private ObjectInstance Create(DomInterfaceDefinition definition, object value)
     {
-        if (definition.WrapperKind == DomWrapperKind.Node)
+        if (definition.WrapperKind is DomWrapperKind.Node or DomWrapperKind.IndexedNode)
         {
-            return new DomNodeObject(this, definition, (INode) value);
+            return NewNode(definition, (INode) value);
         }
 
         if (definition.WrapperKind == DomWrapperKind.HtmlCollection)

--- a/Jint.Browser/Dom/DomUnionMembers.cs
+++ b/Jint.Browser/Dom/DomUnionMembers.cs
@@ -1,0 +1,67 @@
+using AngleSharp.Html.Dom;
+using Jint.Native;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>
+/// The members whose IDL parameter is a <a href="https://webidl.spec.whatwg.org/#idl-union">union of two
+/// interfaces</a>, which AngleSharp models as two overloads sharing one <c>[DomName]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generator binds one <c>[DomName]</c> to one member, so the second overload was reported as a collision
+/// and lost: <c>select.add(optgroup)</c> was a <c>TypeError</c> where a browser accepts it, and so was
+/// <c>select.options.add(optgroup)</c>. There is nothing in AngleSharp's metadata that says the two methods
+/// are one IDL operation, so the union is written here and the two members are <c>skip</c> + <c>additions</c>
+/// entries in the override table — which is also what makes the collision a decision rather than a
+/// diagnostic.
+/// </para>
+/// <para>
+/// The dispatch is on the argument's <em>interface</em> and in the order Web IDL's overload resolution takes:
+/// the most derived first. An argument that is neither half is the ordinary conversion failure, raised by
+/// <see cref="DomBindings.Argument{T}"/> against the option half so that the message names one expected type
+/// rather than none.
+/// </para>
+/// </remarks>
+internal static class DomUnionMembers
+{
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-add —
+    /// <c>add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null)</c>.
+    /// </summary>
+    internal static JsValue SelectAdd(DomBinding<IHtmlSelectElement> self, JsValue[] arguments)
+    {
+        var before = DomBindings.NullableArgument<IHtmlElement>(arguments, 1, "HTMLSelectElement.add");
+
+        if (Target<IHtmlOptionsGroupElement>(arguments) is { } group)
+        {
+            self.Target.AddOption(group, before);
+            return JsValue.Undefined;
+        }
+
+        self.Target.AddOption(DomBindings.Argument<IHtmlOptionElement>(arguments, 0, "HTMLSelectElement.add"), before);
+        return JsValue.Undefined;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmloptionscollection-add —
+    /// the same union, on the collection.
+    /// </summary>
+    internal static JsValue OptionsAdd(DomBinding<IHtmlOptionsCollection> self, JsValue[] arguments)
+    {
+        var before = DomBindings.NullableArgument<IHtmlElement>(arguments, 1, "HTMLOptionsCollection.add");
+
+        if (Target<IHtmlOptionsGroupElement>(arguments) is { } group)
+        {
+            self.Target.Add(group, before);
+            return JsValue.Undefined;
+        }
+
+        self.Target.Add(DomBindings.Argument<IHtmlOptionElement>(arguments, 0, "HTMLOptionsCollection.add"), before);
+        return JsValue.Undefined;
+    }
+
+    /// <summary>The first argument's AngleSharp object when it is a <typeparamref name="T"/>, else null.</summary>
+    private static T? Target<T>(JsValue[] arguments) where T : class
+        => arguments.Length > 0 && arguments[0] is IDomWrapper wrapper ? wrapper.DomTarget as T : null;
+}

--- a/Jint.Browser/Dom/DomWrapperKind.cs
+++ b/Jint.Browser/Dom/DomWrapperKind.cs
@@ -21,6 +21,13 @@ internal enum DomWrapperKind
     Node,
 
     /// <summary>
+    /// An <c>INode</c> that <em>also</em> carries an indexed or named getter — <c>HTMLFormElement</c>,
+    /// <c>HTMLSelectElement</c>: <c>Collections.DomIndexedNodeObject</c>, which is a node wrapper with the
+    /// interface's generated <see cref="DomCollectionAccessor"/> projected on top of it.
+    /// </summary>
+    IndexedNode,
+
+    /// <summary>
     /// An interface with an indexed getter: <c>Collections.DomCollectionObject</c> over the interface's
     /// generated <see cref="DomCollectionAccessor"/>.
     /// </summary>

--- a/Jint.Browser/Dom/Generated/DomCollectionAccessors.g.cs
+++ b/Jint.Browser/Dom/Generated/DomCollectionAccessors.g.cs
@@ -232,6 +232,90 @@ internal sealed class DomAccessorFileList : DomCollectionAccessor
     }
 }
 
+/// <summary>How <c>HTMLFormElement</c> answers indexed and named property lookups.</summary>
+internal sealed class DomAccessorHTMLFormElement : DomCollectionAccessor
+{
+    internal static readonly DomAccessorHTMLFormElement Instance = new();
+
+    internal override uint Length(object target) => (uint) ((global::AngleSharp.Html.Dom.IHtmlFormElement) target).Length;
+
+    internal override bool TryGetIndex(DomRealm realm, object target, uint index, out global::Jint.Native.JsValue value)
+    {
+        var collection = (global::AngleSharp.Html.Dom.IHtmlFormElement) target;
+        if (index >= (uint) collection.Length)
+        {
+            value = global::Jint.Native.JsValue.Undefined;
+            return false;
+        }
+
+        value = realm.WrapNodeValue(collection[(int) index]);
+        return true;
+    }
+
+    internal override bool HasNamedGetter => true;
+
+    internal override global::System.Collections.Generic.IReadOnlyList<string> SupportedNames(object target)
+    {
+        var collection = (global::AngleSharp.Html.Dom.IHtmlFormElement) target;
+        var names = new global::System.Collections.Generic.List<string>(collection.Length);
+        for (var i = 0; i < collection.Length; i++)
+        {
+            var item = collection[i];
+            if (item is null)
+            {
+                continue;
+            }
+
+            Add(names, item.GetAttribute("name"));
+            Add(names, item.Id);
+        }
+
+        return names;
+
+        static void Add(global::System.Collections.Generic.List<string> names, string? name)
+        {
+            if (!string.IsNullOrEmpty(name) && !names.Contains(name!))
+            {
+                names.Add(name!);
+            }
+        }
+    }
+
+    internal override bool TryGetNamed(DomRealm realm, object target, string name, out global::Jint.Native.JsValue value)
+    {
+        var item = ((global::AngleSharp.Html.Dom.IHtmlFormElement) target)[name];
+        if (item is null)
+        {
+            value = global::Jint.Native.JsValue.Undefined;
+            return false;
+        }
+
+        value = realm.WrapNodeValue(item);
+        return true;
+    }
+}
+
+/// <summary>How <c>HTMLSelectElement</c> answers indexed and named property lookups.</summary>
+internal sealed class DomAccessorHTMLSelectElement : DomCollectionAccessor
+{
+    internal static readonly DomAccessorHTMLSelectElement Instance = new();
+
+    internal override uint Length(object target) => (uint) ((global::AngleSharp.Html.Dom.IHtmlSelectElement) target).Length;
+
+    internal override bool TryGetIndex(DomRealm realm, object target, uint index, out global::Jint.Native.JsValue value)
+    {
+        var collection = (global::AngleSharp.Html.Dom.IHtmlSelectElement) target;
+        if (index >= (uint) collection.Length)
+        {
+            value = global::Jint.Native.JsValue.Undefined;
+            return false;
+        }
+
+        value = realm.WrapNodeValue(collection[(int) index]);
+        return true;
+    }
+}
+
 /// <summary>How <c>MediaList</c> answers indexed and named property lookups.</summary>
 internal sealed class DomAccessorMediaList : DomCollectionAccessor
 {

--- a/Jint.Browser/Dom/Generated/DomInterfaces.g.cs
+++ b/Jint.Browser/Dom/Generated/DomInterfaces.g.cs
@@ -1314,7 +1314,8 @@ internal static partial class DomInterfaces
             HTMLElement,
             rootsAtEventTarget: true,
             hasInterfaceObject: true,
-            DomWrapperKind.Node));
+            DomWrapperKind.IndexedNode,
+            collectionAccessor: DomAccessorHTMLFormElement.Instance));
 
         HTMLHRElement = Add(new DomInterfaceDefinition(
             "HTMLHRElement",
@@ -1611,7 +1612,8 @@ internal static partial class DomInterfaces
             HTMLElement,
             rootsAtEventTarget: true,
             hasInterfaceObject: true,
-            DomWrapperKind.Node));
+            DomWrapperKind.IndexedNode,
+            collectionAccessor: DomAccessorHTMLSelectElement.Instance));
 
         HTMLSlotElement = Add(new DomInterfaceDefinition(
             "HTMLSlotElement",

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -354,7 +354,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.after");
-                    self.Target.After(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "CharacterData.after")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.After(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "CharacterData.after")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Method("appendData",
@@ -368,7 +368,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.before");
-                    self.Target.Before(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "CharacterData.before")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Before(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "CharacterData.before")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("data",
@@ -432,7 +432,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.replaceWith", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.replaceWith");
-                    self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "CharacterData.replaceWith")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Replace(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "CharacterData.replaceWith")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Method("substringData",
@@ -661,7 +661,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.append", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.append");
-                    self.Target.Append(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Document.append")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Append(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Document.append")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("body",
@@ -1080,7 +1080,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.prepend", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.prepend");
-                    self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Document.prepend")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Document.prepend")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Method("queryCommandEnabled",
@@ -1224,7 +1224,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.append", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.append");
-                    self.Target.Append(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentFragment.append")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Append(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "DocumentFragment.append")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("childElementCount",
@@ -1262,7 +1262,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.prepend", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.prepend");
-                    self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentFragment.prepend")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "DocumentFragment.prepend")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Method("querySelector",
@@ -1290,14 +1290,14 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.after");
-                    self.Target.After(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentType.after")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.After(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "DocumentType.after")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Method("before",
                 global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.before");
-                    self.Target.Before(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentType.before")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Before(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "DocumentType.before")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("name",
@@ -1323,7 +1323,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.replaceWith", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.replaceWith");
-                    self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "DocumentType.replaceWith")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Replace(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "DocumentType.replaceWith")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("systemId",
@@ -1344,14 +1344,14 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Element.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.after");
-                    self.Target.After(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.after")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.After(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Element.after")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Method("append",
                 global::Jint.Browser.Dom.DomFailures.Guard("Element.append", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.append");
-                    self.Target.Append(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.append")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Append(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Element.append")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("assignedSlot",
@@ -1377,7 +1377,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Element.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.before");
-                    self.Target.Before(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.before")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Before(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Element.before")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("childElementCount",
@@ -1648,7 +1648,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Element.prepend", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.prepend");
-                    self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.prepend")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Prepend(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Element.prepend")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("previousElementSibling",
@@ -1703,7 +1703,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Element.replaceWith", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.replaceWith");
-                    self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, "Element.replaceWith")); return global::Jint.Native.JsValue.Undefined;
+                    self.Target.Replace(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Element.replaceWith")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
             .Accessor("scrollHeight",

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -1077,7 +1077,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("formAction",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.formAction", static (thisObj, args) =>
@@ -1533,7 +1533,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlFieldSetElement>(thisObj, "HTMLFieldSetElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("name",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLFieldSetElement.name", static (thisObj, args) =>
@@ -2179,7 +2179,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("formAction",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formAction", static (thisObj, args) =>
@@ -2600,7 +2600,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlKeygenElement>(thisObj, "HTMLKeygenElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("keytype",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLKeygenElement.keytype", static (thisObj, args) =>
@@ -2696,7 +2696,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLLabelElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLabelElement>(thisObj, "HTMLLabelElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("htmlFor",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLLabelElement.htmlFor", static (thisObj, args) =>
@@ -2720,7 +2720,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLLegendElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLegendElement>(thisObj, "HTMLLegendElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Build();
 
@@ -3313,7 +3313,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("height",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.height", static (thisObj, args) =>
@@ -3468,7 +3468,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionElement>(thisObj, "HTMLOptionElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("index",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionElement.index", static (thisObj, args) =>
@@ -3531,7 +3531,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLOptionsCollection.add", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsCollection>(thisObj, "HTMLOptionsCollection.add");
-                    self.Target.Add(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlOptionElement>(args, 0, "HTMLOptionsCollection.add"), global::Jint.Browser.Dom.DomBindings.NullableArgument<global::AngleSharp.Html.Dom.IHtmlElement>(args, 1, "HTMLOptionsCollection.add")); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomUnionMembers.OptionsAdd(self, args);
                 }),
                 length: 1)
             .Method("remove",
@@ -3581,7 +3581,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("htmlFor",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.htmlFor", static (thisObj, args) =>
@@ -3901,7 +3901,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.add", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.add");
-                    self.Target.AddOption(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Html.Dom.IHtmlOptionElement>(args, 0, "HTMLSelectElement.add"), global::Jint.Browser.Dom.DomBindings.NullableArgument<global::AngleSharp.Html.Dom.IHtmlElement>(args, 1, "HTMLSelectElement.add")); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomUnionMembers.SelectAdd(self, args);
                 }),
                 length: 1)
             .Accessor("autofocus",
@@ -3937,7 +3937,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("labels",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.labels", static (thisObj, args) =>
@@ -4596,7 +4596,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.form", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.form");
-                    return self.Realm.WrapNodeValue(self.Target.Form);
+                    return self.Realm.Wrap(self.Target.Form);
                 }))
             .Accessor("labels",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.labels", static (thisObj, args) =>

--- a/Jint.Tests.Browser/DomBindingsStalenessTests.cs
+++ b/Jint.Tests.Browser/DomBindingsStalenessTests.cs
@@ -67,18 +67,17 @@ public sealed class DomBindingsStalenessTests
     }
 
     [Test]
-    public void TheGeneratorReportsOnlyTheTwoDiagnosticsWeKnowAbout()
+    public void TheGeneratorReportsNoDiagnostics()
     {
-        // Both are one WebIDL member spelled as two CLR overloads with the same [DomName] — HTML's
-        // `select.add((HTMLOptionElement or HTMLOptGroupElement) element, …)` is a union type, and AngleSharp
-        // models it as two methods. The binding takes one of them, so `select.add(optgroup)` is a TypeError
-        // where a browser accepts it. It is a limitation with a name, which is why it is pinned here: a THIRD
-        // diagnostic means the generator found something nobody has looked at.
-        Generate().Diagnostics.Should().BeEquivalentTo(
-        [
-            "HTMLOptionsCollection.add is declared more than once in the interface closure; the first declaration wins (IHtmlOptionsCollection.Add lost).",
-            "HTMLSelectElement.add is declared more than once in the interface closure; the first declaration wins (IHtmlSelectElement.AddOption lost).",
-        ]);
+        // It used to report two, and both were the same thing: one WebIDL member spelled as two CLR overloads
+        // sharing a [DomName] — HTML's `select.add((HTMLOptionElement or HTMLOptGroupElement) element, …)` is
+        // a union type and AngleSharp models it as two methods, so one half always lost and
+        // `select.add(optgroup)` was a TypeError where a browser accepts it. Both are `skip` + `additions`
+        // entries over DomUnionMembers now, which is what turns the collision into a decision.
+        //
+        // Empty is therefore the assertion, and it is a stronger one than a pinned list: ANY diagnostic means
+        // the generator found something nobody has looked at.
+        Generate().Diagnostics.Should().BeEmpty();
     }
 
     [Test]

--- a/Jint.Tests.Browser/DomIndexedNodeTests.cs
+++ b/Jint.Tests.Browser/DomIndexedNodeTests.cs
@@ -1,0 +1,150 @@
+namespace Jint.Tests.Browser;
+
+/// <summary>
+/// The two nodes whose interface also supports indexed or named properties, and the union-typed operations
+/// AngleSharp spells as two overloads.
+/// </summary>
+/// <remarks>
+/// A node's wrapper is what the engine's tree-dispatch lane keys on and the wrapper cache keeps exactly one
+/// per node, so a form cannot be an <c>ArrayLikeObject</c> without ceasing to be an <c>EventTarget</c> the
+/// dispatcher can walk. <c>DomIndexedNodeObject</c> is the answer: a node wrapper with the interface's
+/// generated projection on top, which is why the last test here is about dispatch rather than about
+/// properties.
+/// </remarks>
+public sealed class DomIndexedNodeTests
+{
+    private const string Page = """
+        <form id="f">
+          <input name="username" id="u" value="ada">
+          <input name="password" type="password">
+        </form>
+        <select id="s"><option value="a">A</option><option value="b">B</option></select>
+        """;
+
+    [Test]
+    public void AFormAnswersItsControlsByIndexAndByName()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        // https://html.spec.whatwg.org/multipage/forms.html#dom-form-item and #dom-form-nameditem
+        fixture.Text("document.getElementById('f')[0].name").Should().Be("username");
+        fixture.Text("document.getElementById('f')[1].name").Should().Be("password");
+        fixture.Text("document.getElementById('f').username.value").Should().Be("ada");
+        fixture.Text("document.getElementById('f').u.name").Should().Be("username", "an id is a supported name too");
+        fixture.Evaluate("document.getElementById('f').nope").IsUndefined().Should().BeTrue();
+
+        // The same values the collection beside it carries, which is what a page used to have to reach for.
+        fixture.Bool("document.getElementById('f')[0] === document.getElementById('f').elements[0]").Should().BeTrue();
+        fixture.Bool("document.getElementById('f').username === document.getElementById('f').elements.namedItem('username')").Should().BeTrue();
+    }
+
+    [Test]
+    public void ASelectAnswersItsOptionsByIndex()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-item
+        fixture.Text("document.getElementById('s')[1].value").Should().Be("b");
+        fixture.Evaluate("document.getElementById('s')[9]").IsUndefined().Should().BeTrue();
+
+        // An indexed getter is all HTML gives a select, so a name is nothing special on it.
+        fixture.Evaluate("document.getElementById('s').a").IsUndefined().Should().BeTrue();
+
+        // The Array.prototype generics reach it through the projection, index by index.
+        fixture.Text("Array.prototype.map.call(document.getElementById('s'), o => o.value).join(',')").Should().Be("a,b");
+    }
+
+    [Test]
+    public void TheProjectedPropertiesAreCoherentWithEveryWayOfAskingAboutThem()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        // The obligation Jint/Native/Object/AGENTS.md states: a name GetOwnProperty answers has to be a name
+        // GetOwnPropertyKeys lists, or hasOwnProperty and getOwnPropertyNames disagree about one object.
+        fixture.Text("JSON.stringify(Object.getOwnPropertyNames(document.getElementById('f')))")
+            .Should().Be("[\"0\",\"1\",\"username\",\"u\",\"password\"]");
+        fixture.Bool("document.getElementById('f').hasOwnProperty('username')").Should().BeTrue();
+        fixture.Bool("'username' in document.getElementById('f')").Should().BeTrue();
+        fixture.Bool("'nope' in document.getElementById('f')").Should().BeFalse();
+
+        // https://webidl.spec.whatwg.org/#legacy-platform-object-getownproperty — a supported index with no
+        // setter is read-only, so an assignment is refused rather than shadowing the projection.
+        fixture.Bool("Object.getOwnPropertyDescriptor(document.getElementById('f'), '0').writable").Should().BeFalse();
+        fixture.Bool("Object.getOwnPropertyDescriptor(document.getElementById('f'), '0').configurable").Should().BeTrue();
+        fixture.Execute("document.getElementById('f')[0] = 5;");
+        fixture.Text("document.getElementById('f')[0].name").Should().Be("username");
+
+        // An expando is still an ordinary own property, and it enumerates after the projection.
+        fixture.Execute("document.getElementById('f').expando = 1;");
+        fixture.Text("Object.keys(document.getElementById('f')).join(',')").Should().Be("0,1,username,u,password,expando");
+    }
+
+    [Test]
+    public void AProjectedNodeIsStillANodeAndAnEventTarget()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        // The whole reason the projection rides on the node wrapper rather than replacing it.
+        fixture.Bool("document.getElementById('f') instanceof HTMLFormElement").Should().BeTrue();
+        fixture.Bool("document.getElementById('f') instanceof EventTarget").Should().BeTrue();
+        fixture.Text("document.getElementById('f').nodeName").Should().Be("FORM");
+        fixture.Bool("document.getElementById('f') === document.forms[0]").Should().BeTrue("a node keeps one wrapper");
+
+        fixture.Number("""
+            (function () {
+              let hits = 0;
+              const form = document.getElementById('f');
+              form.addEventListener('probe', () => hits++);
+              form.querySelector('input').dispatchEvent(new Event('probe', { bubbles: true }));
+              return hits;
+            })()
+            """).Should().Be(1, "the event path still walks up through the form");
+    }
+
+    [Test]
+    public void AUnionTypedOperationTakesBothArmsOfItsUnion()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-add —
+        // `(HTMLOptionElement or HTMLOptGroupElement)`, which AngleSharp models as two overloads sharing one
+        // [DomName]. The generator binds one member per name, so the optgroup arm used to be a TypeError.
+        fixture.Execute("const g = document.createElement('optgroup'); g.label = 'G'; document.getElementById('s').add(g);");
+        fixture.Text("document.getElementById('s').lastElementChild.tagName").Should().Be("OPTGROUP");
+
+        fixture.Execute("const o = document.createElement('option'); o.value = 'c'; document.getElementById('s').add(o);");
+        fixture.Number("document.getElementById('s').options.length").Should().Be(3);
+
+        // The same union on HTMLOptionsCollection.
+        fixture.Execute("document.getElementById('s').options.add(document.createElement('optgroup'));");
+        fixture.Number("document.getElementById('s').querySelectorAll('optgroup').length").Should().Be(2);
+
+        // An argument that is neither arm is still WebIDL's conversion failure.
+        fixture.Text("(() => { try { document.getElementById('s').add(document.createElement('div')); return 'accepted'; } catch (e) { return e.name; } })()")
+            .Should().Be("TypeError");
+    }
+
+    [Test]
+    public void AVariadicNodeParameterTakesStringsAsTextNodes()
+    {
+        using var fixture = DomTestFixture.Create("<div id='a'></div><p id='b'>x</p>");
+
+        // https://dom.spec.whatwg.org/#converting-nodes-into-a-node — `(Node or DOMString)...`, where the
+        // string half becomes a Text node in the receiver's node document. AngleSharp's signature is INode[],
+        // so a string argument used to be a TypeError where a browser inserts text.
+        fixture.Execute("document.getElementById('a').append('one', document.createElement('span'), 2);");
+        fixture.Text("document.getElementById('a').innerHTML").Should().Be("one<span></span>2");
+        fixture.Number("document.getElementById('a').childNodes.length").Should().Be(3);
+        fixture.Number("document.getElementById('a').firstChild.nodeType").Should().Be(3, "a text node");
+
+        fixture.Execute("document.getElementById('b').before('lead');");
+        fixture.Text("document.getElementById('b').previousSibling.data").Should().Be("lead");
+
+        fixture.Execute("document.getElementById('a').prepend('first');");
+        fixture.Text("document.getElementById('a').firstChild.data").Should().Be("first");
+
+        // A DocumentFragment is a node document's too, so the same conversion reaches it.
+        fixture.Text("(() => { const f = new DocumentFragment(); f.append('in a fragment'); return f.textContent; })()")
+            .Should().Be("in a fragment");
+    }
+}

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -26,11 +26,11 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | Suite | Documents | Synthesized | Tests | Not passing |
 | --- | --- | --- | --- | --- |
 | `dom/events/` | 56 | 9 | 544 | 20 |
-| `dom/nodes/` | 159 | 0 | 4,796 | 1,416 |
+| `dom/nodes/` | 159 | 0 | 4,796 | 1,336 |
 | `dom/collections/` | 8 | 0 | 43 | 18 |
 | `dom/lists/` | 5 | 0 | 189 | 5 |
 | `dom/traversal/` | 13 | 0 | 52 | 7 |
-| `dom/ranges/` | 17 | 0 | 82 | 10 |
+| `dom/ranges/` | 17 | 0 | 82 | 8 |
 | `html/dom/` | 6 | 0 | 4,962 | 31 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 12 |
@@ -38,7 +38,7 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 68 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **341** | **9** | **11,541** | **1,853** |
+| **total** | **341** | **9** | **11,541** | **1,771** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -172,7 +172,7 @@ They arrived together, 207 documents and 5,247 tests, and **1,532 of those tests
 much worse ratio than any suite already here, and it should be: `dom/events/` is one interface's dispatch,
 where these are every member of every node interface.
 
-The failures are **seventeen distinct causes**, and the table names each of them test by test. Ten of them
+The failures are **sixteen distinct causes**, and the table names each of them test by test. Nine of them
 were filed as [#3765](https://github.com/sebastienros/jint/issues/3765)–[#3774](https://github.com/sebastienros/jint/issues/3774); the counts move as those are fixed.
 The eighteenth was [#3712](https://github.com/sebastienros/jint/issues/3712), a nullable `DOMString` argument
 answering the string `"null"`, and it is fixed here: the 23 rows it accounted for — `createElementNS(null,

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -1118,34 +1118,7 @@ internal static class WptBrowserExclusions
 
         // ---------------------------------------------------------------- a (Node or DOMString) union parameter takes only a Node
         // a (Node or DOMString) union parameter takes only a Node
-        new("dom/nodes/ChildNode-after.html", "*null as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-after.html", "*string as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-after.html", "*text as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-after.html", "*text as arguments.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-after.html", "*the argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-after.html", "*undefined as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-before.html", "*null as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-before.html", "*string as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-before.html", "*text as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-before.html", "*text as arguments.", WptDivergence.NeedsTriage),
         new("dom/nodes/ChildNode-before.html", "*the argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-before.html", "*undefined as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-replaceWith.html", "*with empty string as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-replaceWith.html", "*with null as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-replaceWith.html", "*with one element and text as arguments.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-replaceWith.html", "*with one sibling of child and text as arguments.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-replaceWith.html", "*with only text as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-replaceWith.html", "*with undefined as an argument.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ParentNode-append.html", "*a child.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ParentNode-append.html", "*null as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ParentNode-append.html", "*text as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ParentNode-append.html", "*undefined as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ParentNode-prepend.html", "*a child.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ParentNode-prepend.html", "*null as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ParentNode-prepend.html", "*text as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
-        new("dom/nodes/ParentNode-prepend.html", "*undefined as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
-        new("dom/ranges/StaticRange-constructor.html", "Construct static range with DocumentFragment container", WptDivergence.NeedsTriage),
-        new("dom/ranges/StaticRange-constructor.html", "Construct static range with endpoints in disconnected trees", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- DOM's validate-and-extract, and the XML name productions
         // DOM's validate-and-extract, and the XML name productions
@@ -1268,7 +1241,6 @@ internal static class WptBrowserExclusions
         // inserted namespaced attribute records no prefix, and IChildNode.Replace converts its arguments
         // before it checks whether the child has a parent at all.
         new("dom/nodes/Attr-prefix.html", "Attr.prefix present (SVG)", WptDivergence.NeedsTriage),
-        new("dom/nodes/ChildNode-replaceWith.html", "*on a parentless child with two elements as arguments.", WptDivergence.NeedsTriage),
         new("dom/nodes/ChildNode-replaceWith.html", "*with one sibling of child and child itself as arguments.", WptDivergence.NeedsTriage),
         new("dom/nodes/Document-importNode.html", "*'deep' argument.", WptDivergence.NeedsTriage),
         new("dom/nodes/attributes.html", "Basic functionality of getAttributeNode/getAttributeNodeNS", WptDivergence.NeedsTriage),

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/Conversions.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/Conversions.cs
@@ -223,6 +223,16 @@ internal sealed class Conversions
                 return true;
             }
 
+            // https://dom.spec.whatwg.org/#converting-nodes-into-a-node - a variadic Node parameter is Web
+            // IDL's `(Node or DOMString)...`, and the string half becomes a text node in the receiver's node
+            // document. The receiver is in scope in every emitted body, which is the whole of what this
+            // needed: a static member body has no document until it is handed one.
+            if (element.FullName == "AngleSharp.Dom.INode")
+            {
+                code = "global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, " + index + ", " + CSharpNames.Literal(member) + ")";
+                return true;
+            }
+
             if (element.IsInterface && _lookup(element) is not null)
             {
                 code = "global::Jint.Browser.Dom.DomConvert.ObjectRest<" + CSharpNames.Render(element) + ">(args, " + index + ", " + CSharpNames.Literal(member) + ")";

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/Model.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/Model.cs
@@ -7,6 +7,7 @@ internal enum WrapperKind
 {
     Object,
     Node,
+    IndexedNode,
     Collection,
     NamedMap,
     HtmlCollection,

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
@@ -320,7 +320,13 @@ internal sealed class ModelBuilder
     {
         if (type.GetInterfaces().Any(i => i.FullName == "AngleSharp.Dom.INode") || type.FullName == "AngleSharp.Dom.INode")
         {
-            return WrapperKind.Node;
+            // A node that also supports indexed or named properties. HTML gives two of them a getter -
+            // `form[0]` / `form.username` and `select[0]` - and the projection has to ride on the node
+            // wrapper, because a node's wrapper is what the tree-dispatch lane keys on and there is only
+            // ever one of it per node.
+            return FindIndexedGetter(type) is not null || FindNamedGetter(type) is not null
+                ? WrapperKind.IndexedNode
+                : WrapperKind.Node;
         }
 
         if (type.FullName == "AngleSharp.Dom.IHtmlCollection`1"
@@ -434,8 +440,16 @@ internal sealed class ModelBuilder
             {
                 if (!seen.Add(domName))
                 {
-                    _model.Diagnostics.Add(
-                        model.DomName + "." + domName + " is declared more than once in the interface closure; the first declaration wins (" + declaring.Name + "." + member.Name + " lost).");
+                    // A member the table has taken over is not news: `skip` means the projection of every
+                    // declaration under that name is replaced, so a second one losing is the decision rather
+                    // than a consequence of it. HTML's two union operations are exactly that, and a
+                    // collision anywhere else is still something nobody has looked at.
+                    if (!_overrides.Skip.Any(entry => entry.Interface == model.DomName && entry.Member == domName && entry.Half is null))
+                    {
+                        _model.Diagnostics.Add(
+                            model.DomName + "." + domName + " is declared more than once in the interface closure; the first declaration wins (" + declaring.Name + "." + member.Name + " lost).");
+                    }
+
                     continue;
                 }
 
@@ -729,11 +743,11 @@ internal sealed class ModelBuilder
             {
                 if (model.Kind is WrapperKind.Node)
                 {
-                    // An indexed or named getter needs a property projection, and a node wrapper is a
-                    // JsEventTarget rather than an ArrayLikeObject, so it has none. `form[0]` and
-                    // `form.username` are the two that lose by it; `form.elements[0]` and
-                    // `form.elements.namedItem('username')` are the same values through the collection.
-                    _model.Skipped.Add(new SkipRecord(model.DomName, domName, "is an indexed or named getter on a node, and a node wrapper carries no property projection; the collection member beside it carries the same values"));
+                    // A node whose interface declares an indexed or named getter is an IndexedNode and
+                    // carries the projection; a plain Node reaching here would be one whose getter the
+                    // conversion table could not express, and the collection member beside it carries the
+                    // same values.
+                    _model.Skipped.Add(new SkipRecord(model.DomName, domName, "is an indexed or named getter the conversion table could not project; the collection member beside it carries the same values"));
                     return;
                 }
 
@@ -1102,7 +1116,7 @@ internal sealed class ModelBuilder
 
     private void BuildAccessor(InterfaceModel model)
     {
-        if (model.Kind is not (WrapperKind.Collection or WrapperKind.NamedMap))
+        if (model.Kind is not (WrapperKind.Collection or WrapperKind.NamedMap or WrapperKind.IndexedNode))
         {
             return;
         }
@@ -1115,7 +1129,7 @@ internal sealed class ModelBuilder
         builder.Append("internal sealed class ").Append(className).Append(" : DomCollectionAccessor\n{\n");
         builder.Append("    internal static readonly ").Append(className).Append(" Instance = new();\n\n");
 
-        if (model.Kind == WrapperKind.Collection)
+        if (model.Kind is WrapperKind.Collection or WrapperKind.IndexedNode && FindIndexedGetter(model.ClrType) is not null)
         {
             var length = FindLength(model.ClrType);
             var indexed = FindIndexedGetter(model.ClrType)!;
@@ -1130,17 +1144,21 @@ internal sealed class ModelBuilder
                 ? readOnlyList.GetGenericArguments()[0]
                 : indexed.PropertyType;
 
+            // A node keeps its node wrapper whatever happens here, because the tree-dispatch lane keys on it;
+            // only the projection is lost.
+            var fallback = model.Kind == WrapperKind.IndexedNode ? WrapperKind.Node : WrapperKind.Object;
+
             if (length is null)
             {
-                _model.Diagnostics.Add(model.DomName + " has an indexed getter but no length; it is wrapped as a plain object instead.");
-                model.Kind = WrapperKind.Object;
+                _model.Diagnostics.Add(model.DomName + " has an indexed getter but no length; its indexed properties are dropped.");
+                model.Kind = fallback;
                 return;
             }
 
             if (!_conversions.TryReturn(elementType, access, "realm", nullableString: false, out var element, out var reason))
             {
-                _model.Diagnostics.Add(model.DomName + " has an indexed getter whose element " + reason + "; it is wrapped as a plain object instead.");
-                model.Kind = WrapperKind.Object;
+                _model.Diagnostics.Add(model.DomName + " has an indexed getter whose element " + reason + "; its indexed properties are dropped.");
+                model.Kind = fallback;
                 return;
             }
 
@@ -1205,7 +1223,29 @@ internal sealed class ModelBuilder
             // non-enumerable rather than hidden.
             var length = FindLength(model.ClrType);
             var itemName = ItemNameProperty(model.ClrType);
-            if (length is null || itemName is null)
+
+            // https://html.spec.whatwg.org/multipage/forms.html#dom-form-item - a form's supported property
+            // names are the `name` content attributes and the ids of its listed elements, in tree order, and
+            // an element carries neither as a [DomName] member the heuristic above could find: `name` is a
+            // content attribute rather than an IDL one on IElement. It is the one named getter over elements
+            // in the surface, so the rule is written once, here, rather than made a table entry.
+            var elementItems = FindIndexedGetter(model.ClrType) is { } indexedGetter
+                && Closure(indexedGetter.PropertyType).Any(t => t.FullName == "AngleSharp.Dom.IElement");
+
+            if (length is not null && itemName is null && elementItems)
+            {
+                builder.Append("    internal override global::System.Collections.Generic.IReadOnlyList<string> SupportedNames(object target)\n    {\n");
+                builder.Append("        var collection = (").Append(target).Append(") target;\n");
+                builder.Append("        var names = new global::System.Collections.Generic.List<string>(collection.").Append(length.Name).Append(");\n");
+                builder.Append("        for (var i = 0; i < collection.").Append(length.Name).Append("; i++)\n        {\n");
+                builder.Append("            var item = collection[i];\n");
+                builder.Append("            if (item is null)\n            {\n                continue;\n            }\n\n");
+                builder.Append("            Add(names, item.GetAttribute(\"name\"));\n");
+                builder.Append("            Add(names, item.Id);\n        }\n\n        return names;\n\n");
+                builder.Append("        static void Add(global::System.Collections.Generic.List<string> names, string? name)\n        {\n");
+                builder.Append("            if (!string.IsNullOrEmpty(name) && !names.Contains(name!))\n            {\n                names.Add(name!);\n            }\n        }\n    }\n\n");
+            }
+            else if (length is null || itemName is null)
             {
                 builder.Append("    internal override global::System.Collections.Generic.IReadOnlyList<string> SupportedNames(object target) => [];\n\n");
             }
@@ -1218,7 +1258,12 @@ internal sealed class ModelBuilder
                 builder.Append("            names.Add(collection[i]!.").Append(itemName.Name).Append(");\n        }\n\n        return names;\n    }\n\n");
             }
 
-            builder.Append("    internal override bool AreNamesEnumerable => false;\n\n");
+            // https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties, which NamedNodeMap and
+            // HTMLCollection carry and HTMLFormElement does not: a form's named properties enumerate.
+            if (!elementItems)
+            {
+                builder.Append("    internal override bool AreNamesEnumerable => false;\n\n");
+            }
         }
 
         builder.Append("    internal override bool TryGetNamed(DomRealm realm, object target, string name, out global::Jint.Native.JsValue value)\n    {\n");

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -24,6 +24,16 @@
   ],
   "skip": [
     {
+      "interface": "HTMLSelectElement",
+      "member": "add",
+      "reason": "HTML's `add((HTMLOptionElement or HTMLOptGroupElement) element, ...)` is a union, and AngleSharp models it as two AddOption overloads sharing one [DomName]. The generator binds one member per name, so one half would always lose; re-declared in `additions` over a body that dispatches on the argument's interface."
+    },
+    {
+      "interface": "HTMLOptionsCollection",
+      "member": "add",
+      "reason": "The same union on the collection, and the same two overloads."
+    },
+    {
       "interface": "Document",
       "member": "querySelector",
       "reason": "DOM requires a SyntaxError DOMException for a selector that cannot be parsed, and a page has to be able to catch it -- jQuery's own support detection asks for `:has(*,:jqfake)` inside a try. AngleSharp raises a CLR AngleSharp.Dom.DomException instead, which walks through a script's catch and out of the page loop, and AngleSharp.Css NREs outright on that input. Re-declared in `additions` over the same AngleSharp call, wrapped so that the failure is the DOMException the standard names."
@@ -246,6 +256,28 @@
     }
   ],
   "additions": [
+    {
+      "interface": "HTMLSelectElement",
+      "member": "add",
+      "kind": "operation",
+      "length": 1,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, \"HTMLSelectElement.add\");",
+        "return global::Jint.Browser.Dom.DomUnionMembers.SelectAdd(self, args);"
+      ],
+      "reason": "The other half of the skip above: both arms of the union, dispatched on the argument's interface."
+    },
+    {
+      "interface": "HTMLOptionsCollection",
+      "member": "add",
+      "kind": "operation",
+      "length": 1,
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOptionsCollection>(thisObj, \"HTMLOptionsCollection.add\");",
+        "return global::Jint.Browser.Dom.DomUnionMembers.OptionsAdd(self, args);"
+      ],
+      "reason": "The other half of the skip above, on the collection."
+    },
     {
       "interface": "Node",
       "member": "getRootNode",
@@ -1074,7 +1106,7 @@
       "length": 0,
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, \"CharacterData.replaceWith\");",
-        "self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, \"CharacterData.replaceWith\")); return global::Jint.Native.JsValue.Undefined;"
+        "self.Target.Replace(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, \"CharacterData.replaceWith\")); return global::Jint.Native.JsValue.Undefined;"
       ],
       "reason": "DOM §4.2.7 names it `replaceWith` and AngleSharp's IChildNode carries [DomName(\"replace\")], so the mixin projected a member the standard does not have under a name it does not use. Re-declared in `additions` over the same call; the divergence is in Dom/AGENTS.md's table."
     },
@@ -1085,7 +1117,7 @@
       "length": 0,
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, \"DocumentType.replaceWith\");",
-        "self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, \"DocumentType.replaceWith\")); return global::Jint.Native.JsValue.Undefined;"
+        "self.Target.Replace(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, \"DocumentType.replaceWith\")); return global::Jint.Native.JsValue.Undefined;"
       ],
       "reason": "DOM §4.2.7 names it `replaceWith` and AngleSharp's IChildNode carries [DomName(\"replace\")], so the mixin projected a member the standard does not have under a name it does not use. Re-declared in `additions` over the same call; the divergence is in Dom/AGENTS.md's table."
     },
@@ -1096,7 +1128,7 @@
       "length": 0,
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, \"Element.replaceWith\");",
-        "self.Target.Replace(global::Jint.Browser.Dom.DomConvert.ObjectRest<global::AngleSharp.Dom.INode>(args, 0, \"Element.replaceWith\")); return global::Jint.Native.JsValue.Undefined;"
+        "self.Target.Replace(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, \"Element.replaceWith\")); return global::Jint.Native.JsValue.Undefined;"
       ],
       "reason": "DOM §4.2.7 names it `replaceWith` and AngleSharp's IChildNode carries [DomName(\"replace\")], so the mixin projected a member the standard does not have under a name it does not use. Re-declared in `additions` over the same call; the divergence is in Dom/AGENTS.md's table."
     },


### PR DESCRIPTION
Sits on **#3776** (issue #3656) → **#3761** (#3712) → **#3753** (#3636). Review bottom-up.

## What was wrong

```js
el.append('text')                 // TypeError  (a browser inserts a text node)
select.add(optgroup)              // TypeError  (a browser accepts it)
form[0], form.username, select[0] // undefined
```

## What changed

**`(Node or DOMString)...`.** AngleSharp's signature is `INode[]`, and the string half of the union needs a document to create a `Text` node against — which a static member body had no way to reach. It had one all along: the *receiver* is in scope in every emitted body. `DomConvert.NodeOrTextRest` stringifies a non-node argument and creates the node in the receiver's node document; the generator selects it for any variadic `INode` parameter, which is `append`, `prepend`, `before`, `after` and `replace` across `Element`, `Document`, `DocumentFragment`, `CharacterData` and `DocumentType`.

**The two union-typed operations.** `select.add` and `HTMLOptionsCollection.add` are `(HTMLOptionElement or HTMLOptGroupElement)`, which AngleSharp models as two overloads sharing one `[DomName]`, so one arm always lost. They are `skip` + `additions` entries over `DomUnionMembers` now, dispatching on the argument's interface most-derived-first, with an argument that is neither arm still Web IDL's conversion failure. A `skip` also suppresses the duplicate-declaration diagnostic — a member the table has taken over is a decision, not news — so the generator now reports **no** diagnostics at all, and `DomBindingsStalenessTests` asserts emptiness, which is a stronger claim than the two it used to pin.

**`form[0]`, `form.username`, `select[0]`.** A node wrapper is a `JsEventTarget` and carried no property projection; it cannot become an `ArrayLikeObject` either, because the tree-dispatch lane keys on the node wrapper and the cache keeps exactly one per node — a form that became a collection would stop being an `EventTarget` the dispatcher can walk. So `Collections/DomIndexedNodeObject` is a node wrapper with the interface's *generated* accessor projected on top, behind three overrides (`GetOwnProperty`, `ProbeOwnProperty`, `GetOwnPropertyKeys`) that all read the accessor at the same instant — which is what keeps `hasOwnProperty` and `Object.getOwnPropertyNames` agreeing about one object, the obligation `Jint/Native/Object/AGENTS.md` states. Overriding `GetOwnProperty` and **not** `Get` keeps the receiver on the engine's ordinary property-access lane, so an inherited member still resolves in one probe and the prototype-method cache still serves it.

`HTMLFormElement`'s supported property names are computed rather than read from metadata: HTML makes them the `name` content attributes and the ids of the form's listed elements, and `name` is not an IDL member of `IElement` at all, so no `[DomName]` heuristic could have found it. It is the one named getter over elements in the surface, so the rule is written once in the emitter.

## Tests

`Jint.Tests.Browser/DomIndexedNodeTests` — six tests: a form by index and by name (including by id, and identical to what `form.elements` answers), a select by index and through the `Array.prototype` generics, the coherence of every way of asking about a projected property plus read-only indices and expandos, that a projected node is still a node whose event path works, both arms of both unions plus the failure for neither, and strings becoming text nodes through `append`/`prepend`/`before` and on a `DocumentFragment`.

Regenerated with `JINT_DOM_BINDINGS=update`; staleness test green. `Jint.Tests.Browser` 1225 net10.0 / 1222 net8.0 green — **the wpt browser lane needed no exclusion or census edit for this PR**. The `Shape|MigrationGuide|AgentInstructionFile|SpecCitation` filter (210) and `Jint.Tests.SourceGenerators` (71) green. No engine API changed, so no migration-guide row.

## What was left out

- **The three items are one commit, not three.** They share one regenerated artefact (`DomShapes.*.g.cs`, `DomInterfaces.g.cs`, `DomCollectionAccessors.g.cs`), so splitting them would have produced intermediate commits whose checked-in bindings did not match their emitter — which is exactly what the staleness test exists to forbid. The commit body separates the three.
- **A found divergence, not fixed here:** AngleSharp spells DOM's `ChildNode.replaceWith` as `replace`, so `el.replaceWith(x)` is `undefined` and `el.replace(x)` is the member. It is three `additions` rows to alias, and it is not on this issue's list; recorded for the lead.
- A form's named properties are the elements' `name` and `id`; HTML's rule also scopes them to *listed* elements, and AngleSharp's indexer decides what the form contains. Whatever it contains is what enumerates, which is one source of truth rather than two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
