### PR TITLE
Page: a title a script sets after load is reported, because the end of every turn looks at it

### DIFF
--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -739,9 +739,12 @@ public sealed partial class Page
 
     /// <summary>Tells the watcher how far the load got, and arms the quiet period once it is loaded.</summary>
     /// <remarks>
-    /// The title is reported at each of the three, because it is what a client shows for the target and the
-    /// parse is what settles it: a document's <c>&lt;title&gt;</c> is in place by the commit, and a script
-    /// that rewrites it does so before <c>load</c> far more often than after.
+    /// The title is looked at again at each of the three, because it is what a client shows for the target
+    /// and the parse is what settles it: a document's <c>&lt;title&gt;</c> is in place by the commit, and a
+    /// script that rewrites it does so before <c>load</c> far more often than after. <i>Far more often</i> is
+    /// not <i>always</i>, which is why <see cref="ReportTitleAtEndOfTurn"/> looks at it every turn as well;
+    /// both go through <see cref="ReportTitle"/>, so a title that has not moved is reported by neither and a
+    /// title that has is reported once, at whichever of them saw it first.
     /// </remarks>
     private void Reached(PageRuntime runtime, NavigationPhase phase, string loaderId)
     {
@@ -759,7 +762,7 @@ public sealed partial class Page
         }
 
         observer.Phase(phase, loaderId);
-        observer.TitleChanged(runtime.Document?.Title ?? "");
+        ReportTitle(runtime.Document?.Title ?? "");
 
         if (phase == NavigationPhase.Loaded)
         {

--- a/Jint.Browser/Page.cs
+++ b/Jint.Browser/Page.cs
@@ -399,6 +399,23 @@ public sealed partial class Page : IAsyncDisposable
     /// <summary>The watcher, for the navigation half of this type.</summary>
     internal IPageObserver? Observer => _observer;
 
+    /// <summary>How many turns this page's loop has taken since the page opened.</summary>
+    /// <remarks>
+    /// <para>
+    /// The one thing on <see cref="Page"/> that is <b>not</b> a mailbox request: it is a volatile read of a
+    /// number the loop publishes, safe from any thread and costing the loop nothing to be asked. A turn is a
+    /// bracketed mailbox request or a <c>ProcessTasks</c> drain — <see cref="PageLoop.Turns"/> is the
+    /// definition, including what a navigation and a pump each count as.
+    /// </para>
+    /// <para>
+    /// It exists so that a scheduling test can say <i>which turn</i> something happened on rather than only
+    /// that it eventually did. Read from the loop thread — from inside a request, or from a host function a
+    /// script calls — it is the ordinal of the turn currently running, so two readings that agree happened in
+    /// the same turn.
+    /// </para>
+    /// </remarks>
+    internal int LoopTurns => _loop.Turns;
+
     /// <summary>The identifier of the document currently loaded, which every lifecycle signal carries.</summary>
     internal string LoaderId => _loaderId;
 

--- a/Jint.Browser/Page.cs
+++ b/Jint.Browser/Page.cs
@@ -69,6 +69,9 @@ public sealed partial class Page : IAsyncDisposable
     /// </summary>
     private readonly string _loaderIdPrefix = Guid.NewGuid().ToString("N").ToUpperInvariant() + ".";
 
+    /// <summary>The title the watcher was last told, so that only a move is reported. Loop thread only.</summary>
+    private string _reportedTitle = "";
+
     private readonly System.Threading.Lock _idleGate = new();
     private Timer? _idleTimer;
     private string _idleLoaderId = "";
@@ -97,11 +100,71 @@ public sealed partial class Page : IAsyncDisposable
             "Jint.Browser page loop",
             options.PumpIdle,
             () => BuildEngine("about:blank", ""),
-            exception => recorder.Add(PumpErrorKind(exception), exception.Message, "PageLoop"));
+            exception => recorder.Add(PumpErrorKind(exception), exception.Message, "PageLoop"),
+            ReportTitleAtEndOfTurn);
 
         // The recorder is built before the page, so it is told here where to read the page's URL from — the
         // same volatile field the network log reads, so an error and a request name one document.
         recorder.DocumentUrl = () => _url;
