### PR TITLE
Web platform tests: a triager can run any document of the corpus and read every result it reported

### DIFF
--- a/Jint.Tests.Browser/Wpt/WptBrowserTriage.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserTriage.cs
@@ -1,0 +1,125 @@
+namespace Jint.Tests.Browser.Wpt;
+
+/// <summary>
+/// Runs the documents <c>JINT_WPT_DOCUMENT</c> names and prints <b>every</b> result each one reported.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It exists because the lane's own driver only ever tells you about the failures it did not expect.</b>
+/// <see cref="WptBrowserTestRunner"/> reports a failing test that no exclusion covers and an exclusion that
+/// covers nothing failing — which is exactly right for a gate and useless for triage, because the two things
+/// a new document needs are the count for its minimum-test entry and the <i>names</i> of everything in it.
+/// Worse, a freshly vendored document is not a case at all until that minimum-test entry exists, so the only
+/// way to find out what to put in the table was to put something in the table and read the failure. This runs
+/// any path the server can serve, whether or not anything else knows about it.
+/// </para>
+/// <para>
+/// <b><c>[Explicit]</c>, and it has to be.</b> The driver funnels every run through
+/// <c>WptBrowserHarness.RunAsync</c>, which records the outcome in the lane's census — so a triage run that
+/// happened during an ordinary pass would put a file in the census that no theory produced. Naming this test
+/// explicitly is what keeps the census the tally of a real run.
+/// </para>
+/// <example>
+/// One document, or several separated by <c>;</c> or <c>,</c>:
+/// <code>
+/// JINT_WPT_DOCUMENT=dom/nodes/Node-cloneNode.html \
+///   dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -nr:false \
+///     --filter "FullyQualifiedName~WptBrowserTriage" -l "console;verbosity=detailed"
+/// </code>
+/// A path is what the server serves: a vendored document (<c>dom/events/Event-propagation.html</c>) or a
+/// wrapper it synthesizes for a vendored script (<c>dom/events/Event-constructors.any.html</c>).
+/// </example>
+/// </remarks>
+[Explicit("Triage: prints every result of the documents JINT_WPT_DOCUMENT names, and records them in the census.")]
+[NonParallelizable]
+public class WptBrowserTriage
+{
+    /// <summary>The environment variable naming what to run, because a test takes no arguments.</summary>
+    private const string Variable = "JINT_WPT_DOCUMENT";
+
+    [Test]
+    public async Task PrintsEveryResultOfTheNamedDocuments()
+    {
+        var documents = Documents();
+
+        if (documents.Count == 0)
+        {
+            Assert.Ignore(
+                $"Set {Variable} to the wpt path to triage — for example "
+                + $"{Variable}=dom/nodes/Node-cloneNode.html — separating several with ';' or ','.");
+        }
+
+        foreach (var path in documents)
+        {
+            await ReportAsync(path).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Runs one document and writes everything it said to the test output.</summary>
+    private static async Task ReportAsync(string path)
+    {
+        var outcome = await WptBrowserHarness.Instance.RunAsync(path).ConfigureAwait(false);
+        var output = TestContext.Out;
+
+        output.WriteLine();
+        output.WriteLine(path);
+        output.WriteLine(new string('-', path.Length));
+
+        if (outcome.HarnessError is { } error)
+        {
+            // A harness error covers the whole file and no per-test exclusion can name it, so it is the first
+            // thing a triager has to see: the answer for such a file is a not-vendored reason, never a row in
+            // the exclusion table.
+            output.WriteLine($"  HARNESS ERROR: {error}");
+        }
+
+        var byStatus = new SortedDictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var result in outcome.Results)
+        {
+            byStatus[result.StatusName] = byStatus.TryGetValue(result.StatusName, out var seen) ? seen + 1 : 1;
+
+            output.WriteLine($"  [{result.StatusName}] {result.Name}");
+
+            if (result.Message is { Length: > 0 } message)
+            {
+                output.WriteLine($"      {message.Replace("\n", "\n      ", StringComparison.Ordinal)}");
+            }
+        }
+
+        output.WriteLine();
+        output.WriteLine($"  {outcome.Results.Count} result(s): {Tally(byStatus)}");
+        output.WriteLine(
+            $"  The minimum-test entry for {path} is {outcome.Results.Count}, which is the floor a file that "
+            + "quietly stops registering its tests has to fall through.");
+    }
+
+    /// <summary>The per-status counts as one line, or a note that nothing reported at all.</summary>
+    private static string Tally(SortedDictionary<string, int> byStatus)
+        => byStatus.Count == 0 ? "nothing reported" : string.Join(", ", byStatus.Select(entry => $"{entry.Value} {entry.Key}"));
+
+    /// <summary>The paths <c>JINT_WPT_DOCUMENT</c> names, in the order it named them.</summary>
+    private static IReadOnlyList<string> Documents()
+    {
+        var value = Environment.GetEnvironmentVariable(Variable);
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return [];
+        }
+
+        var paths = new List<string>();
+
+        foreach (var entry in value!.Split([';', ','], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var path = entry.Trim().Replace('\\', '/').TrimStart('/');
+
+            if (path.Length != 0)
+            {
+                paths.Add(path);
+            }
+        }
+
+        return paths;
+    }
+}


### PR DESCRIPTION
Part of #3701 — its last paragraph, "a test that runs one WPT document and prints every result (triage today means editing the exclusion table to find out what to put in it)".

## What was missing

The browser lane's driver only ever reports what it did **not** expect. `WptBrowserTestRunner.Report` prints a failing test no exclusion covers and an exclusion that covers nothing failing, and nothing else — which is exactly right for a gate and useless for triage, because the two things a document needs before it can become a case are the *count* for its minimum-test entry and the *names* of everything in it.

And a freshly vendored document is not a case at all until that entry exists:

```
{path} is a case with no entry in the minimum-test table, so nothing holds it to anything
```

— `EveryVendoredDocumentIsAccountedFor`. So the only way to find out what to put in the table was to put something in it and read the failure back, which is what the issue says.

## What changed

`Jint.Tests.Browser/Wpt/WptBrowserTriage.cs`, one new file and nothing else. It runs whatever `JINT_WPT_DOCUMENT` names — a vendored document or a wrapper the server synthesizes, a case or not, one or several separated by `;` or `,` — and prints every result with its status, its message and a per-status tally, plus the count a minimum-test entry needs.

```
JINT_WPT_DOCUMENT=dom/nodes/Attr-prefix.html \
  dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -nr:false \
    --filter "FullyQualifiedName~WptBrowserTriage" -l "console;verbosity=detailed"
```

```
dom/nodes/Attr-prefix.html
--------------------------
  [FAIL] Attr.prefix present (HTML)
      Property 'getAttributeNodeNS' of object is not a function
  [FAIL] Attr.prefix absent (HTML)
      Property 'getAttributeNodeNS' of object is not a function
  [FAIL] Attr.prefix present (SVG)
      Property 'getAttributeNodeNS' of object is not a function
  ...

  6 result(s): 6 FAIL
  The minimum-test entry for dom/nodes/Attr-prefix.html is 6, which is the floor a file that
  quietly stops registering its tests has to fall through.
```

**It is `[Explicit]`, and that is not a convenience.** Every run goes through `WptBrowserHarness.RunAsync`, which records its outcome in the lane's census — so a triage run that happened during an ordinary pass would put a file in the census that no theory produced. Naming the test explicitly is what keeps the census the tally of a real run. With the variable unset it ignores itself with the usage line rather than passing silently:

```
Skipped PrintsEveryResultOfTheNamedDocuments [16 ms]
```

**Nothing else is touched.** No exclusion row, no minimum-test entry, no census figure, no `README.md`, no `AGENTS.md` — the whole change is one file that reads the harness and writes to the test output, so the lane is exactly what it was.

## The tests that pin it

The test *is* the tool, so what is pinned is that both of its paths work, both verified by running them:

- with `JINT_WPT_DOCUMENT` set it runs and prints the transcript above (`Passed PrintsEveryResultOfTheNamedDocuments [778 ms]`);
- with it unset it is skipped with the usage line.

`Jint.Tests.Browser` 1435 passed / 6 skipped (net10.0) and 1432 passed / 6 skipped (net8.0), `Jint.Tests.DevTools` 404 / 402 passed, `Jint.Tests` (`WebApi|MigrationGuideTests|AgentInstructionFileTests|SpecCitationTests`, net10.0) 2879 passed. No web-platform-tests movement in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
