### PR TITLE
Page loop: a turn has an ordinal, so a scheduling test can say which turn something happened on

### DIFF
--- a/Jint.Browser/Page.cs
+++ b/Jint.Browser/Page.cs
@@ -399,6 +399,23 @@ public sealed partial class Page : IAsyncDisposable
     /// <summary>The watcher, for the navigation half of this type.</summary>
     internal IPageObserver? Observer => _observer;
 
+    /// <summary>How many turns this page's loop has taken since the page opened.</summary>
+    /// <remarks>
+    /// <para>
+    /// The one thing on <see cref="Page"/> that is <b>not</b> a mailbox request: it is a volatile read of a
+    /// number the loop publishes, safe from any thread and costing the loop nothing to be asked. A turn is a
+    /// bracketed mailbox request or a <c>ProcessTasks</c> drain — <see cref="PageLoop.Turns"/> is the
+    /// definition, including what a navigation and a pump each count as.
+    /// </para>
+    /// <para>
+    /// It exists so that a scheduling test can say <i>which turn</i> something happened on rather than only
+    /// that it eventually did. Read from the loop thread — from inside a request, or from a host function a
+    /// script calls — it is the ordinal of the turn currently running, so two readings that agree happened in
+    /// the same turn.
+    /// </para>
+    /// </remarks>
+    internal int LoopTurns => _loop.Turns;
+
     /// <summary>The identifier of the document currently loaded, which every lifecycle signal carries.</summary>
     internal string LoaderId => _loaderId;
 

--- a/Jint.Browser/Runtime/PageLoop.cs
+++ b/Jint.Browser/Runtime/PageLoop.cs
@@ -49,6 +49,7 @@ internal sealed class PageLoop : IDisposable
     private volatile Engine.TaskOperations? _tasks;
     private volatile PageBudget? _budget;
     private volatile bool _closed;
+    private volatile int _turns;
     private Action<Engine?>? _beforeStop;
 
     /// <summary>The turn the loop currently has open, if any. Loop thread only.</summary>
@@ -71,6 +72,37 @@ internal sealed class PageLoop : IDisposable
 
     /// <summary>The thread this loop runs on, which is the only thread allowed to touch the engine.</summary>
     internal Thread Thread => _thread;
+
+    /// <summary>How many turns this loop has taken since it started.</summary>
+    /// <remarks>
+    /// <para>
+    /// <b>One turn is what the page runtime's <c>AGENTS.md</c> calls one</b>, counted at the two places the
+    /// loop takes one: a <b>bracketed mailbox request</b>, and a <b><c>ProcessTasks</c> drain</b>. Both are
+    /// counted as they open, so a value read from the loop thread itself — from inside a request, a job or a
+    /// listener — is the ordinal of the turn currently running, and two things that read the same number ran
+    /// in the same turn. A drain that finds nothing due still counts, because the loop still took it.
+    /// </para>
+    /// <para>
+    /// <b>A request posted <c>bracketed: false</c> is not a turn, and neither is a drain it performs.</b>
+    /// Those are the pumps — <c>Page.WaitForIdleAsync</c> and <c>Page.WaitForNavigationAsync</c> — and each
+    /// takes the page's <see cref="PageBudget"/> over its own drains directly rather than through the loop,
+    /// so the count stands still for as long as one of them holds the thread. That is the honest reading:
+    /// the loop is not turning, something else is using it.
+    /// </para>
+    /// <para>
+    /// <b><see cref="ReplaceEngine"/>'s close-and-reopen is not a turn either.</b> A navigation is one
+    /// mailbox request from the loop's point of view, and the swap in the middle of it re-arms the budget on
+    /// the incoming engine rather than starting a new unit of work — so a document is replaced without the
+    /// count moving, and a scheduling test that measures a navigation measures the request.
+    /// </para>
+    /// <para>
+    /// An <see cref="int"/> and not a <see cref="long"/>, because the field is <c>volatile</c> — which is
+    /// what a field written here and read from another thread has to be, and which C# does not allow on a
+    /// 64-bit one. It is a scheduling instrument rather than a meter, and it wraps where an
+    /// <see cref="int"/> does.
+    /// </para>
+    /// </remarks>
+    internal int Turns => _turns;
 
     /// <summary>
     /// The engine the loop currently owns, for the members already running on the loop thread.