+    }
+
+    /// <summary>
+    /// Looks at <c>document.title</c> at the end of one of the loop's turns, and reports a move.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why here and not from the DOM.</b> The navigation phases report the title too, and until this hook
+    /// existed they were the only ones that did — so a title a script set after <c>load</c> reached a client
+    /// only at the next navigation. A DOM-side notification would mean AngleSharp's own
+    /// <c>MutationObserver</c>, which queues a record for <i>every</i> mutation of <i>every</i> page whether
+    /// or not anyone is watching; that is the wrong trade for one string, and it is the same trade
+    /// <c>Layout/FlatLayout</c> declines for the same reason. The end of a turn is the moment a script has
+    /// finished running and the loop is about to go and do something else, which is where a browser would
+    /// have painted.
+    /// </para>
+    /// <para>
+    /// <b>What it costs, exactly.</b> A page nobody is watching pays <i>nothing</i>: the observer is checked
+    /// first, and a page with none returns before touching the document. A watched page pays one
+    /// <c>IDocument.Title</c> read per turn, which for an HTML document is AngleSharp's
+    /// <c>DocumentElement.FindDescendant&lt;IHtmlTitleElement&gt;()</c> — a depth-first walk that <b>stops at
+    /// the first title element</b>. So a document with a <c>&lt;title&gt;</c> in its <c>&lt;head&gt;</c>
+    /// costs a handful of node visits, and one <i>without</i> a title costs a walk of its whole tree, once
+    /// per turn, for as long as a watcher is attached. The cheap-looking short circuit — search
+    /// <c>document.Head</c> only — is <i>not</i> taken: it is not exactly correct, because HTML's
+    /// <c>document.title</c> is the first <c>title</c> element in tree order wherever it sits, and a page
+    /// that puts one in its body would silently stop being reported.
+    /// </para>
+    /// <para>Runs on the loop thread, outside the turn's budget bracket. See <see cref="PageLoop"/>.</para>
+    /// </remarks>
+    private void ReportTitleAtEndOfTurn(Engine engine)
+    {
+        if (_observer is null)
+        {
+            return;
+        }
+
+        ReportTitle(PageRuntime.Find(engine)?.Document?.Title ?? "");
+    }
+
+    /// <summary>Tells the watcher the title, if it has moved since the last time it was told.</summary>
+    /// <remarks>
+    /// The one place <see cref="IPageObserver.TitleChanged"/> is called from, so that the three navigation
+    /// phases and every turn of the loop cannot between them report one title more than once. A client
+    /// dedupes as well — <c>DevToolsTarget.UpdateInfo</c> raises nothing unless the value moved — but the
+    /// watcher is a seam a host may implement, and it is owed one call per move rather than one per look.
+    /// The last-reported title is the <i>page's</i>, not a watcher's, so one that registers mid-life reads
+    /// the current title for itself — <c>PageTarget</c> does, as the target is created — rather than being
+    /// told it here.
+    /// </remarks>
+    private void ReportTitle(string title)
+    {
+        if (_observer is not { } observer || string.Equals(_reportedTitle, title, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _reportedTitle = title;
+        observer.TitleChanged(title);
     }
 
     /// <summary>What a page calls something that erupts from its pump rather than from a callback.</summary>

--- a/Jint.Browser/Runtime/PageLoop.cs
+++ b/Jint.Browser/Runtime/PageLoop.cs
@@ -49,6 +49,7 @@ internal sealed class PageLoop : IDisposable
     private volatile Engine.TaskOperations? _tasks;
     private volatile PageBudget? _budget;
     private volatile bool _closed;
+    private volatile int _turns;
     private Action<Engine?>? _beforeStop;
 
     /// <summary>The turn the loop currently has open, if any. Loop thread only.</summary>
@@ -71,6 +72,37 @@ internal sealed class PageLoop : IDisposable
 
     /// <summary>The thread this loop runs on, which is the only thread allowed to touch the engine.</summary>
     internal Thread Thread => _thread;
+
+    /// <summary>How many turns this loop has taken since it started.</summary>
+    /// <remarks>
+    /// <para>
+    /// <b>One turn is what the page runtime's <c>AGENTS.md</c> calls one</b>, counted at the two places the
+    /// loop takes one: a <b>bracketed mailbox request</b>, and a <b><c>ProcessTasks</c> drain</b>. Both are
+    /// counted as they open, so a value read from the loop thread itself — from inside a request, a job or a
+    /// listener — is the ordinal of the turn currently running, and two things that read the same number ran
+    /// in the same turn. A drain that finds nothing due still counts, because the loop still took it.
+    /// </para>
+    /// <para>
+    /// <b>A request posted <c>bracketed: false</c> is not a turn, and neither is a drain it performs.</b>
+    /// Those are the pumps — <c>Page.WaitForIdleAsync</c> and <c>Page.WaitForNavigationAsync</c> — and each
+    /// takes the page's <see cref="PageBudget"/> over its own drains directly rather than through the loop,
+    /// so the count stands still for as long as one of them holds the thread. That is the honest reading:
+    /// the loop is not turning, something else is using it.
+    /// </para>
+    /// <para>
+    /// <b><see cref="ReplaceEngine"/>'s close-and-reopen is not a turn either.</b> A navigation is one
+    /// mailbox request from the loop's point of view, and the swap in the middle of it re-arms the budget on
+    /// the incoming engine rather than starting a new unit of work — so a document is replaced without the
+    /// count moving, and a scheduling test that measures a navigation measures the request.
+    /// </para>
+    /// <para>
+    /// An <see cref="int"/> and not a <see cref="long"/>, because the field is <c>volatile</c> — which is
+    /// what a field written here and read from another thread has to be, and which C# does not allow on a
+    /// 64-bit one. It is a scheduling instrument rather than a meter, and it wraps where an
+    /// <see cref="int"/> does.
+    /// </para>
+    /// </remarks>
+    internal int Turns => _turns;
 
     /// <summary>
     /// The engine the loop currently owns, for the members already running on the loop thread.
@@ -290,7 +322,7 @@ internal sealed class PageLoop : IDisposable
                 // The bracket is outside the request rather than inside it, and that is what makes a budget
                 // failure the caller's: PostAsync's own try/catch is inside this one, so a TimeoutException
                 // from the turn's deadline faults that request's Task and nothing reaches the pump.
-                BeginTurn(request.Bracketed);
+                BeginLoopTurn(request.Bracketed);
 
                 try
                 {
@@ -314,7 +346,7 @@ internal sealed class PageLoop : IDisposable
                 // One drain is one turn: every timer callback, microtask, promise reaction and animation
                 // frame that was due shares one time and one allocation budget, because none of them reaches
                 // ExecuteWithConstraints and so none of them is bounded by a per-entry limit at all.
-                BeginTurn(bracketed: true);
+                BeginLoopTurn(bracketed: true);
 
                 try
                 {
@@ -358,6 +390,25 @@ internal sealed class PageLoop : IDisposable
                 _onPumpError(exception);
             }
         }
+    }
+
+    /// <summary>Opens one of the loop's own turns: counts it, then arms the budget over it.</summary>
+    /// <remarks>
+    /// Counting here rather than in <see cref="BeginTurn"/> is what makes <see cref="Turns"/> the count of
+    /// the loop's own turns and nothing else. <see cref="ReplaceEngine"/> re-brackets the request it is
+    /// already running, on the engine that replaced the one the bracket was opened on; that is a budget
+    /// re-armed rather than a second turn, and it goes to <see cref="BeginTurn"/> directly.
+    /// </remarks>
+    private void BeginLoopTurn(bool bracketed)
+    {
+        if (bracketed)
+        {
+            // Written on the loop thread and on no other, so the increment needs nothing beyond the volatile
+            // write the field already is: every reader is on another thread and reads a published value.
+            _turns++;
+        }
+
+        BeginTurn(bracketed);
     }
 
     /// <summary>Opens the loop's own turn on whichever engine it currently owns.</summary>

--- a/Jint.Browser/Runtime/PageLoop.cs
+++ b/Jint.Browser/Runtime/PageLoop.cs
@@ -42,6 +42,7 @@ internal sealed class PageLoop : IDisposable
     private readonly TaskCompletionSource _stopped = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Func<Engine> _engineFactory;
     private readonly Action<Exception> _onPumpError;
+    private readonly Action<Engine>? _onTurnEnd;
     private readonly TimeSpan _idle;
     private readonly Thread _thread;
 
@@ -56,11 +57,28 @@ internal sealed class PageLoop : IDisposable
     private PageBudget.TurnScope _turn;
     private bool _inTurn;
 
-    internal PageLoop(string name, TimeSpan idle, Func<Engine> engineFactory, Action<Exception> onPumpError)
+    /// <param name="name">What the loop's thread is called.</param>
+    /// <param name="idle">The ceiling on a park with nothing due.</param>
+    /// <param name="engineFactory">Builds the first engine, on the loop thread.</param>
+    /// <param name="onPumpError">Where anything that erupts out of the pump is recorded.</param>
+    /// <param name="onTurnEnd">
+    /// What the page does at the end of each of the loop's own turns, with the engine the turn ran on, or
+    /// <see langword="null"/> for a loop that does nothing there. It runs <i>outside</i> the turn's budget
+    /// bracket, so a page's own bookkeeping cannot spend the budget a caller's request is bounded by or fail
+    /// that request; anything it throws goes to <paramref name="onPumpError"/> like everything else the loop
+    /// runs, because a page survives what watches it as well as what it runs.
+    /// </param>
+    internal PageLoop(
+        string name,
+        TimeSpan idle,
+        Func<Engine> engineFactory,
+        Action<Exception> onPumpError,
+        Action<Engine>? onTurnEnd = null)
     {
         _idle = idle;
         _engineFactory = engineFactory;
         _onPumpError = onPumpError;
+        _onTurnEnd = onTurnEnd;
         _thread = new Thread(Run) { IsBackground = true, Name = name };
     }
 
@@ -330,7 +348,7 @@ internal sealed class PageLoop : IDisposable
                 }
                 finally
                 {
-                    EndTurn();
+                    EndLoopTurn();
                 }
             }
 
