### PR TITLE
Interop: a params overload is chosen by the array's element type, and a failing element declines instead of throwing (#3764)

### DIFF
--- a/Jint.Tests.PublicInterface/HostArrayElementOverloadTests.cs
+++ b/Jint.Tests.PublicInterface/HostArrayElementOverloadTests.cs
@@ -1,0 +1,302 @@
+#nullable enable
+
+using System.Globalization;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Overload candidates that differ only in the element type of an array or collection parameter are chosen
+/// by that element type, and an element the conversion cannot perform declines instead of throwing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>params</c> call bundles its trailing arguments into one JavaScript array before scoring, so scoring
+/// saw a single argument against <c>CDecimal[]</c>, <c>CInteger[]</c> and <c>CLong[]</c> alike and answered a
+/// blanket "is an array, wants an array" for every one of them. Every candidate tied, the converter probe
+/// below that rule — the rule that would have declined <c>CInteger -&gt; CDecimal</c> — was never reached, and
+/// declaration order decided. Where the first-declared candidate happened to be convertible the wrong
+/// overload answered silently; where it was not, the conversion's <see cref="InvalidCastException"/> left
+/// through the embedder's <c>Evaluate</c>, because the composite branches of <c>TryConvert</c> converted their
+/// parts through the throwing <c>Convert</c> and so escaped the candidate loop that exists to move on.
+/// </para>
+/// <para>
+/// <see href="https://github.com/sebastienros/jint/issues/3754">#3754</see>, reported in
+/// <see href="https://github.com/sebastienros/jint/discussions/3746">discussion #3746</see>; the
+/// same shape as <see href="https://github.com/sebastienros/jint/issues/3407">#3407</see>, one level down —
+/// a score that claims a binding the conversion cannot perform.
+/// </para>
+/// </remarks>
+public class HostArrayElementOverloadTests
+{
+    // Three unrelated host classes, none of them IConvertible and none declaring a conversion to any other:
+    // exactly the shape of the report, where nothing but the element type tells the overloads apart.
+
+    public sealed class CDecimal
+    {
+        public CDecimal(decimal value) => Value = value;
+
+        public decimal Value { get; }
+
+        public string Kind => nameof(CDecimal);
+    }
+
+    public sealed class CInteger
+    {
+        public CInteger(int value) => Value = value;
+
+        public int Value { get; }
+
+        public string Kind => nameof(CInteger);
+    }
+
+    public sealed class CLong
+    {
+        public CLong(long value) => Value = value;
+
+        public long Value { get; }
+
+        public string Kind => nameof(CLong);
+    }
+
+    public sealed class MathHost
+    {
+        public CDecimal Add(params CDecimal[] args)
+        {
+            decimal sum = 0;
+            foreach (var arg in args)
+            {
+                sum += arg.Value;
+            }
+
+            return new CDecimal(sum);
+        }
+
+        public CInteger Add(params CInteger[] args)
+        {
+            var sum = 0;
+            foreach (var arg in args)
+            {
+                sum += arg.Value;
+            }
+
+            return new CInteger(sum);
+        }
+
+        public CLong Add(params CLong[] args)
+        {
+            long sum = 0;
+            foreach (var arg in args)
+            {
+                sum += arg.Value;
+            }
+
+            return new CLong(sum);
+        }
+    }
+
+    /// <summary>Both elements convert to both parameter types; only the score can tell the two apart.</summary>
+    public sealed class StringDeclaredFirst
+    {
+        public string Join(params string[] values) => string.Concat(values);
+
+        public string Join(params int[] values)
+        {
+            var sum = 0;
+            foreach (var value in values)
+            {
+                sum += value;
+            }
+
+            return sum.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+
+    /// <summary>The same pair in the opposite declaration order.</summary>
+    public sealed class IntDeclaredFirst
+    {
+        public string Join(params int[] values)
+        {
+            var sum = 0;
+            foreach (var value in values)
+            {
+                sum += value;
+            }
+
+            return sum.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public string Join(params string[] values) => string.Concat(values);
+    }
+
+    public sealed class CollectionHost
+    {
+        public string Sum(List<CDecimal> values) => "CDecimal:" + values.Count;
+
+        public string Sum(List<CInteger> values)
+        {
+            var sum = 0;
+            foreach (var value in values)
+            {
+                sum += value.Value;
+            }
+
+            return "CInteger:" + sum.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+
+    public sealed class CatchAllHost
+    {
+        public string Take(object value) => "object";
+
+        public string Take(params object[] values) => "params:" + values.Length;
+    }
+
+    public sealed class JsValueParamsHost
+    {
+        public string Take(char value) => "char:" + value;
+
+        public string Take(params JsValue[] values) => "params:" + values.Length;
+    }
+
+    public sealed class Bag
+    {
+        public Bag(params CDecimal[] items) => Kind = "CDecimal:" + items.Length;
+
+        public Bag(params CInteger[] items) => Kind = "CInteger:" + items.Length;
+
+        public string Kind { get; }
+    }
+
+    private static Engine NewEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("math", new MathHost());
+        engine.SetValue("stringFirst", new StringDeclaredFirst());
+        engine.SetValue("intFirst", new IntDeclaredFirst());
+        engine.SetValue("collections", new CollectionHost());
+        engine.SetValue("catchAll", new CatchAllHost());
+        engine.SetValue("jsValues", new JsValueParamsHost());
+        engine.SetValue("Bag", typeof(Bag));
+        engine.SetValue("a", new CInteger(1));
+        engine.SetValue("b", new CInteger(2));
+        return engine;
+    }
+
+    // ---- method lane ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void AParamsOverloadIsChosenByTheElementTypeTheArgumentsActuallyAre()
+    {
+        // The report verbatim. CDecimal is declared first and nothing converts a CInteger to it, so the call
+        // used to die inside Convert.ChangeType with "Object must implement IConvertible" - a CLR exception
+        // out of Evaluate that neither a script catch nor a host catch (JavaScriptException) could see.
+        var engine = NewEngine();
+
+        engine.Evaluate("math.Add(a, b).Kind").AsString().Should().Be("CInteger");
+        engine.Evaluate("math.Add(a, b).Value").Should().Be(3);
+    }
+
+    [Fact]
+    public void AConvertibleButWrongEarlierOverloadNoLongerWinsSilently()
+    {
+        // The half that never threw: a double element converts to string through Convert.ChangeType, so the
+        // first-declared params string[] answered the concatenation "12" for Join(1, 2). The element type is
+        // an exact match for int[] and a forced conversion for string[], so int[] is now the better score.
+        NewEngine().Evaluate("stringFirst.Join(1, 2)").AsString().Should().Be("3");
+    }
+
+    [Fact]
+    public void DeclarationOrderDoesNotDecide()
+    {
+        var engine = NewEngine();
+
+        engine.Evaluate("stringFirst.Join(1, 2)").AsString()
+            .Should().Be(engine.Evaluate("intFirst.Join(1, 2)").AsString());
+    }
+
+    [Fact]
+    public void AnArgumentNoOverloadAcceptsIsACatchableResolutionFailure()
+    {
+        // Nothing converts a string to any of the three element types, so every candidate declines and the
+        // call ends in resolution rather than in whatever the first candidate's conversion threw.
+        var engine = NewEngine();
+
+        Invoking(() => engine.Evaluate("math.Add('text')"))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("No public methods with the specified arguments were found.");
+
+        engine.Evaluate("try { math.Add('text') } catch (e) { e instanceof TypeError }")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void AGenericCollectionParameterTakesTheSamePath()
+    {
+        // List<T> and the other single-argument generic collection types are scored by the same branch, and
+        // read their element type off the generic argument rather than off Type.GetElementType().
+        NewEngine().Evaluate("collections.Sum([a, b])").AsString().Should().Be("CInteger:3");
+    }
+
+    [Fact]
+    public void AnExplicitJavaScriptArrayArgumentTakesTheSamePath()
+    {
+        // A single array argument is passed through to the params parameter unwrapped, so it reaches scoring
+        // as the very same JsArray the bundling would have built.
+        var engine = NewEngine();
+
+        engine.Evaluate("math.Add([a, b]).Kind").AsString().Should().Be("CInteger");
+        engine.Evaluate("math.Add([a, b]).Value").Should().Be(3);
+    }
+
+    [Fact]
+    public void AnEmptyArrayKeepsTodaysAnswer()
+    {
+        // Deliberately unchanged: with no element to read, the candidates are genuinely indistinguishable and
+        // the base score is all there is. Pinned so that a future element rule cannot quietly change it.
+        NewEngine().Evaluate("math.Add().Kind").AsString().Should().Be("CDecimal");
+    }
+
+    // ---- carve-out guards ----------------------------------------------------------------------------
+
+    [Fact]
+    public void AnObjectElementTypeKeepsItsScoreBesideAScalarObjectOverload()
+    {
+        // params object[] is what every host writes for "anything"; scoring its elements would rate each of
+        // them the catch-all 5 and hand the call to the scalar object overload instead.
+        NewEngine().Evaluate("catchAll.Take(1)").AsString().Should().Be("params:1");
+    }
+
+    [Fact]
+    public void AJsValueElementTypeKeepsItsScoreBesideAConvertibleScalarOverload()
+    {
+        // params JsValue[] is the other "anything" signature. A JsString is an is-a match for JsValue rather
+        // than an exact one, so scoring the elements would add 1 and tie this with the char overload beside
+        // it - and a tie is decided by the candidate order, which puts params last.
+        NewEngine().Evaluate("jsValues.Take('x')").AsString().Should().Be("params:1");
+    }
+
+    // ---- constructor lane ----------------------------------------------------------------------------
+
+    [Fact]
+    public void AConstructorParamsOverloadIsChosenByTheElementTypeToo()
+    {
+        // Constructor resolution has no retry - TypeReference calls the first match and stops - so the wrong
+        // selection was not merely a preference here, it was the whole answer.
+        NewEngine().Evaluate("new Bag(a, b).Kind").AsString().Should().Be("CInteger:2");
+    }
+
+    [Fact]
+    public void AConstructorArgumentNoOverloadAcceptsIsACatchableResolutionFailure()
+    {
+        var engine = NewEngine();
+
+        Invoking(() => engine.Evaluate("new Bag('text')"))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Could not resolve a constructor for type * for given arguments");
+
+        engine.Evaluate("try { new Bag('text') } catch (e) { e instanceof TypeError }")
+            .AsBoolean().Should().BeTrue();
+    }
+}

--- a/Jint.Tests/Runtime/CompositeConversionDeclineTests.cs
+++ b/Jint.Tests/Runtime/CompositeConversionDeclineTests.cs
@@ -1,0 +1,145 @@
+#nullable enable
+
+using System.Collections.ObjectModel;
+using System.Globalization;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see cref="DefaultTypeConverter.TryConvert"/> declines a composite whose parts cannot be converted, and
+/// <see cref="DefaultTypeConverter.Convert"/> still throws for the very same input.
+/// </summary>
+/// <remarks>
+/// The composite branches — <c>List&lt;T&gt;</c>, <c>Collection&lt;T&gt;</c>, <c>T[]</c>, a target dictionary's
+/// values and the members of a POCO built from a dictionary — converted their parts through the public,
+/// throwing <c>Convert</c> whatever their own frame had been asked, so a <c>Try</c> method documented as
+/// returning false threw a CLR exception instead. That is what defeated the candidate loop in
+/// <c>MethodInfoFunction.Call</c>, which asks the converter per candidate and is meant to move on when one
+/// declines (<see href="https://github.com/sebastienros/jint/issues/3754">#3754</see>).
+/// </remarks>
+public class CompositeConversionDeclineTests
+{
+    public sealed class Widget
+    {
+        public string Name { get; set; } = "widget";
+    }
+
+    public sealed class Gadget
+    {
+        public string Name { get; set; } = "gadget";
+    }
+
+    public sealed class Holder
+    {
+        public Gadget? Part { get; set; }
+    }
+
+    private static DefaultTypeConverter NewConverter() => new DefaultTypeConverter(new Engine());
+
+    private static void ShouldDeclineRatherThanThrow(object value, Type type)
+    {
+        var converter = NewConverter();
+        var declined = false;
+        object? converted = null;
+
+        Invoking(() => declined = !converter.TryConvert(value, type, CultureInfo.InvariantCulture, out converted))
+            .Should().NotThrow();
+
+        declined.Should().BeTrue();
+        converted.Should().BeNull();
+    }
+
+    private static void ConvertShouldStillThrow(object value, Type type)
+    {
+        var converter = NewConverter();
+
+        Invoking(() => converter.Convert(value, type, CultureInfo.InvariantCulture))
+            .Should().Throw<InvalidCastException>();
+    }
+
+    private static object[] ArrayWithUnconvertibleElement() => [new Widget()];
+
+    private static Dictionary<string, object> DictionaryWithUnconvertibleValue() => new() { ["part"] = new Widget() };
+
+    private static Dictionary<string, object> DictionaryForPoco() => new() { ["Part"] = new Widget() };
+
+    [Fact]
+    public void AnArrayWithAnUnconvertibleElementDeclines()
+    {
+        ShouldDeclineRatherThanThrow(ArrayWithUnconvertibleElement(), typeof(Gadget[]));
+    }
+
+    [Fact]
+    public void AListWithAnUnconvertibleItemDeclines()
+    {
+        ShouldDeclineRatherThanThrow(ArrayWithUnconvertibleElement(), typeof(List<Gadget>));
+    }
+
+    [Fact]
+    public void ACollectionWithAnUnconvertibleItemDeclines()
+    {
+        ShouldDeclineRatherThanThrow(ArrayWithUnconvertibleElement(), typeof(Collection<Gadget>));
+    }
+
+    [Fact]
+    public void ADictionaryWithAnUnconvertibleValueDeclines()
+    {
+        ShouldDeclineRatherThanThrow(DictionaryWithUnconvertibleValue(), typeof(Dictionary<string, Gadget>));
+    }
+
+    [Fact]
+    public void APocoWithAnUnconvertibleMemberDeclines()
+    {
+        ShouldDeclineRatherThanThrow(DictionaryForPoco(), typeof(Holder));
+    }
+
+    [Fact]
+    public void ConvertStillThrowsForAnArray()
+    {
+        ConvertShouldStillThrow(ArrayWithUnconvertibleElement(), typeof(Gadget[]));
+    }
+
+    [Fact]
+    public void ConvertStillThrowsForAList()
+    {
+        ConvertShouldStillThrow(ArrayWithUnconvertibleElement(), typeof(List<Gadget>));
+    }
+
+    [Fact]
+    public void ConvertStillThrowsForACollection()
+    {
+        ConvertShouldStillThrow(ArrayWithUnconvertibleElement(), typeof(Collection<Gadget>));
+    }
+
+    [Fact]
+    public void ConvertStillThrowsForADictionary()
+    {
+        ConvertShouldStillThrow(DictionaryWithUnconvertibleValue(), typeof(Dictionary<string, Gadget>));
+    }
+
+    [Fact]
+    public void ConvertStillThrowsForAPoco()
+    {
+        ConvertShouldStillThrow(DictionaryForPoco(), typeof(Holder));
+    }
+
+    [Fact]
+    public void AConvertibleCompositeStillConverts()
+    {
+        // The control: nothing about a composite whose parts do convert changes.
+        var converter = NewConverter();
+
+        converter.TryConvert(new object[] { 1d, 2d }, typeof(int[]), CultureInfo.InvariantCulture, out var array)
+            .Should().BeTrue();
+        ((int[]) array!).Should().Equal(1, 2);
+
+        converter.TryConvert(new object[] { 1d, 2d }, typeof(List<int>), CultureInfo.InvariantCulture, out var list)
+            .Should().BeTrue();
+        ((List<int>) list!).Should().Equal(1, 2);
+
+        converter.TryConvert(new Dictionary<string, object> { ["Part"] = "1" }, typeof(Dictionary<string, int>), CultureInfo.InvariantCulture, out var dictionary)
+            .Should().BeTrue();
+        ((Dictionary<string, int>) dictionary!)["Part"].Should().Be(1);
+    }
+}

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -95,6 +95,53 @@ public class DefaultTypeConverter : ITypeConverter
         return TryConvertInternal(value, type, formatProvider, propagateException: false, out converted, out _);
     }
 
+    /// <summary>
+    /// Converts one part of a composite - an array element, a collection item, a target dictionary's value,
+    /// a member of a POCO built from a dictionary - under the same <paramref name="propagateException"/>
+    /// contract as the frame that is assembling the composite.
+    /// </summary>
+    /// <remarks>
+    /// Every one of those sites reached for the public, throwing <see cref="Convert"/> whatever its own frame
+    /// had been asked, so a part that could not be converted escaped <see cref="TryConvert"/> as a CLR
+    /// exception rather than as the <see langword="false"/> that method documents - and an exception is not
+    /// something <c>MethodInfoFunction.Call</c> can move on from: it tries candidates in score order and
+    /// declines its way to the next one, so a throwing conversion ends the call rather than the candidate
+    /// (<see href="https://github.com/sebastienros/jint/issues/3754">#3754</see>). The body mirrors
+    /// <see cref="Convert"/> so that behaviour under <paramref name="propagateException"/> is unchanged: the
+    /// virtual <see cref="TryConvert"/> first, so a subclass override still answers for the parts, and only
+    /// then the internal pipeline that produces the detailed message and honours
+    /// <see cref="Options.InteropOptions.ExceptionHandler"/>.
+    /// </remarks>
+    private bool TryConvertPart(
+        object? value,
+        [DynamicallyAccessedMembers(InteropHelper.DefaultDynamicallyAccessedMemberTypes)] Type type,
+        IFormatProvider formatProvider,
+        bool propagateException,
+        out object? converted,
+        out string? problemMessage)
+    {
+        problemMessage = null;
+
+        if (TryConvert(value, type, formatProvider, out converted))
+        {
+            return true;
+        }
+
+        if (!propagateException)
+        {
+            converted = null;
+            problemMessage = $"Unable to convert a value of type '{value?.GetType()}' to '{type}'";
+            return false;
+        }
+
+        if (!TryConvertInternal(value, type, formatProvider, propagateException: true, out converted, out problemMessage))
+        {
+            Throw.Error(_engine, problemMessage ?? $"Unable to convert {value} to type {type}");
+        }
+
+        return true;
+    }
+
     private static readonly ConditionalWeakTable<IFunction, TypeKeyedCache<Func<object, Delegate>>> _targetBinderDelegateCache = new();
     private static readonly ConditionalWeakTable<object, TypeKeyedCache<Delegate>> _boundTargetDelegateCache = new();
 
@@ -216,7 +263,12 @@ public class DefaultTypeConverter : ITypeConverter
                     var targetList = (IList) Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType))!;
                     foreach (var item in sourceArray)
                     {
-                        targetList.Add(item is null ? null : Convert(item, elementType, formatProvider));
+                        if (!TryConvertPart(item, elementType, formatProvider, propagateException, out var convertedItem, out problemMessage))
+                        {
+                            return false;
+                        }
+
+                        targetList.Add(convertedItem);
                     }
                     converted = targetList;
                     return true;
@@ -228,7 +280,12 @@ public class DefaultTypeConverter : ITypeConverter
                     var innerList = (IList) Activator.CreateInstance(innerListType)!;
                     foreach (var item in sourceArray)
                     {
-                        innerList.Add(item is null ? null : Convert(item, elementType, formatProvider));
+                        if (!TryConvertPart(item, elementType, formatProvider, propagateException, out var convertedItem, out problemMessage))
+                        {
+                            return false;
+                        }
+
+                        innerList.Add(convertedItem);
                     }
                     converted = Activator.CreateInstance(type, innerList)!;
                     return true;
@@ -326,7 +383,10 @@ public class DefaultTypeConverter : ITypeConverter
             var itemsConverted = new object?[source.Length];
             for (var i = 0; i < source.Length; i++)
             {
-                itemsConverted[i] = Convert(source[i], targetElementType, formatProvider);
+                if (!TryConvertPart(source[i], targetElementType, formatProvider, propagateException, out itemsConverted[i], out problemMessage))
+                {
+                    return false;
+                }
             }
             var result = Array.CreateInstance(targetElementType, source.Length);
             itemsConverted.CopyTo(result, 0);
@@ -406,7 +466,12 @@ public class DefaultTypeConverter : ITypeConverter
                 {
                     if (typeDescriptor.TryGetDictionaryValue(value, key, out var sourceVal))
                     {
-                        targetDict[key] = Convert(sourceVal, targetValueType, formatProvider);
+                        if (!TryConvertPart(sourceVal, targetValueType, formatProvider, propagateException, out var convertedValue, out problemMessage))
+                        {
+                            return false;
+                        }
+
+                        targetDict[key] = convertedValue;
                     }
                 }
             }
@@ -425,7 +490,14 @@ public class DefaultTypeConverter : ITypeConverter
                     if (typeDescriptor.TryGetDictionaryValue(value, member.Name, out var val)
                         || typeDescriptor.TryGetDictionaryValue(value, member.Name.UpperToLowerCamelCase(), out val))
                     {
-                        var output = Convert(val, member.GetDefinedType(), formatProvider);
+                        // A member the dictionary supplies but the target cannot hold is a decline of the
+                        // whole conversion, not an exception out of a Try method - the same reason the other
+                        // four composite sites route through the flag their frame was given.
+                        if (!TryConvertPart(val, member.GetDefinedType(), formatProvider, propagateException, out var output, out problemMessage))
+                        {
+                            return false;
+                        }
+
                         member.SetValue(obj, output);
                     }
                 }