@@ -290,7 +322,7 @@ internal sealed class PageLoop : IDisposable
                 // The bracket is outside the request rather than inside it, and that is what makes a budget
                 // failure the caller's: PostAsync's own try/catch is inside this one, so a TimeoutException
                 // from the turn's deadline faults that request's Task and nothing reaches the pump.
-                BeginTurn(request.Bracketed);
+                BeginLoopTurn(request.Bracketed);
 
                 try
                 {
@@ -314,7 +346,7 @@ internal sealed class PageLoop : IDisposable
                 // One drain is one turn: every timer callback, microtask, promise reaction and animation
                 // frame that was due shares one time and one allocation budget, because none of them reaches
                 // ExecuteWithConstraints and so none of them is bounded by a per-entry limit at all.
-                BeginTurn(bracketed: true);
+                BeginLoopTurn(bracketed: true);
 
                 try
                 {
@@ -358,6 +390,25 @@ internal sealed class PageLoop : IDisposable
                 _onPumpError(exception);
             }
         }
+    }
+
+    /// <summary>Opens one of the loop's own turns: counts it, then arms the budget over it.</summary>
+    /// <remarks>
+    /// Counting here rather than in <see cref="BeginTurn"/> is what makes <see cref="Turns"/> the count of
+    /// the loop's own turns and nothing else. <see cref="ReplaceEngine"/> re-brackets the request it is
+    /// already running, on the engine that replaced the one the bracket was opened on; that is a budget
+    /// re-armed rather than a second turn, and it goes to <see cref="BeginTurn"/> directly.
+    /// </remarks>
+    private void BeginLoopTurn(bool bracketed)
+    {
+        if (bracketed)
+        {
+            // Written on the loop thread and on no other, so the increment needs nothing beyond the volatile
+            // write the field already is: every reader is on another thread and reads a published value.
+            _turns++;
+        }
+
+        BeginTurn(bracketed);
     }
 
     /// <summary>Opens the loop's own turn on whichever engine it currently owns.</summary>

--- a/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
+++ b/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
@@ -591,6 +591,71 @@ public sealed class ActivationBehaviorTests
     }
 
     /// <summary>