@@ -354,7 +372,7 @@ internal sealed class PageLoop : IDisposable
                 }
                 finally
                 {
-                    EndTurn();
+                    EndLoopTurn();
                 }
             }
             catch (Exception exception)
@@ -421,6 +439,41 @@ internal sealed class PageLoop : IDisposable
 
         _turn = budget.BeginTurn();
         _inTurn = true;
+    }
+
+    /// <summary>Closes one of the loop's own turns: unarms the budget, then tells the page it ended.</summary>
+    /// <remarks>
+    /// <para>
+    /// The hook runs <b>after</b> <see cref="EndTurn"/> and not inside it, for two reasons and both matter.
+    /// A turn's budget bounds the work the turn was <i>for</i>: charging a page's own end-of-turn bookkeeping
+    /// to it would let that bookkeeping fail a caller's request with a <see cref="TimeoutException"/> the
+    /// caller could do nothing about. And <see cref="ReplaceEngine"/> closes a turn mid-request through
+    /// <see cref="EndTurn"/> directly, so a navigation runs the hook <b>once</b> — at the end of the request,
+    /// on the engine the swap installed and the document now showing — rather than twice, once about a
+    /// document that has been thrown away.
+    /// </para>
+    /// <para>
+    /// It is wrapped, like everything else the loop runs on a page's behalf. A page survives its scripts;
+    /// it survives what watches them too.
+    /// </para>
+    /// </remarks>
+    private void EndLoopTurn()
+    {
+        EndTurn();
+
+        if (_onTurnEnd is not { } onTurnEnd || _engine is not { } engine)
+        {
+            return;
+        }
+
+        try
+        {
+            onTurnEnd(engine);
+        }
+        catch (Exception exception)
+        {
+            _onPumpError(exception);
+        }
     }
 
     /// <summary>Closes it, if one is open. Safe to call when none is.</summary>

