### PR TITLE
DevTools: a target can name the commands that touch no engine state, so answering a paused request never waits for the loop

### DIFF
--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -70,8 +70,15 @@ target/runtime split and the manifest are there and none of it is repeated here.
   protocol say the same thing about the same request and the two domains share identifiers. **The
   notifications and the interception run on the transport thread, not the page loop**, and
   [`Runtime/AGENTS.md`](../Runtime/AGENTS.md#the-request-log-is-the-protocols-seam-too) argues why moving them
-  would deadlock the one fetch a page cannot pump through. The document's request carries the `loaderId` as
-  its `requestId`, which is how every client tells a navigation apart.
+  would deadlock the one fetch a page cannot pump through. **The three commands that release a pause run
+  there too**, which is what makes "a pause never blocks the loop's answer" unconditional rather than true
+  with one exception: `PageTarget.RunsOffThread` names `Fetch.continueRequest`, `failRequest` and
+  `fulfillRequest` — they look one entry up and complete a promise, touching no engine, no `JsValue` and no
+  node, which is the bar [`Jint.DevTools/AGENTS.md`](../../Jint.DevTools/AGENTS.md#the-thread-rule) sets —
+  so a `<script src>` a running script inserted, fetched with the loop *blocked* rather than pumping, is
+  released while it blocks. `Fetch.enable` and `disable` are deliberately not named: they are the domain's
+  own state, not a request's. The document's request carries the `loaderId` as its `requestId`, which is how
+  every client tells a navigation apart.
 - **What is accepted and not effective says so, in place.** `Network.setCacheDisabled` (there is no cache)
   and `Audits.enable` are answered because a refusal fails an ordinary connection. Three whole lanes are
   absent with a reason rather than pending: the `Fetch` **response stage** and with it `IO` (an observer

--- a/Jint.Browser/DevTools/FetchDomain.cs
+++ b/Jint.Browser/DevTools/FetchDomain.cs
@@ -23,13 +23,13 @@ namespace Jint.Browser.DevTools;
 /// thinks about a request.
 /// </para>
 /// <para>
-/// <b>One case is not covered by that sentence, and it is stated rather than hidden.</b> A
-/// <c>&lt;script src&gt;</c> that a <i>running script</i> inserted is fetched with the loop blocked rather
-/// than pumping — <c>Runtime/Parsing/AGENTS.md</c> says why: pumping from inside a running script would run
-/// the page's jobs in the middle of one. So a client's answer to a pause on that one fetch cannot be
-/// delivered until the fetch ends, and it ends at <c>BrowserOptions.SubresourceTimeout</c>. Every other
-/// request the page makes — the document, a parser-driven subresource, <c>fetch</c>,
-/// <c>XMLHttpRequest</c>, a worker's module — is answered while the loop is free.
+/// <b>That sentence has no exception left, and the reason is that the answer no longer comes from the
+/// loop.</b> A <c>&lt;script src&gt;</c> that a <i>running script</i> inserted is still fetched with the
+/// loop blocked rather than pumping — <c>Runtime/Parsing/AGENTS.md</c> says why: pumping from inside a
+/// running script would run the page's jobs in the middle of one. So <c>PageTarget.RunsOffThread</c> names
+/// <see cref="ContinueRequestAsync"/>, <see cref="FailRequestAsync"/> and <see cref="FulfillRequestAsync"/>,
+/// which look one entry up and complete a promise and touch no engine state at all: they are answered on the
+/// thread that read them, and what they release is the fetch the loop is blocked on.
 /// </para>
 /// <para>
 /// <b>The <c>Request</c> stage only, and that is an engine seam rather than an omission.</b> A pattern

--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -187,6 +187,32 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// <b>Three commands, and they are the three that release a paused request.</b>
+    /// <c>FetchDomain.ContinueRequestAsync</c>, <c>FailRequestAsync</c> and <c>FulfillRequestAsync</c> look
+    /// one entry up in a <c>ConcurrentDictionary</c> and complete a <c>TaskCompletionSource</c>; between
+    /// them they touch no engine, no <c>JsValue</c> and no node, which is the bar the base class sets.
+    /// </para>
+    /// <para>
+    /// <b>What that makes unconditional is that a pause never blocks the answer to it.</b> A
+    /// <c>&lt;script src&gt;</c> a running script inserted is fetched with the loop blocked rather than
+    /// pumping (<c>Runtime/Parsing/AGENTS.md</c>), so the one command that could end that block used to be
+    /// queued behind it and could not be answered until the fetch gave up.
+    /// </para>
+    /// <para>
+    /// <b><c>Fetch.enable</c> and <c>Fetch.disable</c> are deliberately not here.</b> They mark the domain
+    /// enabled and emit through the session, which is a domain's own state rather than a request's, so they
+    /// keep the ordering every other command has.
+    /// </para>
+    /// </remarks>
+    internal override bool RunsOffThread(string method) => method switch
+    {
+        "Fetch.continueRequest" or "Fetch.failRequest" or "Fetch.fulfillRequest" => true,
+        _ => false,
+    };
+
+    /// <inheritdoc/>
     internal override ValueTask CloseAsync() => new(Page.CloseAsync());
 
     /// <summary>Registers one attachment's <c>Page</c> domain as a listener.</summary>

--- a/Jint.DevTools/AGENTS.md
+++ b/Jint.DevTools/AGENTS.md
@@ -33,8 +33,15 @@ WebSocket receive loop happens to be on, the only thing it may hand a `DevToolsS
 
 Everything downstream of that follows:
 
-- **Every domain method runs on the engine thread.** A `DevToolsDomain` may hold engine state — a
-  `RemoteObjectTable`, a `ScriptRegistry`, a `DebugHandler` subscription — none of it thread-safe.
+- **Every domain method runs on the engine thread, except the ones a target names.** A `DevToolsDomain` may
+  hold engine state — a `RemoteObjectTable`, a `ScriptRegistry`, a `DebugHandler` subscription — none of it
+  thread-safe. `DevToolsTarget.RunsOffThread(method)` is the gateway hook a target overrides to answer one
+  command on the thread that read it instead, and **the bar for naming a method is that it provably touches
+  no engine state, no `JsValue` and no AngleSharp node** — a method that reads any of the three above, an
+  `Engine` or a DOM node may never be named, because nothing here would catch it. What it buys is a command
+  answerable while the loop is not: today the three `Fetch` commands that release a paused request
+  ([`Jint.Browser/DevTools/AGENTS.md`](../Jint.Browser/DevTools/AGENTS.md)), since the pause holds a
+  transport thread and the loop may be blocked on the very fetch it is about.
 - **Nothing a command returns may outlive the command.** A `CommandContext` is valid for the command that
   received it, and must not be captured.
 - **Serialization happens on the engine thread too**, because that is where the `JsValue` is. That is why

--- a/Jint.DevTools/DevToolsTarget.cs
+++ b/Jint.DevTools/DevToolsTarget.cs
@@ -175,10 +175,48 @@ public abstract class DevToolsTarget : ICommandGateway
     /// <inheritdoc/>
     /// <remarks>
     /// Read per command rather than captured, because the mailbox belongs to the engine and the engine is
-    /// replaced under the target on every navigation.
+    /// replaced under the target on every navigation. A method <see cref="RunsOffThread"/> names is the one
+    /// exception: it is answered here, on the thread that read it, and never reaches the mailbox at all.
     /// </remarks>
     ValueTask<string> ICommandGateway.DispatchAsync(DevToolsSession session, ProtocolRequest request, CommandContext context)
-        => Runtime.Dispatcher.DispatchAsync(session, request, context);
+        => RunsOffThread(request.Method)
+            ? session.DispatchAsync(in request, context)
+            : Runtime.Dispatcher.DispatchAsync(session, request, context);
+
+    /// <summary>Whether one command is answered on the thread that read it rather than on the engine's.</summary>
+    /// <param name="method">The qualified method a client sent, such as <c>Fetch.continueRequest</c>.</param>
+    /// <returns>
+    /// <see langword="true"/> to answer the command in place, <see langword="false"/> — the default — to
+    /// queue it on the current engine's mailbox.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// <b>The one documented exception to "every domain method runs on the engine thread", and the bar is
+    /// what keeps it one.</b> A method may be named here only if it provably touches no engine state, no
+    /// <c>JsValue</c> and no AngleSharp node — nothing but its own parameters and structures that are
+    /// thread-safe by construction. One that reads a <c>RemoteObjectTable</c>, a <c>ScriptRegistry</c>, a
+    /// <c>DebugHandler</c>, an <c>Engine</c> or a DOM node may never be, whatever it costs on the loop.
+    /// </para>
+    /// <para>
+    /// <b>What it buys is a command that is answerable while the loop is not.</b> A pause a client is asked
+    /// to answer holds a transport thread, and the answer has to reach that thread — so a command queued
+    /// behind a loop the pause itself is blocking could not be delivered until the block ended.
+    /// <c>PageTarget</c> names the three <c>Fetch</c> commands that release such a pause and nothing else.
+    /// </para>
+    /// <para>
+    /// <b>It needs no clone of its parameters, unlike a queued command.</b> It runs inside
+    /// <c>DevToolsSession.HandleMessageAsync</c>'s own <see langword="try"/>, so the caller's
+    /// <c>JsonDocument</c> is still open; the mailbox clones because an item it answered on a timeout is
+    /// read by the engine thread after that document has gone back to the pool.
+    /// </para>
+    /// <para>
+    /// <b>And a navigation never abandons it.</b> Abandoning is for a command addressed to a context that
+    /// was replaced; a command that reaches no engine names no context, and it is answered before a swap
+    /// could reach it. <see langword="internal"/> so that <c>Jint.Browser</c> overrides it and nothing
+    /// outside this repository can widen the thread rule.
+    /// </para>
+    /// </remarks>
+    internal virtual bool RunsOffThread(string method) => false;
 
     /// <summary>Registers what one attachment to this target answers, on <paramref name="session"/>.</summary>
     /// <param name="session">The session node the attachment answers on.</param>

--- a/Jint.DevTools/Session/AGENTS.md
+++ b/Jint.DevTools/Session/AGENTS.md
@@ -36,6 +36,14 @@ Four consequences that are not negotiable:
   commands around it. The single exception is `WaitForDebuggerOnStart`: host work is held and protocol
   commands are not, because otherwise the command that ends the wait could never be answered.
 
+**A target may take one command out of that path entirely.** The gateway reads
+`DevToolsTarget.RunsOffThread(method)` before the enqueue, and a method it names is answered by
+`DevToolsSession.DispatchAsync` on the thread that read it — no clone of the parameters (the caller's
+`JsonDocument` is still open, which is the only reason the mailbox clones), no queue, and no `Abandon`,
+since a command that reaches no engine names no context. The bar for naming one is in
+[`Jint.DevTools/AGENTS.md`](../AGENTS.md#the-thread-rule), and today it is the three `Fetch` commands that
+release a paused request: the page loop can be blocked on the very fetch the pause is about.
+
 The two thread modes are `EngineTargetOptions.ThreadMode`. `HostOwned` (the default) is the host's own loop;
 `EngineTarget.Pump` is a convenience over `engine.Tasks.ProcessTasks()`, not a second mechanism.
 `LibraryOwned` starts one thread running drain → `ProcessTasks` → `WaitForScheduledWork`, and the host

--- a/Jint.Tests.Browser/DevTools/FetchDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/FetchDomainTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using Jint.Browser;
@@ -191,6 +192,67 @@ public class FetchDomainTests
         await fixture.ContinueAsync(paused);
     }
 
+    /// <summary>
+    /// The one fetch the page loop blocks on rather than pumping through, and the command that releases it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <c>&lt;script src&gt;</c> a <i>running script</i> inserted is fetched with the loop held, because
+    /// pumping from inside a running script would run the page's jobs in the middle of one
+    /// (<c>Runtime/Parsing/AGENTS.md</c>). So the answer to a pause on that fetch cannot come from the loop,
+    /// and until <c>PageTarget.RunsOffThread</c> it was queued on it: the client's <c>continueRequest</c> sat
+    /// in the mailbox until the fetch gave up at <c>BrowserOptions.SubresourceTimeout</c>, by which point
+    /// the pause it named was gone.
+    /// </para>
+    /// <para>
+    /// The timeout is shortened so that a regression fails in seconds rather than in half a minute; the
+    /// assertion is on the round trip, which is milliseconds when the command never reaches the loop at all.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task ContinuingTheOneFetchTheLoopBlocksOnIsAnsweredWhileItBlocks()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/inserted.js", _ => LoopbackResponse.Script("globalThis.__inserted = true;"));
+        server.MapHtml("/page", """
+            <html><head><title>Blocked</title><script>
+              var el = document.createElement('script');
+              el.src = '/inserted.js';
+              document.head.appendChild(el);
+            </script></head><body>ok</body></html>
+            """);
+
+        await using var fixture = await InterceptionFixture.OpenAsync(
+            server,
+            new BrowserOptions { SubresourceTimeout = TimeSpan.FromSeconds(8) });
+
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/inserted.js"}]}""");
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+
+        var paused = await fixture.PausedAsync();
+        paused.GetProperty("request").GetProperty("url").GetString().Should().Be(server.Url("/inserted.js"));
+        paused.GetProperty("resourceType").GetString().Should().Be("Script");
+
+        var clock = Stopwatch.StartNew();
+        var reply = await fixture.Session.SendAsync(
+            "Fetch.continueRequest",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment);
+        clock.Stop();
+
+        clock.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3),
+            "the command touches no engine state, so it is answered on the thread that read it rather than queued behind the fetch the loop is blocked on");
+
+        reply.TryGetProperty("error", out var error).Should().BeFalse(
+            "the pause was still there to be released, and it answered {0}", error);
+
+        await navigation.WaitAsync(Bound);
+
+        (await fixture.Page.EvaluateAsync<bool>("globalThis.__inserted === true")).Should().BeTrue(
+            "the inserted script really was paused, really was continued, and really did run");
+    }
+
     [Test]
     public async Task DetachingContinuesEverythingThatWasPaused()
     {
@@ -266,9 +328,9 @@ public class FetchDomainTests
 
         internal string FrameId { get; }
 
-        internal static async Task<InterceptionFixture> OpenAsync(LoopbackServer server)
+        internal static async Task<InterceptionFixture> OpenAsync(LoopbackServer server, BrowserOptions? options = null)
         {
-            var session = await PageSession.CreateAsync(new BrowserContextOptions { UrlFilter = server.Owns });
+            var session = await PageSession.CreateAsync(new BrowserContextOptions { UrlFilter = server.Owns }, options);
             var page = await session.NewPageAsync();
             var target = await session.TargetForAsync(page);
             var attachment = await session.AttachAsync(target);

--- a/Jint.Tests.DevTools/Session/OffThreadCommandTests.cs
+++ b/Jint.Tests.DevTools/Session/OffThreadCommandTests.cs
@@ -1,0 +1,101 @@
+using Jint.DevTools;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// The one documented exception to the thread rule: a target names a command, and the gateway answers it on
+/// the thread that read it instead of queueing it on the engine's mailbox.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>An engine nothing pumps is what makes the property observable.</b> Every other way of asking the
+/// question measures a clock; this one asks whether the command is answered at all, which it can only be if
+/// it never reached the mailbox.
+/// </para>
+/// <para>
+/// <b>The routing is per method, not per target.</b> The same target that answers its named method off the
+/// thread still queues everything else, which is the half that keeps the exception one.
+/// </para>
+/// <para>
+/// <b>Every wait is bounded.</b> A protocol test that can hang is a continuous-integration leg that can hang.
+/// </para>
+/// </remarks>
+public class OffThreadCommandTests
+{
+    /// <summary>
+    /// What a wait is allowed to take before the test calls it a hang, on the terms
+    /// <see cref="ThreadModeTests"/> sets: a tight bound here measures the runner, not the server.
+    /// </summary>
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(120);
+
+    /// <summary>How long a command the mailbox holds waits before it is told nothing is pumping.</summary>
+    private static readonly TimeSpan ShortCommandTimeout = TimeSpan.FromMilliseconds(300);
+
+    [Test]
+    public async Task AMethodTheTargetNamesIsAnsweredWithTheEngineNeverPumped()
+    {
+        await using var session = ProtocolSession.Create(options: new DevToolsServerOptions
+        {
+            CommandTimeout = ShortCommandTimeout,
+        });
+
+        var target = new UnpumpedTarget(new Engine(), offThread: "Log.enable");
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        var reply = await session.SendAsync("Log.enable", null, attachment).WaitAsync(Bound);
+
+        reply.TryGetProperty("error", out var error).Should().BeFalse(
+            "a method the target declares off-thread is answered where it was read, and it answered {0}", error);
+        target.Pumps.Should().Be(0, "nothing ran the engine's loop, which is the whole of the claim");
+    }
+
+    /// <summary>
+    /// The same target, a method it did not name: still the mailbox, so an engine nobody pumps answers with
+    /// the diagnosis a host needs rather than with the command.
+    /// </summary>
+    [Test]
+    public async Task AMethodTheSameTargetDoesNotNameStillWaitsForThePump()
+    {
+        await using var session = ProtocolSession.Create(options: new DevToolsServerOptions
+        {
+            CommandTimeout = ShortCommandTimeout,
+        });
+
+        var target = new UnpumpedTarget(new Engine(), offThread: "Log.enable");
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        var error = (await session.SendAsync("Log.disable", null, attachment).WaitAsync(Bound)).GetProperty("error");
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Engine is not being pumped");
+    }
+
+    /// <summary>
+    /// A target that names nothing is unchanged: the command is queued, and the host's next turn answers it.
+    /// </summary>
+    [Test]
+    public async Task ATargetThatNamesNothingAnswersOnceItIsPumped()
+    {
+        await using var session = ProtocolSession.Create();
+
+        var target = new UnpumpedTarget(new Engine());
+        session.Server.AddTarget(target);
+        var attachment = await session.AttachAsync(target);
+
+        var pending = session.SendAsync("Log.enable", null, attachment);
+
+        var deadline = DateTime.UtcNow + Bound;
+        while (!pending.IsCompleted && DateTime.UtcNow < deadline)
+        {
+            target.Pump();
+            await Task.Delay(5);
+        }
+
+        var reply = await pending.WaitAsync(Bound);
+        reply.TryGetProperty("error", out var error).Should().BeFalse(
+            "the command was answered by the pump rather than off it, and it answered {0}", error);
+        target.Pumps.Should().BeGreaterThan(0, "the mailbox is what answered it");
+    }
+}

--- a/Jint.Tests.DevTools/Session/UnpumpedTarget.cs
+++ b/Jint.Tests.DevTools/Session/UnpumpedTarget.cs
@@ -1,0 +1,69 @@
+using Jint.DevTools;
+
+namespace Jint.Tests.DevTools.Session;
+
+/// <summary>
+/// A target whose engine nothing pumps unless a test says so, and which may name one method as answerable
+/// off the engine thread.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The suite declares one rather than waiting for <c>Jint.Browser</c> to bring one, for the reason
+/// <see cref="NavigableTarget"/> exists: an extension point nothing exercises is a design nobody has tried.
+/// This is the smallest thing that is a real target — an identity, an engine and a mailbox — and it is
+/// deliberately <i>not</i> pumped, which is what makes "answered without the engine thread" an observation
+/// rather than a claim about timing.
+/// </para>
+/// <para>
+/// The method it names is <c>Log.enable</c>, which touches nothing of the engine's. That is the bar
+/// <see cref="DevToolsTarget.RunsOffThread"/> sets, and a test target is not exempt from it.
+/// </para>
+/// </remarks>
+internal sealed class UnpumpedTarget : DevToolsTarget
+{
+    private readonly string? _offThread;
+
+    private int _closed;
+
+    /// <summary>Creates a target over <paramref name="engine"/>, naming <paramref name="offThread"/>.</summary>
+    /// <param name="engine">The engine the target answers about.</param>
+    /// <param name="offThread">The one method answered on the reading thread, or <see langword="null"/>.</param>
+    internal UnpumpedTarget(Engine engine, string? offThread = null)
+        : base(
+            type: "page",
+            title: "Unpumped target",
+            url: "about:blank",
+            browserContextId: null,
+            openerId: null,
+            describer: null,
+            waitForDebuggerOnStart: false)
+    {
+        _offThread = offThread;
+        InstallRuntime(engine);
+    }
+
+    /// <summary>Gets how many turns of the mailbox a test has run.</summary>
+    internal int Pumps { get; private set; }
+
+    /// <inheritdoc/>
+    internal override bool RunsOffThread(string method)
+        => _offThread is not null && string.Equals(method, _offThread, StringComparison.Ordinal);
+
+    /// <summary>Runs one turn of the mailbox, which is all a host's loop does for a command.</summary>
+    internal void Pump()
+    {
+        Pumps++;
+        Runtime.Dispatcher.Drain();
+    }
+
+    /// <inheritdoc/>
+    internal override ValueTask CloseAsync()
+    {
+        if (Interlocked.Exchange(ref _closed, 1) == 0)
+        {
+            DisposeRuntime();
+        }
+
+        return default;
+    }
+}


### PR DESCRIPTION
Part of #3701 — item 4, the gateway hook for commands that touch no engine state.

## What was missing

`DevToolsTarget` implements `ICommandGateway`, and its `DispatchAsync` sent **every** command through the engine's mailbox. So "a pause never blocks the loop" was true with one named exception, stated in `FetchDomain`'s class remarks:

> **One case is not covered by that sentence, and it is stated rather than hidden.** A `<script src>` that a *running script* inserted is fetched with the loop blocked rather than pumping — `Runtime/Parsing/AGENTS.md` says why: pumping from inside a running script would run the page's jobs in the middle of one. So a client's answer to a pause on that one fetch cannot be delivered until the fetch ends, and it ends at `BrowserOptions.SubresourceTimeout`. Every other request the page makes — the document, a parser-driven subresource, `fetch`, `XMLHttpRequest`, a worker's module — is answered while the loop is free.

And the thread rule in `Jint.DevTools/AGENTS.md` said it flatly, with no exception:

> - **Every domain method runs on the engine thread.** A `DevToolsDomain` may hold engine state — a `RemoteObjectTable`, a `ScriptRegistry`, a `DebugHandler` subscription — none of it thread-safe.

The command that could end that block was queued behind the very fetch it was about.

## What changed and why

**`DevToolsTarget.RunsOffThread(string method)`** — `internal virtual`, `false` by default. An off-thread method is answered in place with `session.DispatchAsync(in request, context)`; everything else keeps the mailbox. It is `internal` so `Jint.Browser` overrides it through the `InternalsVisibleTo` grant and nothing outside this repository can widen the thread rule.

**The bar for naming a method** is that it *provably* touches no engine state, no `JsValue` and no AngleSharp node — nothing but its own parameters and structures that are thread-safe by construction. A method that reads a `RemoteObjectTable`, a `ScriptRegistry`, a `DebugHandler`, an `Engine` or a DOM node may never be named, whatever it costs on the loop, because there is nothing in the design that would catch it.

Two things the XML doc states because they are what a reader will ask next:

- **An off-thread command needs no `Parameters.Clone()`.** It runs inside `DevToolsSession.HandleMessageAsync`'s own `try`, so the caller's `JsonDocument` is still open. The mailbox clones because an item it answered on a timeout is read by the engine thread *after* that document has gone back to the pool.
- **A navigation never `Abandon`s one.** Abandoning is for a command addressed to a context that was replaced; a command that reaches no engine names no context, and it is answered before a swap could reach it.

**`PageTarget` names exactly three**: `Fetch.continueRequest`, `Fetch.failRequest`, `Fetch.fulfillRequest`. Each looks one entry up in a `ConcurrentDictionary<string, PausedRequest>` and completes a `TaskCompletionSource<PageNetworkDecision>` created with `RunContinuationsAsynchronously`, so the fetch resumes on the thread pool and never on the caller's thread. `Fetch.enable`/`disable` are deliberately **not** named: they mark the domain enabled and emit events, which is the domain's own state rather than a request's, so they keep the ordering every other command has. Nothing else in the page's domains qualifies — everything else reaches a node, a handle or the engine.

The loop still blocks on that one fetch; what changed is that the answer no longer waits for it. `FetchDomain`'s paragraph, `Jint.DevTools/AGENTS.md`'s thread-rule bullet, `Jint.DevTools/Session/AGENTS.md`'s mailbox section and `Jint.Browser/DevTools/AGENTS.md` are all rewritten to say that, with the bar in each.

## The tests that pin it

**`Jint.Tests.Browser/DevTools/FetchDomainTests.ContinuingTheOneFetchTheLoopBlocksOnIsAnsweredWhileItBlocks`** serves a document whose inline script inserts a `<script src>` into the head — the one fetch the page loop blocks on rather than pumping through — pauses only that request with a `Fetch.enable` pattern, and asserts the `Fetch.continueRequest` round trip is answered promptly and that the inserted script really ran. `BrowserOptions.SubresourceTimeout` is lowered to 8 s so a regression fails in seconds rather than in half a minute.

Against the unfixed code (the gateway routing removed, everything else identical) it fails on both target frameworks:

```
Failed ContinuingTheOneFetchTheLoopBlocksOnIsAnsweredWhileItBlocks [8 s]
  Expected clock.Elapsed to be less than 3s because the command touches no engine state,
  so it is answered on the thread that read it rather than queued behind the fetch the loop
  is blocked on, but found 7s, 992ms and 17.3µs.
```

7 s 992 ms is `SubresourceTimeout`: the continue sat in the mailbox until the fetch gave up, by which point the pause it named was gone.

**`Jint.Tests.DevTools/Session/OffThreadCommandTests`** pins the seam itself, through an `UnpumpedTarget` of the suite's own — a real target whose engine nothing ever pumps, declared for the reason `NavigableTarget` and `DomainLifecycleTests` exist. Three cases: a method the target names is answered with `Pumps == 0`; a method the *same* target does not name still goes to the mailbox (so the routing is per method, not per target); and a target that names nothing is answered by the pump as before. The first fails against unfixed code with:

```
Failed AMethodTheTargetNamesIsAnsweredWithTheEngineNeverPumped [353 ms]
  Expected reply.TryGetProperty("error", out var error) to be False because a method the
  target declares off-thread is answered where it was read, and it answered
  {"code":-32000,"message":"Engine is not being pumped","data":"no thread ran the engine's
  event loop within the command timeout; ..."}, but found True.
```

## Test runs

| Suite | net8.0 | net10.0 |
| --- | --- | --- |
| `Jint.Tests.DevTools` | 405 passed, 0 failed | 407 passed, 0 failed |
| `Jint.Tests.Browser` | 1,432 passed, 6 skipped | 1,435 passed, 6 skipped |
| `Jint.Tests` (`WebApi`, `MigrationGuideTests`, `AgentInstructionFileTests`, `SpecCitationTests`) | — | 2,878 passed, 0 failed |

Plus `dotnet build -c Release` on the solution, clean. The six skips are the `JINT_BROWSER_CLIENTS`-gated Playwright suite and the wpt census table, unchanged. Nothing here is public surface — `RunsOffThread` is `internal` — so there is no `docs/v5-migration.md` row and no API baseline movement, and none was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