+    /// The same scheduling, measured against the <b>loop's</b> own turns rather than the script's: the
+    /// <c>hashchange</c> listener runs on the turn the click was made on, and not on a later one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The test above pins the script's half of the measurement the page runtime's <c>AGENTS.md</c> made by
+    /// hand — "turn 20 of 20; turn 1 now" — by counting the ticks a page had to spin through. This pins the
+    /// loop's half, and nothing did before: <c>Page.LoopTurns</c> is the ordinal of the turn the loop is
+    /// currently taking, so a click and a listener that read the same number ran in the same one.
+    /// </para>
+    /// <para>
+    /// It is the difference the fix made rather than a restatement of it. Sending the fragment arm of
+    /// <i>navigate</i> round the thread pool and the navigation gate made the commit come back as a mailbox
+    /// request, which is a <i>later turn by construction</i> however few timers were queued in front of it;
+    /// a job on the engine's own queue is delivered by the drain the evaluation performs on its way out,
+    /// before the turn that clicked has ended.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task AFragmentLinkFiresHashChangeOnTheTurnTheClickWasMadeOn()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<a id='go'>go</a><p id='target'>t</p>");
+
+        // Installed on the engine the document ended up with, from the loop, the way a protocol client
+        // installs a binding. Reading the count is a volatile read of a number this very thread publishes.
+        await page.RunOnLoopAsync(engine =>
+        {
+            engine.SetValue("loopTurn", new Func<double>(() => page.LoopTurns));
+            return true;
+        });
+
+        await page.EvaluateAsync(
+            """
+            window.clicked = -1;
+            window.heard = -2;
+            window.ticks = 0;
+            window.onhashchange = () => { window.heard = loopTurn(); };
+            // The absolute form, because resolving a bare `#target` is AngleSharp's and it mangles an
+            // `about:blank` base; what is measured here is when the navigation lands, not how it resolved.
+            document.getElementById('go').setAttribute('href', location.href + '#target');
+            window.clicked = loopTurn();
+            document.getElementById('go').click();
+            (function tick() {
+              window.ticks++;
+              if (window.ticks < 20 && window.heard < 0) { setTimeout(tick, 0); }
+            })();
+            """);
+
+        await page.WaitForIdleAsync(TimeSpan.FromSeconds(5));
+
+        var clicked = await page.EvaluateAsync<double>("window.clicked");
+        var heard = await page.EvaluateAsync<double>("window.heard");
+
+        clicked.Should().BeGreaterThan(0, "the click ran on a turn of the loop");
+        heard.Should().Be(clicked, "the fragment move is a job on the engine's own queue, so it is delivered before the turn that clicked ends");
+
+        // And the number moves, so the equality above is two things in one turn rather than a counter that
+        // never advanced: the idle wait and the two reads after it are turns of their own.
+        ((double) page.LoopTurns).Should().BeGreaterThan(clicked);
+        page.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
     /// https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox) — step 1 of the
     /// checkbox and radio activation behaviours is "if the element is not connected, then return", so a
     /// detached control toggles silently.

--- a/Jint.Tests.Browser/Runtime/PageSchedulingTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageSchedulingTests.cs
@@ -172,6 +172,37 @@ public sealed class PageSchedulingTests
         (await page.EvaluateAsync<int>("window.ticks")).Should().BeGreaterThan(0);
     }
 