--- a/Jint.Tests.Browser/DevTools/PageDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/PageDomainTests.cs
@@ -450,5 +450,75 @@ public class PageDomainTests
         (await session.EvaluateAsync("1 + 1", attachment)).GetProperty("value").GetInt32().Should().Be(2);
     }
 
+    /// <summary>
+    /// A title a script sets <b>after</b> <c>load</c> reaches the client, with no navigation to carry it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The page used to report its title only at the three navigation phases, and
+    /// <c>Page.Navigation.cs</c>'s own remark admitted the gap — "a script that rewrites it does so before
+    /// <c>load</c> far more often than after". Far more often is not always: a single-page application that
+    /// sets <c>document.title</c> from its router does it after <c>load</c> every time, and until the page
+    /// looked at the title at the end of each of its loop's turns, a client was told the old one until the
+    /// next navigation.
+    /// </para>
+    /// <para>
+    /// <c>Target.targetInfoChanged</c> is what a client reads <c>page.title()</c> from, and it needs
+    /// <c>Target.setDiscoverTargets</c> — the first thing every recorded client turns on — to reach one at
+    /// all. The event is deduped by the target, so what is asserted here is that one arrives carrying the new
+    /// title, while the page is still showing the document it loaded.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task ATitleSetAfterLoadReachesTheClientWithoutANavigation()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml(
+            "/one",
+            """
+            <html><head><title>Before load</title></head><body>
+            <script>addEventListener('load', () => setTimeout(() => { document.title = 'After load' }, 5))</script>
+            </body></html>
+            """);
+
+        await using var session = await PageSession.CreateAsync(Options(server));
+
+        // Discovery is what makes targetInfoChanged reach a client at all, and it is the first thing every
+        // recorded client turns on.
+        await session.ResultAsync("Target.setDiscoverTargets", """{"discover":true}""");
+
+        var page = await session.NewPageAsync();
+        var target = await session.TargetForAsync(page);
+        var attachment = await session.AttachAsync(target);
+        await session.EnablePageAsync(attachment);
+
+        await page.NavigateAsync(server.Url("/one"));
+
+        // Nothing else is driven from here: the page's own loop turns, the timer fires in one of its drains,
+        // and the end of that turn is what tells the target.
+        var deadline = Environment.TickCount64 + 30_000L;
+        string? announced = null;
+
+        while (Environment.TickCount64 < deadline && announced is null)
+        {
+            announced = session.EventsOf("Target.targetInfoChanged")
+                .Select(message => message.GetProperty("params").GetProperty("targetInfo").GetProperty("title").GetString())
+                .LastOrDefault(title => string.Equals(title, "After load", StringComparison.Ordinal));
+
+            if (announced is null)
+            {
+                await Task.Delay(20);
+            }
+        }
+
+        announced.Should().Be("After load", "a watched page looks at its title at the end of every turn");
+
+        // And it got there without a navigation: the document, and the loader identifier naming it, are the
+        // ones the one navigation of this test produced.
+        page.Url.Should().Be(server.Url("/one"));
+        (await page.TitleAsync()).Should().Be("After load");
+        page.Errors.Should().BeEmpty();
+    }
+
     private static BrowserContextOptions Options(LoopbackServer server) => new() { UrlFilter = server.Owns };
 }