--- a/Jint/Runtime/Interop/InteropHelper.cs
+++ b/Jint/Runtime/Interop/InteropHelper.cs
@@ -87,9 +87,16 @@ internal sealed class InteropHelper
     /// Determines how well parameter type matches target method's type.
     /// </summary>
     private static int CalculateMethodParameterScore(Engine engine, ParameterInfo parameter, JsValue parameterValue)
-    {
-        var paramType = parameter.ParameterType;
+        => CalculateParameterTypeScore(engine, parameter.ParameterType, parameter.IsOptional, parameterValue);
 
+    /// <summary>
+    /// The same question asked of a bare <see cref="Type"/>, so that a value with no <see cref="ParameterInfo"/>
+    /// of its own - an element of a JavaScript array being rated against an array or collection parameter -
+    /// is scored by the very rules its parameter would be. Only the parameter's type and its optionality were
+    /// ever read, and an element is never optional.
+    /// </summary>
+    private static int CalculateParameterTypeScore(Engine engine, Type paramType, bool isOptional, JsValue parameterValue)
+    {
         // Special case: if parameter expects a JsValue-derived type (e.g., TypeReference),
         // check if the argument is of that exact type before calling ToObject().
         // This is important because ToObject() unwraps TypeReference to System.Type,
@@ -118,7 +125,7 @@ internal sealed class InteropHelper
 
         if (objectValue is null)
         {
-            if (!parameter.IsOptional && !TypeIsNullable(paramType))
+            if (!isOptional && !TypeIsNullable(paramType))
             {
                 // this is bad
                 return -1;
@@ -210,10 +217,9 @@ internal sealed class InteropHelper
             return 1;
         }
 
-        if (parameterValue.IsArray() && (paramType.IsArray || IsGenericCollectionType(paramType)))
+        if (parameterValue.IsArray() && TryGetCollectionElementType(paramType, out var elementType))
         {
-            // we have potential, TODO if we'd know JS array's internal type we could have exact match
-            return 2;
+            return CalculateArrayParameterScore(engine, elementType, parameterValue);
         }
 
         // not sure the best point to start generic type tests
@@ -269,6 +275,91 @@ internal sealed class InteropHelper
 
         // this is bad
         return -1;
+    }
+
+    /// <summary>What an array or collection parameter is worth before its elements are read.</summary>
+    private const int ArrayParameterBaseScore = 2;
+
+    /// <summary>How many of a JavaScript array's elements are rated against the parameter's element type.</summary>
+    private const int MaxScoredArrayElements = 8;
+
+    /// <summary>
+    /// Rates a JavaScript array against an array or generic-collection parameter by the elements it actually
+    /// holds, so that overloads differing only in element type are told apart rather than tied.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The score is the base plus the <em>worst</em> element, never their sum, so an array parameter's
+    /// contribution stays the same magnitude as a scalar's and a long array cannot outweigh the parameters
+    /// beside it. Exact elements therefore still answer 2, which is what every array parameter answered
+    /// before. It also never answers 0: a perfect score ends <see cref="FindBestMatch{TState}"/> outright
+    /// with a one-element candidate set, and an array argument has never been a perfect match.
+    /// </para>
+    /// <para>
+    /// Only the first <see cref="MaxScoredArrayElements"/> elements are read, and the cap is safe in both
+    /// directions. A tail that would have scored worse only reorders the candidates - the conversion still
+    /// validates every element, and since the composite branches of <c>DefaultTypeConverter.TryConvert</c>
+    /// now decline instead of throwing, a wrong order costs a decline and a move to the next candidate rather
+    /// than a failed call. A tail that would have scored better cannot promote a candidate past a rival the
+    /// prefix already ruled out, because a <c>-1</c> is returned on the first element that cannot bind at all.
+    /// </para>
+    /// <para>
+    /// That <c>-1</c> is the converter's own answer, reached through the same ladder
+    /// <c>MethodDescriptor.Call</c> will use to perform the conversion - the
+    /// <see href="https://github.com/sebastienros/jint/issues/3407">#3407</see> invariant applied one level
+    /// down, so the score cannot claim an element conversion the call then fails to perform. The recursion
+    /// terminates because each level strips one array rank off the <em>parameter</em> type, which is finite.
+    /// </para>
+    /// </remarks>
+    private static int CalculateArrayParameterScore(Engine engine, Type elementType, JsValue parameterValue)
+    {
+        // CARVE-OUT: an element type any JsValue is already assignable to - object, JsValue itself, or a base
+        // of it - answers for every element there could be, so reading them buys nothing and costs the
+        // candidate its place. params object[] and params JsValue[] are what a host writes for "anything",
+        // and rating their elements (5 for the catch-all object, 1 for an is-a JsValue) would hand the call
+        // to whatever scalar overload sits beside them.
+        if (elementType.IsAssignableFrom(typeof(JsValue)))
+        {
+            return ArrayParameterBaseScore;
+        }
+
+        // A Proxy reports itself as an array; reading its elements here would run its traps - user
+        // JavaScript - during overload scoring, so it keeps the base score the way it always had.
+        if (parameterValue is not Jint.Native.Array.ArrayInstance array)
+        {
+            return ArrayParameterBaseScore;
+        }
+
+        var length = array.GetLength();
+        if (length == 0)
+        {
+            // nothing to read: the candidates are genuinely indistinguishable and the base score is all there is
+            return ArrayParameterBaseScore;
+        }
+
+        var scoredElements = length < MaxScoredArrayElements ? length : (uint) MaxScoredArrayElements;
+        var worstElementScore = 0;
+        for (uint i = 0; i < scoredElements; i++)
+        {
+            if (!array.TryGetValue(i, out var element))
+            {
+                element = JsValue.Undefined;
+            }
+
+            var elementScore = CalculateParameterTypeScore(engine, elementType, isOptional: false, element);
+            if (elementScore < 0)
+            {
+                // an element this parameter cannot hold makes the whole array unbindable to it
+                return -1;
+            }
+
+            if (elementScore > worstElementScore)
+            {
+                worstElementScore = elementScore;
+            }
+        }
+
+        return ArrayParameterBaseScore + worstElementScore;
     }
 
     /// <summary>
@@ -340,6 +431,28 @@ internal sealed class InteropHelper
         return type.IsGenericType
                && type.GetGenericArguments().Length == 1
                && GenericCollectionTypeDefinitions.Contains(type.GetGenericTypeDefinition());
+    }
+
+    /// <summary>
+    /// The element type an array or single-argument generic collection parameter holds, which is what
+    /// <see cref="CalculateArrayParameterScore"/> rates a JavaScript array's elements against.
+    /// </summary>
+    private static bool TryGetCollectionElementType(Type type, [NotNullWhen(true)] out Type? elementType)
+    {
+        if (type.IsArray)
+        {
+            elementType = type.GetElementType();
+            return elementType is not null;
+        }
+
+        if (IsGenericCollectionType(type))
+        {
+            elementType = type.GetGenericArguments()[0];
+            return true;
+        }
+
+        elementType = null;
+        return false;
     }
 
     internal static bool TypeIsNullable(Type type)


### PR DESCRIPTION
Backports #3764 (`main`) to the **4.x** maintenance branch. Both defects were confirmed present on 4.x by running the ported tests against unfixed code first.

## The two defects

**A. A JavaScript array short-circuited overload scoring above the converter probe.** A `params` call bundles its trailing arguments into one `JsArray` before overload resolution runs, so `InteropHelper.CalculateMethodParameterScore` rated three candidates differing only in their element type — `CDecimal[]`, `CInteger[]`, `CLong[]` — with one rule, "is an array, wants an array", that answered a flat `2` for every one of them. The element type was never consulted, the converter probe below that rule (the #3407 fix, which 4.x already has) was never reached, and declaration order decided. Where the first-declared candidate happened to be convertible it answered silently and wrongly; where it was not, the conversion's `InvalidCastException` left through the embedder's `Evaluate` — invisible to a script `catch` and to a host `catch (JavaScriptException)` alike.

**B. The composite branches of `DefaultTypeConverter.TryConvert` converted their parts through the public, throwing `Convert`.** A `List<T>` or `Collection<T>` item, a `T[]` element, a target dictionary's value and a member of a POCO built from a dictionary all ignored the `propagateException` flag their own frame had been called with, so a method documented as returning `false` threw. That is not something the candidate loop in `MethodInfoFunction.Call` can move on from: it tries candidates in score order and declines its way to the next, and an exception ends the call rather than the candidate.

They are fixed together, because fixing A by asking the converter per element throws until B is fixed.

- `TryConvertPart` routes all five composite sites through the flag their frame was given. It mirrors `Convert` — the virtual `TryConvert` first, so a subclass override still answers for the parts — so behaviour under `propagateException: true` is unchanged.
- `CalculateParameterTypeScore` is the type-level core of the parameter score, so an element with no `ParameterInfo` of its own can be scored by the same rules. An array parameter now scores its base `2` plus its *worst* element, up to eight of them, and returns `-1` on the first element that cannot bind at all. Element types any `JsValue` is assignable to — `object`, `JsValue` — are carved out and keep the flat base, or `params object[]` and `params JsValue[]` would rank below the scalar overload beside them.

Deliberately out of scope, exactly as on `main`: `MethodDescriptor.Call`'s `TypeReference` constructor lane keeps its throwing `Convert` and gets no retry loop (correct selection is what repairs it), and an empty JS array against several `params T[]` overloads stays ambiguous and keeps today's answer.

## Failing first

Both files were ported and run against **unfixed** 4.x before `Jint/` was touched. Identical counts on both legs (`net472`, which exercises Jint's `net462`-compiled asset, and `net10.0`):

| Suite | Unfixed 4.x | After |
| --- | --- | --- |
| `Jint.Tests.PublicInterface/HostArrayElementOverloadTests` | **8 failed / 3 passed** of 11 | 11 passed |
| `Jint.Tests/Runtime/CompositeConversionDeclineTests` | **5 failed / 6 passed** of 11 | 11 passed |

The three that passed unfixed in the first file are exactly the ones meant to: the empty-array pin (`AnEmptyArrayKeepsTodaysAnswer`, deliberately unchanged behaviour) and the two carve-out guards (`params object[]`, `params JsValue[]`). The six that passed unfixed in the second are the five `Convert`-still-throws cases and the convertible-composite control — the half that pins what must *not* change.

The two representative unfixed failures:

- `math.Add(a, b)` with two `CInteger`s → `System.InvalidCastException: Invalid cast from '…' to '…+CDecimal'` out of `Evaluate`, through `MethodInfoFunction.TryCall` → `DefaultTypeConverter.TryConvert` → `Convert`.
- `converter.TryConvert(new object[] { new Widget() }, typeof(Gadget[]), …)` threw instead of returning `false`.

## Divergences from `main` actually found

1. `parameterValue.IsSpecArray()` on `main` is `parameterValue.IsArray()` on 4.x — confirmed. `JsProxy` overrides it on 4.x too, so the Proxy carve-out (`is not ArrayInstance` keeps the base score, no traps run during scoring) still holds and the comment was reworded from "spec array" to "array".
2. `engine._typeConverter` on `main` is `engine.TypeConverter` on 4.x — confirmed, but it did **not** affect this change: the only site reading it is the existing #3407 probe, which the port leaves untouched.
3. `ClrTypeConverter` on `main` is `ITypeConverter` on 4.x — confirmed as the base type of `DefaultTypeConverter`. It did not affect `TryConvertPart`, whose doc comment references only `Convert`, `TryConvert` and `Options.InteropOptions.ExceptionHandler`, all of which exist on 4.x with the same names.
4. The fifth site does differ structurally, as expected: 4.x has the POCO-member copy **inline** in a `foreach (var member in type.GetMembers())` loop with a `MemberType != Property && != Field` filter, not `main`'s extracted `static void CopyDictionaryEntryToMember(…)` local function over separate `GetProperties()`/`GetFields()` passes. `main`'s refactor was **not** imported; `TryConvertPart` is called inline and the loop `return false`s on a decline.
5. 4.x's `catch` in the `Convert.ChangeType` fallback has no `Throw.MustPropagateHostException(e)` call — confirmed, and left alone.
6. `ArrayInstance.GetLength()` (`internal override uint`) and `TryGetValue(uint, out JsValue)` (`public bool`) exist on 4.x with the same signatures — no adaptation needed.

Two more that turned up during the port:

7. **The constructor-resolution message differs.** 4.x throws `Could not resolve a constructor for type {type} for given arguments`; `main` reworded it to `Could not resolve a constructor for the specified arguments.`. `AConstructorArgumentNoOverloadAcceptsIsACatchableResolutionFailure` asserts 4.x's wording (with a `*` wildcard for the type name). The *behaviour* being pinned — a catchable `JavaScriptException` / script-visible `TypeError` instead of a raw `InvalidCastException` — is identical, and that test is red on unfixed 4.x either way.
8. **The tests are xUnit v3 on 4.x, and the folder layout differs.** `[Test]` → `[Fact]` throughout (no `[TestCase]` in either file). `Invoking(…)` and the AwesomeAssertions global usings are already present on 4.x in both projects, so the assertion style is unchanged. `main` created `Jint.Tests/Runtime/Interop/` for `CompositeConversionDeclineTests.cs`; 4.x has no such folder and keeps `DefaultTypeConverterTests.cs` directly in `Jint.Tests/Runtime/`, so the ported file sits there with namespace `Jint.Tests.Runtime`.

**No `AGENTS.md` change.** 4.x has no `Jint/Runtime/Interop/AGENTS.md` — the co-located split is `main`-only, and 4.x's single root `AGENTS.md` carries no "Overload scoring's last rule" bullet (and no mention of #3407) to extend. No `docs/v5-migration.md` row either; that file is `main`-only.

## Verification

All in Release, no `--no-build`, `TreatWarningsAsErrors` on, both TFMs where the project multi-targets:

| Suite | Result |
| --- | --- |
| `Jint.Tests` | 7017 passed / 0 failed / 4 skipped (net472) · 7102 / 0 / 4 (net10.0) |
| `Jint.Tests.PublicInterface` | 1828 / 0 / 9 (net472) · 1836 / 0 / 9 (net10.0) |
| `Jint.Tests.CommonScripts` | 28 / 0 / 0 on both |
| `Jint.Tests.Test262` | **102,499 passed / 0 failed / 185 skipped of 102,684** |

test262 matches the branch control exactly, with neither of the two known load flakes (`intl402/supportedLocalesOf-unicode-extensions-ignored.js`, `staging/sm/Array/toSpliced-dense.js`) firing this run. Full solution build: 0 errors, and the only warning is the pre-existing `MSB3277` reference conflict in `Jint.Tests.CommonScripts` on `net472`, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfyCDDqtkhyWVEFHKWhZfu