+    /// <summary>
+    /// <c>Page.LoopTurns</c> counts the loop's own turns and nothing else: a request the page is given costs
+    /// it one, and a page nobody is asking anything of costs it none.
+    /// </summary>
+    /// <remarks>
+    /// The long park is what makes the second half assertable at all. A page's loop wakes every
+    /// <c>BrowserOptions.PumpIdle</c> to drain whatever came due, so a default page turns twenty times a
+    /// second with nothing to do; this one is given a park it will not wake from on its own, and what the
+    /// counter reports over a quiet window is then exactly what was posted to it.
+    /// </remarks>
+    [Test]
+    public async Task TheLoopTurnCountRisesWhenTheLoopTurnsAndNotOtherwise()
+    {
+        await using var browser = new Browser(new BrowserOptions { PumpIdle = TimeSpan.FromMinutes(5) });
+        var page = await browser.NewPageAsync();
+
+        // Whatever opening the page cost the loop, spent before anything is measured: this request is a
+        // turn, the drain behind it is another, and then the loop parks.
+        await page.EvaluateAsync("1");
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+
+        var parked = page.LoopTurns;
+        parked.Should().BeGreaterThan(0, "opening a page and evaluating in it are turns");
+
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+        page.LoopTurns.Should().Be(parked, "a parked loop turns for nobody");
+
+        await page.EvaluateAsync("1");
+        page.LoopTurns.Should().BeGreaterThan(parked, "a mailbox request is a turn");
+    }
+
     [Test]
     public async Task TheRecordingsAreBounded()
     {


### PR DESCRIPTION
Part of #3701 — its last paragraph asks for "a per-`Page` loop-turn counter for scheduling tests".

## What was missing

`Jint.Browser/Runtime/AGENTS.md` defines what a turn is and then **counts them by hand**, in the paragraph about same-document fragment navigation:

> `Page.RequestNavigation` used to send an `<a href="#x">` round the thread pool and the gate, which put the commit behind every timer already due, so a page that clicked a link and then spun zero-delay timers waiting for `hashchange` waited out the whole chain (**measured at turn 20 of 20; turn 1 now**).

That measurement was made once, by hand, and nothing in the suite held the scheduling to it. `git grep -n "turn 20"` found the prose and no counter anywhere.

## What changed

`PageLoop` counts its own turns. `BeginLoopTurn` wraps the bracket at the two places the loop takes one — a bracketed mailbox request and a `ProcessTasks` drain — and `Page.LoopTurns` publishes the count. Three decisions are in the XML doc, because a test that reads the number has to know what one means:

- **A request posted `bracketed: false` is not a turn, and neither is a drain it performs.** Those are the pumps (`WaitForIdleAsync`, `WaitForNavigationAsync`), and each takes the page's `PageBudget` over its own drains directly rather than through the loop — so the count stands still for as long as one holds the thread.
- **`ReplaceEngine`'s close-and-reopen is not a turn either.** A navigation is one mailbox request from the loop's point of view, and the swap re-arms the budget on the incoming engine rather than starting a new unit of work, so it goes to `BeginTurn` directly.
- **The count is as of the moment it is read**, so a value read *on* the loop — from a request, a job, or a host function a script calls — is the ordinal of the turn currently running, and two readings that agree ran in one turn.

The field is `volatile`, like every other cross-thread field in that class, which is why it is an `int`: C# does not allow `volatile` on a 64-bit field, and this is a scheduling instrument rather than a meter.

**Both members are `internal`.** `Jint.Browser/AGENTS.md`'s "seams promoted later" keeps everything but the named host API internal until its shape has settled, and `Jint.Tests.Browser` holds the `InternalsVisibleTo` grant — so `Jint.Tests.Browser/Verify/PublicApiTest.verified.txt` is untouched, and there is no `docs/v5-migration.md` row.

## The tests that pin it

**`AFragmentLinkFiresHashChangeOnTheTurnTheClickWasMadeOn`** (beside `AFragmentLinkFiresHashChangeOnTheNextTurn`, which pins the *script's* half of the same measurement). A host function reading `Page.LoopTurns` is installed on the page's engine the way a protocol client installs a binding; the script records the turn just before the click and the `hashchange` listener records it again, and they are the same number. Routing the fragment arm of *navigate* round the thread pool and the gate made the commit come back as a mailbox request, which is a **later turn by construction** however few timers were queued in front of it.

**`TheLoopTurnCountRisesWhenTheLoopTurnsAndNotOtherwise`** proves the counter measures something real rather than time passing: with a `PumpIdle` the loop will not wake from on its own, a quiet page's count does not move over a 250 ms window, and a posted request moves it.

### Against unfixed code

Neither compiles without the counter — the whole change is the counter — so the useful check was that the equality is not vacuous. Temporarily asserting `heard == clicked + 1`:

```
Expected value to be 13.0 because the fragment move is a job on the engine's own queue, so it is
delivered before the turn that clicked ends, but found 12.0 (difference of -1).
```

Real turn ordinals: the click ran on turn 12 and the listener ran on turn 12. The test keeps a third assertion that `Page.LoopTurns` is greater than `clicked` after the idle wait, so the equality is two things in one turn rather than a counter that never moved.

## Test runs

All in Release, `-nr:false`:

| | net8.0 | net10.0 |
| --- | --- | --- |
| `Jint.Tests.Browser` | 1437 passed, 6 skipped | 1440 passed, 6 skipped |
| `Jint.Tests.DevTools` | 402 passed | 404 passed |
| `Jint.Tests` (WebApi / MigrationGuide / AgentInstructionFile / SpecCitation) | — | 2879 passed |

`dotnet build -c Release` on the solution: 0 errors, and the one pre-existing `MSB3277`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