--- a/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
+++ b/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
@@ -591,6 +591,71 @@ public sealed class ActivationBehaviorTests
     }
 
     /// <summary>
+    /// The same scheduling, measured against the <b>loop's</b> own turns rather than the script's: the
+    /// <c>hashchange</c> listener runs on the turn the click was made on, and not on a later one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The test above pins the script's half of the measurement the page runtime's <c>AGENTS.md</c> made by
+    /// hand — "turn 20 of 20; turn 1 now" — by counting the ticks a page had to spin through. This pins the
+    /// loop's half, and nothing did before: <c>Page.LoopTurns</c> is the ordinal of the turn the loop is
+    /// currently taking, so a click and a listener that read the same number ran in the same one.
+    /// </para>
+    /// <para>
+    /// It is the difference the fix made rather than a restatement of it. Sending the fragment arm of
+    /// <i>navigate</i> round the thread pool and the navigation gate made the commit come back as a mailbox
+    /// request, which is a <i>later turn by construction</i> however few timers were queued in front of it;
+    /// a job on the engine's own queue is delivered by the drain the evaluation performs on its way out,
+    /// before the turn that clicked has ended.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task AFragmentLinkFiresHashChangeOnTheTurnTheClickWasMadeOn()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<a id='go'>go</a><p id='target'>t</p>");
+
+        // Installed on the engine the document ended up with, from the loop, the way a protocol client
+        // installs a binding. Reading the count is a volatile read of a number this very thread publishes.
+        await page.RunOnLoopAsync(engine =>
+        {
+            engine.SetValue("loopTurn", new Func<double>(() => page.LoopTurns));
+            return true;
+        });
+
+        await page.EvaluateAsync(
+            """
+            window.clicked = -1;
+            window.heard = -2;
+            window.ticks = 0;
+            window.onhashchange = () => { window.heard = loopTurn(); };
+            // The absolute form, because resolving a bare `#target` is AngleSharp's and it mangles an
+            // `about:blank` base; what is measured here is when the navigation lands, not how it resolved.
+            document.getElementById('go').setAttribute('href', location.href + '#target');
+            window.clicked = loopTurn();
+            document.getElementById('go').click();
+            (function tick() {
+              window.ticks++;
+              if (window.ticks < 20 && window.heard < 0) { setTimeout(tick, 0); }
+            })();
+            """);
+
+        await page.WaitForIdleAsync(TimeSpan.FromSeconds(5));
+
+        var clicked = await page.EvaluateAsync<double>("window.clicked");
+        var heard = await page.EvaluateAsync<double>("window.heard");
+
+        clicked.Should().BeGreaterThan(0, "the click ran on a turn of the loop");
+        heard.Should().Be(clicked, "the fragment move is a job on the engine's own queue, so it is delivered before the turn that clicked ends");
+
+        // And the number moves, so the equality above is two things in one turn rather than a counter that
+        // never advanced: the idle wait and the two reads after it are turns of their own.
+        ((double) page.LoopTurns).Should().BeGreaterThan(clicked);
+        page.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
     /// https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox) — step 1 of the
     /// checkbox and radio activation behaviours is "if the element is not connected, then return", so a
     /// detached control toggles silently.

--- a/Jint.Tests.Browser/Runtime/PageObserverTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageObserverTests.cs
@@ -54,10 +54,106 @@ public sealed class PageObserverTests
         recorder.ParsedLoaderId.Should().Be(recorder.CommittedLoaderId);
     }
 
+    /// <summary>
+    /// A title the markup declares is reported once, at the phase that already reported it — the end of the
+    /// turn looks again and finds nothing has moved.
+    /// </summary>
+    /// <remarks>
+    /// The page looks at <c>document.title</c> at the end of every one of its loop's turns, so that a script
+    /// which sets it after <c>load</c> is not sat on until the next navigation. The three navigation phases
+    /// look at it too, and a document's <c>&lt;title&gt;</c> is in place by the commit — so without one place
+    /// deciding, one title would be announced four times over. <c>Page.ReportTitle</c> is that place, and
+    /// this is what holds it to one call per move.
+    /// </remarks>
+    [Test]
+    public async Task ATitleTheMarkupDeclaresIsReportedOnceAtThePhaseThatAlreadyReportedIt()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        var recorder = new Recorder();
+        await page.RunOnLoopAsync(_ =>
+        {
+            page.Observe(recorder);
+            return true;
+        });
+
+        await page.SetContentAsync("<html><head><title>Parsed</title></head><body><p>x</p></body></html>");
+        await page.WaitForIdleAsync(TimeSpan.FromSeconds(5));
+
+        // One document's title is one move, however many places look at it.
+        recorder.Titles.Should().Equal(new[] { "Parsed" });
+        recorder.Calls.Should().ContainInOrder("Phase(Committed)", "TitleChanged(Parsed)");
+    }
+
+    /// <summary>
+    /// A page nobody is watching is never asked what its title is, and one that is watched again resumes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The end-of-turn look is not free: <c>IDocument.Title</c> is AngleSharp's depth-first search for the
+    /// first <c>&lt;title&gt;</c> element, which stops at one and walks the whole tree when there is none. So
+    /// the observer is checked <i>first</i> and a page with none returns before touching the document at all
+    /// — which is most pages, because <c>Page.Observer</c> is null for every page nobody is driving over the
+    /// protocol.
+    /// </para>
+    /// <para>
+    /// What is asserted is the seam rather than the timing: the title moves while nothing is watching and no
+    /// call is made about it, and the move is announced on the next turn once a watcher is back.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task APageNobodyIsWatchingIsNeverAskedForItsTitle()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        var recorder = new Recorder();
+        await page.RunOnLoopAsync(_ =>
+        {
+            page.Observe(recorder);
+            return true;
+        });
+
+        await page.SetContentAsync("<html><head><title>Watched</title></head><body></body></html>");
+        await page.WaitForIdleAsync(TimeSpan.FromSeconds(5));
+        recorder.Titles.Should().Equal(new[] { "Watched" });
+
+        await page.RunOnLoopAsync(_ =>
+        {
+            page.Observe(null);
+            return true;
+        });
+
+        await page.EvaluateAsync("document.title = 'Unwatched'");
+
+        // A second request, so that the turn the assignment ran in has ended before the assertion: the look
+        // this test says does not happen is the one at the end of that turn.
+        await page.EvaluateAsync("1");
+        (await page.TitleAsync()).Should().Be("Unwatched", "the title really did move");
+        // A page with no observer looks at nothing and tells nobody.
+        recorder.Titles.Should().Equal(new[] { "Watched" });
+
+        await page.RunOnLoopAsync(_ =>
+        {
+            page.Observe(recorder);
+            return true;
+        });
+
+        await page.EvaluateAsync("1");
+        await page.EvaluateAsync("1");
+
+        // A watcher that is back is told on the next turn.
+        recorder.Titles.Should().Equal(new[] { "Watched", "Unwatched" });
+    }
+
     /// <summary>Records what it is told, on the loop it is told it on.</summary>
     private sealed class Recorder : IPageObserver
     {
         internal List<string> Calls { get; } = [];
+
+        /// <summary>Every title it has been told, in order, so a second report of one is visible.</summary>
+        internal List<string> Titles { get; } = [];
 
         internal string? CreatedGreeting { get; private set; }
 
@@ -91,6 +187,12 @@ public sealed class PageObserverTests
             {
                 CommittedLoaderId = loaderId;
             }
+        }
+
+        public void TitleChanged(string title)
+        {
+            Calls.Add("TitleChanged(" + title + ")");
+            Titles.Add(title);
         }
 
         private static string? Greeting(PageRuntime runtime)

--- a/Jint.Tests.Browser/Runtime/PageSchedulingTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageSchedulingTests.cs
@@ -172,6 +172,37 @@ public sealed class PageSchedulingTests
         (await page.EvaluateAsync<int>("window.ticks")).Should().BeGreaterThan(0);
     }
 
+    /// <summary>
+    /// <c>Page.LoopTurns</c> counts the loop's own turns and nothing else: a request the page is given costs
+    /// it one, and a page nobody is asking anything of costs it none.
+    /// </summary>
+    /// <remarks>
+    /// The long park is what makes the second half assertable at all. A page's loop wakes every
+    /// <c>BrowserOptions.PumpIdle</c> to drain whatever came due, so a default page turns twenty times a
+    /// second with nothing to do; this one is given a park it will not wake from on its own, and what the
+    /// counter reports over a quiet window is then exactly what was posted to it.
+    /// </remarks>
+    [Test]
+    public async Task TheLoopTurnCountRisesWhenTheLoopTurnsAndNotOtherwise()
+    {
+        await using var browser = new Browser(new BrowserOptions { PumpIdle = TimeSpan.FromMinutes(5) });
+        var page = await browser.NewPageAsync();
+
+        // Whatever opening the page cost the loop, spent before anything is measured: this request is a
+        // turn, the drain behind it is another, and then the loop parks.
+        await page.EvaluateAsync("1");
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+
+        var parked = page.LoopTurns;
+        parked.Should().BeGreaterThan(0, "opening a page and evaluating in it are turns");
+
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+        page.LoopTurns.Should().Be(parked, "a parked loop turns for nobody");
+
+        await page.EvaluateAsync("1");
+        page.LoopTurns.Should().BeGreaterThan(parked, "a mailbox request is a turn");
+    }
+
     [Test]
     public async Task TheRecordingsAreBounded()
     {


### PR DESCRIPTION
Part of #3684 (item 2).

> **Stacks on #3797** — its first commit is that PR's, and both touch `Jint.Browser/Runtime/PageLoop.cs`. Review the second commit only; the base is `main` because a cross-fork base branch is not usable here.

## What was missing

#3684 item 2:

> **A `document.title` change hook on the page.** `Target.targetInfoChanged` is emitted when a page's title or URL moves, but the page only reports its title at navigation phases: a title a script sets after `load` is not reported until the next navigation.

`Page.Navigation.cs`'s `Reached(...)` was the only caller of `IPageObserver.TitleChanged`, and its own `<remarks>` admitted the gap:

> The title is reported at each of the three, because it is what a client shows for the target and the parse is what settles it: a document's `<title>` is in place by the commit, and **a script that rewrites it does so before `load` far more often than after**.

Far more often is not always. A single-page application that sets `document.title` from its router does it after `load` every time, and until now a client was told the old title until the next navigation.

## What changed

The page looks at `document.title` at the **end of each of its loop's turns** — the seam #3797 built the counter on — and calls `TitleChanged` only when it has moved.

- **A page nobody is watching pays nothing.** `Page.Observer` is `null` for every page not being driven over the protocol, and it is the first thing checked; such a page never touches its document.
- **No DOM-side notification, and no new AngleSharp seam.** A `MutationObserver` over the document would queue a record for *every* mutation of *every* page whether or not anyone is watching — the same trade `Layout/FlatLayout` declines, for the same reason — and it would buy one string.
- **What a watched page pays is stated in the XML doc rather than glossed.** `IDocument.Title` is `DocumentElement.FindDescendant<IHtmlTitleElement>()`, a depth-first walk that **stops at the first title element**: a document with a `<title>` in its `<head>` costs a handful of node visits, and one *without* a title costs a walk of its whole tree, once per turn, while a watcher is attached. The cheap short circuit — search `document.Head` only — is **not** taken, because HTML's `document.title` is the first `title` element in tree order wherever it sits, and a page with one in its body would silently stop being reported. A fast answer that is only usually right is worse here than a simple one.
- **`Page.ReportTitle` is now the one caller of `TitleChanged`.** The three navigation phases go through it too, so one title is announced once however many places look at it. `DevToolsTarget.UpdateInfo` already deduped for a protocol client, but `IPageObserver` is a seam a host may implement and it is owed one call per move rather than one per look.

Three things the loop side gets right:

1. **The hook cannot erupt into the pump.** `PageLoop.EndLoopTurn` wraps it and sends anything it throws to `_onPumpError`, like everything else the loop runs.
2. **It runs *after* the budget bracket closes**, so a page's own bookkeeping can never spend the budget a caller's request is bounded by, nor fail that request with a `TimeoutException` the caller could do nothing about.
3. **A navigation runs it once.** `ReplaceEngine` closes its mid-request turn through `EndTurn` directly rather than `EndLoopTurn`, so the hook runs at the end of the request, on the document now showing — whose title the phases have already reported, so nothing is announced twice.

Nothing here is public: no API baseline change and no `docs/v5-migration.md` row.

## The tests that pin it, and the verbatim failures against unfixed code

**`ATitleSetAfterLoadReachesTheClientWithoutANavigation`** (`Jint.Tests.Browser/DevTools/PageDomainTests.cs`) drives a real page over the protocol; the document sets `document.title` from a `setTimeout` armed on `load`, and the client is sent `Target.targetInfoChanged` carrying the new title with no navigation. Unfixed:

```
Expected announced to be "After load" because a watched page looks at its title at the end of
every turn, but found <null>.
```

**`ATitleTheMarkupDeclaresIsReportedOnceAtThePhaseThatAlreadyReportedIt`** — a title in the markup is reported once, at the phase that already reported it. Unfixed:

```
Expected recorder.Titles to be equal to {"Parsed"}, but {"Parsed", "Parsed", "Parsed"} contains
2 item(s) too many.
```

**`APageNobodyIsWatchingIsNeverAskedForItsTitle`** moves the title while nothing is watching, asserts no call was made about it, and asserts the move is announced on the next turn once a watcher is back. Unfixed:

```
Expected recorder.Titles to be equal to {"Watched"}, but {"Watched", "Watched", "Watched"}
contains 2 item(s) too many.
```

(The "unfixed" build is this branch with the end-of-turn hook removed and `Reached` calling `observer.TitleChanged` directly, which is `main`'s behaviour.)

## The web-platform-tests browser lane is unmoved

It runs hundreds of documents through `Page`, and none of them has an observer, so none pays for the check. Measured on both branches, net10.0, Release:

| | passed | skipped | duration |
| --- | --- | --- | --- |
| #3797 (before) | 366 | 1 | 23 s |
| this branch | 366 | 1 | 23 s |

`Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs` and `Jint.Tests.Browser/Wpt/README.md` are untouched.

## Test runs

All in Release, `-nr:false`:

| | net8.0 | net10.0 |
| --- | --- | --- |
| `Jint.Tests.Browser` | 1440 passed, 6 skipped | 1443 passed, 6 skipped |
| `Jint.Tests.DevTools` | 402 passed | 404 passed |
| `Jint.Tests` (WebApi / MigrationGuide / AgentInstructionFile / SpecCitation) | — | 2879 passed |

`dotnet build -c Release` on the solution: 0 errors, and the one pre-existing `MSB3277`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
