### PR TITLE
Add direct Playwright adapter for Jint.Browser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,9 @@ jobs:
     - name: Pack Jint.Browser with dotnet
       run: dotnet pack Jint.Browser/Jint.Browser.csproj --output artifacts --configuration Release -p:VersionSuffix=preview-$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=True
 
+    - name: Pack Jint.Browser.Playwright with dotnet
+      run: dotnet pack Jint.Browser.Playwright/Jint.Browser.Playwright.csproj --output artifacts --configuration Release -p:VersionSuffix=preview-$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=True
+
     - name: Pack Jint.Browser.Mcp with dotnet
       run: dotnet pack Jint.Browser.Mcp/Jint.Browser.Mcp.csproj --output artifacts --configuration Release -p:VersionSuffix=preview-$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=True
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,16 @@ jobs:
         -p:FileVersion=${{ steps.version.outputs.numeric }}
         -p:ContinuousIntegrationBuild=True
 
+    # The direct Playwright interface adapter ships with the browser it wraps. It references
+    # Microsoft.Playwright only for its public contracts and carries no Node driver or browser binary.
+    - name: Pack Jint.Browser.Playwright with dotnet
+      run: >
+        dotnet pack Jint.Browser.Playwright/Jint.Browser.Playwright.csproj --output artifacts --configuration Release
+        -p:Version=${{ steps.version.outputs.version }}
+        -p:AssemblyVersion=${{ steps.version.outputs.numeric }}
+        -p:FileVersion=${{ steps.version.outputs.numeric }}
+        -p:ContinuousIntegrationBuild=True
+
     # The Model Context Protocol server, from the same tag and the same version, because it is a library
     # over Jint.Browser referenced by project. Packed before the tool, which references it.
     - name: Pack Jint.Browser.Mcp with dotnet

--- a/Jint.Browser.Playwright/BrowserAdapters.cs
+++ b/Jint.Browser.Playwright/BrowserAdapters.cs
@@ -1,0 +1,266 @@
+using System.Reflection;
+using JintBrowser = Jint.Browser.Browser;
+using JintBrowserContext = Jint.Browser.BrowserContext;
+using JintBrowserContextOptions = Jint.Browser.BrowserContextOptions;
+using JintBrowserOptions = Jint.Browser.BrowserOptions;
+using Microsoft.Playwright;
+
+namespace Jint.Browser.Playwright;
+
+internal sealed class BrowserTypeTarget(Action<JintBrowserOptions>? configure) : ProxyTarget
+{
+    internal override object? Invoke(MethodInfo method, object?[] arguments)
+    {
+        return method.Name switch
+        {
+            "get_Name" => "jint",
+            "get_ExecutablePath" => string.Empty,
+            nameof(IBrowserType.LaunchAsync) => LaunchAsync((BrowserTypeLaunchOptions?) arguments[0]),
+            _ => Unsupported(method),
+        };
+    }
+
+    private Task<IBrowser> LaunchAsync(BrowserTypeLaunchOptions? launchOptions)
+    {
+        OptionSupport.EnsureOnly(launchOptions, "IBrowserType.LaunchAsync", nameof(BrowserTypeLaunchOptions.Headless));
+        if (launchOptions?.Headless is false)
+        {
+            throw new NotSupportedException("Jint.Browser.Playwright cannot launch a headed browser.");
+        }
+
+        var options = new JintBrowserOptions();
+        configure?.Invoke(options);
+        var browser = new JintBrowser(options);
+        var target = new BrowserTarget(browser, (IBrowserType) Proxy);
+        return Task.FromResult(ProxyFactory.Create<IBrowser>(target));
+    }
+}
+
+internal sealed class BrowserTarget(JintBrowser browser, IBrowserType browserType) : ProxyTarget
+{
+    private readonly List<BrowserContextTarget> _contexts = [];
+    private EventHandler<IBrowserContext>? _contextCreated;
+    private EventHandler<IBrowser>? _disconnected;
+    private bool _closed;
+
+    internal override object? Invoke(MethodInfo method, object?[] arguments)
+    {
+        switch (method.Name)
+        {
+            case "add_Context":
+                _contextCreated += (EventHandler<IBrowserContext>) arguments[0]!;
+                return null;
+            case "remove_Context":
+                _contextCreated -= (EventHandler<IBrowserContext>) arguments[0]!;
+                return null;
+            case "add_Disconnected":
+                _disconnected += (EventHandler<IBrowser>) arguments[0]!;
+                return null;
+            case "remove_Disconnected":
+                _disconnected -= (EventHandler<IBrowser>) arguments[0]!;
+                return null;
+            case "get_BrowserType":
+                return browserType;
+            case "get_Contexts":
+                return _contexts.Where(x => !x.IsClosed).Select(x => x.Context).ToArray();
+            case "get_IsConnected":
+                return !_closed;
+            case "get_Version":
+                return typeof(JintBrowser).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+            case nameof(IBrowser.NewContextAsync):
+                OptionSupport.EnsureOnly(arguments[0], "IBrowser.NewContextAsync");
+                return NewContextAsync();
+            case nameof(IBrowser.NewPageAsync):
+                OptionSupport.EnsureOnly(arguments[0], "IBrowser.NewPageAsync");
+                return NewPageAsync();
+            case nameof(IBrowser.CloseAsync):
+                OptionSupport.EnsureOnly(arguments[0], "IBrowser.CloseAsync");
+                return CloseAsync();
+            case nameof(IAsyncDisposable.DisposeAsync):
+                return new ValueTask(CloseAsync());
+            default:
+                return Unsupported(method);
+        }
+    }
+
+    private async Task<IBrowserContext> NewContextAsync()
+        => (await NewContextTargetAsync().ConfigureAwait(false)).Context;
+
+    private async Task<BrowserContextTarget> NewContextTargetAsync()
+    {
+        ObjectDisposedException.ThrowIf(_closed, this);
+        var inner = await browser.NewContextAsync(new JintBrowserContextOptions()).ConfigureAwait(false);
+        var target = new BrowserContextTarget(this, inner);
+        target.Context = ProxyFactory.Create<IBrowserContext>(target);
+        _contexts.Add(target);
+
+        var errors = new CleanupErrors();
+        errors.Run(() => _contextCreated?.Invoke((IBrowser) Proxy, target.Context));
+        if (errors.HasAny)
+        {
+            await errors.RunAsync(target.CloseAfterCreationFailureAsync).ConfigureAwait(false);
+            errors.ThrowIfAny();
+        }
+
+        return target;
+    }
+
+    private async Task<IPage> NewPageAsync()
+    {
+        var context = await NewContextTargetAsync().ConfigureAwait(false);
+        context.CloseWithPage = true;
+        return await context.NewPageAsync().ConfigureAwait(false);
+    }
+
+    private async Task CloseAsync()
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        _closed = true;
+        var errors = new CleanupErrors();
+        await errors.RunAsync(browser.CloseAsync).ConfigureAwait(false);
+        foreach (var context in _contexts.ToArray())
+        {
+            errors.Run(context.BrowserClosed);
+        }
+
+        _contexts.Clear();
+        errors.Run(() => _disconnected?.Invoke((IBrowser) Proxy, (IBrowser) Proxy));
+        errors.ThrowIfAny();
+    }
+
+    internal void Remove(BrowserContextTarget context) => _contexts.Remove(context);
+}
+
+internal sealed class BrowserContextTarget(BrowserTarget owner, JintBrowserContext inner) : ProxyTarget
+{
+    private readonly List<PageTarget> _pages = [];
+    private EventHandler<IPage>? _pageCreated;
+    private EventHandler<IBrowserContext>? _closed;
+    private bool _isClosed;
+
+    internal IBrowserContext Context { get; set; } = null!;
+
+    internal bool CloseWithPage { get; set; }
+
+    internal bool IsClosed => _isClosed || inner.IsClosed;
+
+    internal float DefaultTimeout { get; private set; } = 30_000;
+
+    internal float DefaultNavigationTimeout { get; private set; } = 30_000;
+
+    internal override object? Invoke(MethodInfo method, object?[] arguments)
+    {
+        switch (method.Name)
+        {
+            case "add_Page":
+                _pageCreated += (EventHandler<IPage>) arguments[0]!;
+                return null;
+            case "remove_Page":
+                _pageCreated -= (EventHandler<IPage>) arguments[0]!;
+                return null;
+            case "add_Close":
+                _closed += (EventHandler<IBrowserContext>) arguments[0]!;
+                return null;
+            case "remove_Close":
+                _closed -= (EventHandler<IBrowserContext>) arguments[0]!;
+                return null;
+            case "get_Browser":
+                return owner.Proxy;
+            case "get_BackgroundPages":
+                return Array.Empty<IPage>();
+            case "get_IsClosed":
+                return IsClosed;
+            case "get_Pages":
+                return _pages.Where(x => !x.IsClosed).Select(x => x.Page).ToArray();
+            case nameof(IBrowserContext.NewPageAsync):
+                return NewPageAsync();
+            case nameof(IBrowserContext.CloseAsync):
+                OptionSupport.EnsureOnly(arguments[0], "IBrowserContext.CloseAsync");
+                return CloseAsync();
+            case nameof(IBrowserContext.SetDefaultTimeout):
+                DefaultTimeout = (float) arguments[0]!;
+                return null;
+            case nameof(IBrowserContext.SetDefaultNavigationTimeout):
+                DefaultNavigationTimeout = (float) arguments[0]!;
+                return null;
+            case nameof(IAsyncDisposable.DisposeAsync):
+                return new ValueTask(CloseAsync());
+            default:
+                return Unsupported(method);
+        }
+    }
+
+    internal async Task<IPage> NewPageAsync()
+    {
+        ObjectDisposedException.ThrowIf(_isClosed, this);
+        var page = await inner.NewPageAsync().ConfigureAwait(false);
+        var target = new PageTarget(this, page);
+        target.Page = ProxyFactory.Create<IPage>(target);
+        _pages.Add(target);
+
+        var errors = new CleanupErrors();
+        errors.Run(() => _pageCreated?.Invoke(Context, target.Page));
+        if (errors.HasAny)
+        {
+            await errors.RunAsync(target.CloseAfterCreationFailureAsync).ConfigureAwait(false);
+            errors.ThrowIfAny();
+        }
+
+        return target.Page;
+    }
+
+    private async Task CloseAsync()
+    {
+        if (_isClosed)
+        {
+            return;
+        }
+
+        _isClosed = true;
+        var errors = new CleanupErrors();
+        await errors.RunAsync(inner.CloseAsync).ConfigureAwait(false);
+        foreach (var page in _pages.ToArray())
+        {
+            errors.Run(page.ContextClosed);
+        }
+
+        _pages.Clear();
+        owner.Remove(this);
+        errors.Run(() => _closed?.Invoke(Context, Context));
+        errors.ThrowIfAny();
+    }
+
+    internal async Task PageClosedAsync(PageTarget page)
+    {
+        _pages.Remove(page);
+        if (CloseWithPage && !_isClosed)
+        {
+            await CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    internal Task CloseAfterCreationFailureAsync() => CloseAsync();
+
+    internal void BrowserClosed()
+    {
+        if (_isClosed)
+        {
+            return;
+        }
+
+        _isClosed = true;
+        var errors = new CleanupErrors();
+        foreach (var page in _pages)
+        {
+            errors.Run(page.ContextClosed);
+        }
+
+        _pages.Clear();
+        errors.Run(() => _closed?.Invoke(Context, Context));
+        errors.ThrowIfAny();
+    }
+}

--- a/Jint.Browser.Playwright/Jint.Browser.Playwright.csproj
+++ b/Jint.Browser.Playwright/Jint.Browser.Playwright.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+
+    <AssemblyOriginatorKeyFile>..\Jint\Jint.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+
+    <IsPackable>true</IsPackable>
+    <PackageId>Jint.Browser.Playwright</PackageId>
+    <Description>A direct Microsoft.Playwright interface adapter over Jint.Browser, without a browser process or CDP.</Description>
+    <PackageTags>javascript, interpreter, jint, anglesharp, headless, browser, playwright, testing</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <Nullable>enable</Nullable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jint.Browser\Jint.Browser.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Only the public API contracts are used. Excluding the build assets prevents the bundled Node
+         runtime and Playwright driver from being copied into applications that use this adapter. -->
+    <PackageReference Include="Microsoft.Playwright" ExcludeAssets="build;buildTransitive;contentFiles" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Remove="Acornima" />
+    <Using Remove="Acornima.Ast" />
+  </ItemGroup>
+
+</Project>

--- a/Jint.Browser.Playwright/JintPlaywright.cs
+++ b/Jint.Browser.Playwright/JintPlaywright.cs
@@ -1,0 +1,16 @@
+using Jint.Browser;
+using Microsoft.Playwright;
+
+namespace Jint.Browser.Playwright;
+
+/// <summary>Creates Microsoft.Playwright browser interfaces backed directly by Jint.Browser.</summary>
+public static class JintPlaywright
+{
+    /// <summary>Gets the default Jint browser type.</summary>
+    public static IBrowserType BrowserType { get; } = CreateBrowserType();
+
+    /// <summary>Creates a Jint browser type with browser-wide configuration.</summary>
+    /// <param name="configure">The configuration applied to each launched browser.</param>
+    public static IBrowserType CreateBrowserType(Action<BrowserOptions>? configure = null)
+        => ProxyFactory.Create<IBrowserType>(new BrowserTypeTarget(configure));
+}

--- a/Jint.Browser.Playwright/PageAdapters.cs
+++ b/Jint.Browser.Playwright/PageAdapters.cs
@@ -1,0 +1,718 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using JintPage = Jint.Browser.Page;
+using JintResponse = Jint.Browser.PageResponse;
+using JintWaitUntil = Jint.Browser.WaitUntilState;
+using Microsoft.Playwright;
+
+namespace Jint.Browser.Playwright;
+
+internal sealed class PageTarget(BrowserContextTarget context, JintPage inner) : ProxyTarget
+{
+    private static readonly TimeSpan DefaultWaitPoll = TimeSpan.FromMilliseconds(25);
+    private static readonly MethodInfo EvaluateMethod = typeof(PageTarget)
+        .GetMethod(nameof(EvaluateAsync), BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private EventHandler<IPage>? _closed;
+    private float? _defaultTimeout;
+    private float? _defaultNavigationTimeout;
+    private bool _isClosed;
+    private IFrame? _mainFrame;
+
+    internal IPage Page { get; set; } = null!;
+
+    internal bool IsClosed => _isClosed || inner.IsClosed;
+
+    internal float DefaultTimeout => _defaultTimeout ?? context.DefaultTimeout;
+
+    internal float DefaultNavigationTimeout => _defaultNavigationTimeout ?? context.DefaultNavigationTimeout;
+
+    internal override object? Invoke(MethodInfo method, object?[] arguments)
+    {
+        switch (method.Name)
+        {
+            case "add_Close":
+                _closed += (EventHandler<IPage>) arguments[0]!;
+                return null;
+            case "remove_Close":
+                _closed -= (EventHandler<IPage>) arguments[0]!;
+                return null;
+            case "get_Context":
+                return context.Context;
+            case "get_Frames":
+                return new[] { MainFrame };
+            case "get_MainFrame":
+                return MainFrame;
+            case "get_IsClosed":
+                return IsClosed;
+            case "get_Url":
+                return inner.Url;
+            case nameof(IPage.Locator):
+                OptionSupport.EnsureOnly(arguments[1], "IPage.Locator");
+                return Locator((string) arguments[0]!);
+            case nameof(IPage.GetByRole):
+                return RoleLocator((AriaRole) arguments[0]!, (PageGetByRoleOptions?) arguments[1]);
+            case nameof(IPage.GotoAsync):
+                return GotoAsync((string) arguments[0]!, (PageGotoOptions?) arguments[1]);
+            case nameof(IPage.ReloadAsync):
+                return ReloadAsync((PageReloadOptions?) arguments[0]);
+            case nameof(IPage.GoBackAsync):
+                return GoBackAsync((PageGoBackOptions?) arguments[0]);
+            case nameof(IPage.GoForwardAsync):
+                return GoForwardAsync((PageGoForwardOptions?) arguments[0]);
+            case nameof(IPage.SetContentAsync):
+                return SetContentAsync((string) arguments[0]!, (PageSetContentOptions?) arguments[1]);
+            case nameof(IPage.ContentAsync):
+                return inner.ContentAsync();
+            case nameof(IPage.TitleAsync):
+                return inner.TitleAsync();
+            case nameof(IPage.EvaluateAsync):
+                return EvaluateMethod.MakeGenericMethod(method.ReturnType.GenericTypeArguments[0])
+                    .Invoke(this, [(string) arguments[0]!, arguments[1]])!;
+            case nameof(IPage.WaitForFunctionAsync):
+                return WaitForFunctionAsync(
+                    (string) arguments[0]!,
+                    arguments[1],
+                    (PageWaitForFunctionOptions?) arguments[2]);
+            case nameof(IPage.CloseAsync):
+                OptionSupport.EnsureOnly(arguments[0], "IPage.CloseAsync");
+                return CloseAsync();
+            case nameof(IPage.SetDefaultTimeout):
+                _defaultTimeout = (float) arguments[0]!;
+                return null;
+            case nameof(IPage.SetDefaultNavigationTimeout):
+                _defaultNavigationTimeout = (float) arguments[0]!;
+                return null;
+            case nameof(IPage.BringToFrontAsync):
+                return Task.CompletedTask;
+            case nameof(IAsyncDisposable.DisposeAsync):
+                return new ValueTask(CloseAsync());
+            default:
+                return Unsupported(method);
+        }
+    }
+
+    internal IFrame MainFrame => _mainFrame ??= ProxyFactory.Create<IFrame>(new FrameTarget(this));
+
+    private ILocator Locator(string selector)
+        => ProxyFactory.Create<ILocator>(new LocatorTarget(this, LocatorDescriptor.Css(selector)));
+
+    private ILocator RoleLocator(AriaRole role, PageGetByRoleOptions? options)
+    {
+        OptionSupport.EnsureOnly(
+            options,
+            "IPage.GetByRole",
+            nameof(PageGetByRoleOptions.Name),
+            nameof(PageGetByRoleOptions.NameString),
+            nameof(PageGetByRoleOptions.NameRegex),
+            nameof(PageGetByRoleOptions.Exact),
+            nameof(PageGetByRoleOptions.IncludeHidden));
+        return ProxyFactory.Create<ILocator>(new LocatorTarget(this, LocatorDescriptor.Role(role, options)));
+    }
+
+    private async Task<IResponse?> GotoAsync(string url, PageGotoOptions? options)
+    {
+        var timeout = Timeout(options?.Timeout, DefaultNavigationTimeout);
+        var started = Stopwatch.GetTimestamp();
+        var response = await inner.NavigateAsync(url, NavigationOptions(options, timeout)).ConfigureAwait(false);
+        await WaitForNetworkIdleAsync(options?.WaitUntil, timeout, started).ConfigureAwait(false);
+        return response is null ? null : ProxyFactory.Create<IResponse>(new ResponseTarget(this, response));
+    }
+
+    private async Task<IResponse?> ReloadAsync(PageReloadOptions? options)
+    {
+        var timeout = Timeout(options?.Timeout, DefaultNavigationTimeout);
+        var started = Stopwatch.GetTimestamp();
+        var response = await inner.ReloadAsync(new Jint.Browser.NavigationOptions
+        {
+            Timeout = timeout,
+            WaitUntil = Map(options?.WaitUntil),
+        }).ConfigureAwait(false);
+        await WaitForNetworkIdleAsync(options?.WaitUntil, timeout, started).ConfigureAwait(false);
+        return response is null ? null : ProxyFactory.Create<IResponse>(new ResponseTarget(this, response));
+    }
+
+    private async Task<IResponse?> GoBackAsync(PageGoBackOptions? options)
+    {
+        var timeout = Timeout(options?.Timeout, DefaultNavigationTimeout);
+        var started = Stopwatch.GetTimestamp();
+        var moved = await inner.GoBackAsync(timeout).ConfigureAwait(false);
+        await WaitForLoadStateAsync(options?.WaitUntil, timeout, started, moved).ConfigureAwait(false);
+        return moved && inner.Response is { } response
+            ? ProxyFactory.Create<IResponse>(new ResponseTarget(this, response))
+            : null;
+    }
+
+    private async Task<IResponse?> GoForwardAsync(PageGoForwardOptions? options)
+    {
+        var timeout = Timeout(options?.Timeout, DefaultNavigationTimeout);
+        var started = Stopwatch.GetTimestamp();
+        var moved = await inner.GoForwardAsync(timeout).ConfigureAwait(false);
+        await WaitForLoadStateAsync(options?.WaitUntil, timeout, started, moved).ConfigureAwait(false);
+        return moved && inner.Response is { } response
+            ? ProxyFactory.Create<IResponse>(new ResponseTarget(this, response))
+            : null;
+    }
+
+    private async Task SetContentAsync(string html, PageSetContentOptions? options)
+    {
+        var timeout = Timeout(options?.Timeout, DefaultNavigationTimeout);
+        var started = Stopwatch.GetTimestamp();
+
+        await inner.SetContentAsync(html, inner.Url).WaitAsync(timeout).ConfigureAwait(false);
+        await WaitForNetworkIdleAsync(options?.WaitUntil, timeout, started).ConfigureAwait(false);
+    }
+
+    private Task<T> EvaluateAsync<T>(string expression, object? argument)
+        => EvaluateValueAsync<T>(Scripts.Invocation(expression, argument));
+
+    internal async Task<T> EvaluateValueAsync<T>(string script)
+    {
+        var value = await inner.EvaluateAndAwaitAsync(script).ConfigureAwait(false);
+        if (value is null)
+        {
+            return default!;
+        }
+
+        if (value is T typed)
+        {
+            return typed;
+        }
+
+        var json = JsonSerializer.Serialize(value, value.GetType());
+        return JsonSerializer.Deserialize<T>(json)!;
+    }
+
+    private async Task<IJSHandle> WaitForFunctionAsync(
+        string expression,
+        object? argument,
+        PageWaitForFunctionOptions? options)
+    {
+        OptionSupport.EnsureOnly(
+            options,
+            "IPage.WaitForFunctionAsync",
+            nameof(PageWaitForFunctionOptions.PollingInterval),
+            nameof(PageWaitForFunctionOptions.Timeout));
+        var invocation = Scripts.WaitInvocation(expression, argument);
+        var timeout = Timeout(options?.Timeout, DefaultTimeout);
+        var poll = options?.PollingInterval is > 0
+            ? TimeSpan.FromMilliseconds(options.PollingInterval.Value)
+            : DefaultWaitPoll;
+        using var timeoutCancellation = timeout == System.Threading.Timeout.InfiniteTimeSpan
+            ? null
+            : new CancellationTokenSource(timeout);
+        var cancellationToken = timeoutCancellation?.Token ?? CancellationToken.None;
+
+        try
+        {
+            while (true)
+            {
+                var evaluation = inner.EvaluateAndAwaitAsync<IDictionary<string, object?>>(
+                    invocation,
+                    cancellationToken);
+                var result = await evaluation.WaitAsync(cancellationToken).ConfigureAwait(false);
+                if (result is not null
+                    && result.TryGetValue("truthy", out var truthy)
+                    && truthy is true)
+                {
+                    result.TryGetValue("value", out var value);
+                    return ProxyFactory.Create<IJSHandle>(new JsHandleTarget(value));
+                }
+
+                await Task.Delay(poll, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (timeoutCancellation?.IsCancellationRequested is true)
+        {
+            throw new TimeoutException($"Timeout {DisplayTimeout(timeout)} exceeded.");
+        }
+    }
+
+    private async Task CloseAsync()
+    {
+        if (IsClosed)
+        {
+            return;
+        }
+
+        _isClosed = true;
+        var errors = new CleanupErrors();
+        await errors.RunAsync(inner.CloseAsync).ConfigureAwait(false);
+        errors.Run(() => _closed?.Invoke(Page, Page));
+        await errors.RunAsync(() => context.PageClosedAsync(this)).ConfigureAwait(false);
+        errors.ThrowIfAny();
+    }
+
+    internal void ContextClosed()
+    {
+        if (_isClosed)
+        {
+            return;
+        }
+
+        _isClosed = true;
+        _closed?.Invoke(Page, Page);
+    }
+
+    internal Task CloseAfterCreationFailureAsync() => CloseAsync();
+
+    private static Jint.Browser.NavigationOptions NavigationOptions(PageGotoOptions? options, TimeSpan timeout) => new()
+    {
+        Referrer = options?.Referer,
+        Timeout = timeout,
+        WaitUntil = Map(options?.WaitUntil),
+    };
+
+    internal static TimeSpan Timeout(float? milliseconds, float defaultMilliseconds)
+    {
+        var value = milliseconds ?? defaultMilliseconds;
+        return value <= 0 ? System.Threading.Timeout.InfiniteTimeSpan : TimeSpan.FromMilliseconds(value);
+    }
+
+    internal static bool HasTimedOut(TimeSpan timeout, long started)
+        => timeout != System.Threading.Timeout.InfiniteTimeSpan
+            && Stopwatch.GetElapsedTime(started) >= timeout;
+
+    internal static TimeSpan Remaining(TimeSpan timeout, long started)
+        => timeout == System.Threading.Timeout.InfiniteTimeSpan
+            ? timeout
+            : timeout - Stopwatch.GetElapsedTime(started);
+
+    internal static string DisplayTimeout(TimeSpan timeout)
+        => timeout == System.Threading.Timeout.InfiniteTimeSpan
+            ? "the configured timeout"
+            : $"{timeout.TotalMilliseconds:0}ms";
+
+    private static JintWaitUntil Map(Microsoft.Playwright.WaitUntilState? state) => state switch
+    {
+        Microsoft.Playwright.WaitUntilState.Commit => JintWaitUntil.Commit,
+        Microsoft.Playwright.WaitUntilState.DOMContentLoaded => JintWaitUntil.DomContentLoaded,
+        _ => JintWaitUntil.Load,
+    };
+
+    private async Task WaitForNetworkIdleAsync(
+        Microsoft.Playwright.WaitUntilState? state,
+        TimeSpan timeout,
+        long started)
+    {
+        if (state != Microsoft.Playwright.WaitUntilState.NetworkIdle)
+        {
+            return;
+        }
+
+        var remaining = Remaining(timeout, started);
+        if ((remaining != System.Threading.Timeout.InfiniteTimeSpan && remaining <= TimeSpan.Zero)
+            || !await inner.WaitForNetworkIdleAsync(remaining).ConfigureAwait(false))
+        {
+            throw new TimeoutException($"Timeout {DisplayTimeout(timeout)} exceeded.");
+        }
+    }
+
+    private async Task WaitForLoadStateAsync(
+        Microsoft.Playwright.WaitUntilState? state,
+        TimeSpan timeout,
+        long started,
+        bool navigationStarted)
+    {
+        if (!navigationStarted || state == Microsoft.Playwright.WaitUntilState.Commit)
+        {
+            return;
+        }
+
+        var waitUntil = state ?? Microsoft.Playwright.WaitUntilState.Load;
+        var expression = waitUntil == Microsoft.Playwright.WaitUntilState.DOMContentLoaded
+            ? "document.readyState !== 'loading'"
+            : "document.readyState === 'complete'";
+        var remaining = Remaining(timeout, started);
+        if ((remaining != System.Threading.Timeout.InfiniteTimeSpan && remaining <= TimeSpan.Zero)
+            || !await inner.WaitForAsync(expression, remaining).ConfigureAwait(false))
+        {
+            throw new TimeoutException($"Timeout {DisplayTimeout(timeout)} exceeded.");
+        }
+
+        await WaitForNetworkIdleAsync(waitUntil, timeout, started).ConfigureAwait(false);
+    }
+
+    internal JintPage Inner => inner;
+}
+
+internal sealed class FrameTarget(PageTarget page) : ProxyTarget
+{
+    internal override object? Invoke(MethodInfo method, object?[] arguments)
+    {
+        return method.Name switch
+        {
+            "get_Page" => page.Page,
+            "get_Url" => page.Inner.Url,
+            "get_Name" => string.Empty,
+            "get_ParentFrame" => null,
+            "get_ChildFrames" => Array.Empty<IFrame>(),
+            "get_IsDetached" => false,
+            nameof(IFrame.Locator) => Locator(
+                (string) arguments[0]!,
+                (FrameLocatorOptions?) arguments[1]),
+            nameof(IFrame.ContentAsync) => page.Inner.ContentAsync(),
+            nameof(IFrame.TitleAsync) => page.Inner.TitleAsync(),
+            _ => Unsupported(method),
+        };
+    }
+
+    private ILocator Locator(string selector, FrameLocatorOptions? options)
+    {
+        OptionSupport.EnsureOnly(options, "IFrame.Locator");
+        return ProxyFactory.Create<ILocator>(new LocatorTarget(page, LocatorDescriptor.Css(selector)));
+    }
+}
+
+internal sealed class LocatorTarget(PageTarget page, LocatorDescriptor descriptor) : ProxyTarget
+{
+    internal override object? Invoke(MethodInfo method, object?[] arguments)
+    {
+        return method.Name switch
+        {
+            "get_Page" => page.Page,
+            "get_First" => New(descriptor with { Index = 0 }),
+            "get_Last" => New(descriptor with { Index = -1 }),
+            "get_Description" => null,
+            nameof(ILocator.Nth) => New(descriptor with { Index = (int) arguments[0]! }),
+            nameof(ILocator.CountAsync) => CountAsync(),
+            nameof(ILocator.AllTextContentsAsync) => AllTextContentsAsync(),
+            nameof(ILocator.TextContentAsync) => TextContentAsync((LocatorTextContentOptions?) arguments[0]),
+            nameof(ILocator.InputValueAsync) => InputValueAsync((LocatorInputValueOptions?) arguments[0]),
+            nameof(ILocator.IsVisibleAsync) => IsVisibleAsync(),
+            nameof(ILocator.WaitForAsync) => WaitForAsync((LocatorWaitForOptions?) arguments[0]),
+            nameof(ILocator.ClickAsync) => ClickAsync((LocatorClickOptions?) arguments[0]),
+            nameof(ILocator.FillAsync) => FillAsync((string) arguments[0]!, (LocatorFillOptions?) arguments[1]),
+            nameof(ILocator.PressAsync) => PressAsync((string) arguments[0]!, (LocatorPressOptions?) arguments[1]),
+            _ => Unsupported(method),
+        };
+    }
+
+    private ILocator New(LocatorDescriptor value)
+        => ProxyFactory.Create<ILocator>(new LocatorTarget(page, value));
+
+    private async Task<int> CountAsync()
+        => await page.EvaluateValueAsync<int>(descriptor.CountScript()).ConfigureAwait(false);
+
+    private async Task<IReadOnlyList<string>> AllTextContentsAsync()
+        => await page.EvaluateValueAsync<string[]>(descriptor.TextContentsScript()).ConfigureAwait(false);
+
+    private async Task<string?> TextContentAsync(LocatorTextContentOptions? options)
+    {
+        OptionSupport.EnsureOnly(options, "ILocator.TextContentAsync", nameof(LocatorTextContentOptions.Timeout));
+        await WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Attached,
+            Timeout = options?.Timeout,
+        }).ConfigureAwait(false);
+        return await page.EvaluateValueAsync<string?>(descriptor.PropertyScript("textContent")).ConfigureAwait(false);
+    }
+
+    private async Task<string> InputValueAsync(LocatorInputValueOptions? options)
+    {
+        OptionSupport.EnsureOnly(options, "ILocator.InputValueAsync", nameof(LocatorInputValueOptions.Timeout));
+        await WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Attached,
+            Timeout = options?.Timeout,
+        }).ConfigureAwait(false);
+        return await page.EvaluateValueAsync<string>(descriptor.PropertyScript("value")).ConfigureAwait(false)
+            ?? throw new PlaywrightException("The locator did not resolve to an input element.");
+    }
+
+    private async Task<bool> IsVisibleAsync()
+    {
+        await EnsureStrictAsync().ConfigureAwait(false);
+        return await page.EvaluateValueAsync<bool>(descriptor.VisibleScript()).ConfigureAwait(false);
+    }
+
+    private async Task WaitForAsync(LocatorWaitForOptions? options)
+    {
+        OptionSupport.EnsureOnly(
+            options,
+            "ILocator.WaitForAsync",
+            nameof(LocatorWaitForOptions.State),
+            nameof(LocatorWaitForOptions.Timeout));
+        var state = options?.State ?? WaitForSelectorState.Visible;
+        var expression = state switch
+        {
+            WaitForSelectorState.Attached => descriptor.ExistsScript(),
+            WaitForSelectorState.Detached => $"!({descriptor.ExistsScript()})",
+            WaitForSelectorState.Hidden => $"!({descriptor.VisibleScript()})",
+            _ => descriptor.VisibleScript(),
+        };
+        var timeout = PageTarget.Timeout(options?.Timeout, page.DefaultTimeout);
+        if (!await page.Inner.WaitForAsync(expression, timeout).ConfigureAwait(false))
+        {
+            throw new TimeoutException($"Timeout {PageTarget.DisplayTimeout(timeout)} exceeded.");
+        }
+
+        await EnsureStrictAsync().ConfigureAwait(false);
+    }
+
+    private async Task ClickAsync(LocatorClickOptions? options)
+    {
+        OptionSupport.EnsureOnly(options, "ILocator.ClickAsync", nameof(LocatorClickOptions.Timeout));
+        var timeout = PageTarget.Timeout(options?.Timeout, page.DefaultTimeout);
+        var started = Stopwatch.GetTimestamp();
+        await WaitForAsync(new LocatorWaitForOptions { Timeout = options?.Timeout }).ConfigureAwait(false);
+        var index = await descriptor.ResolveIndexAsync(page.Inner).ConfigureAwait(false);
+        var remaining = RequireRemaining(timeout, started);
+        var clicked = index is not null
+            && await page.Inner.ClickAsync(
+                    descriptor.Selector,
+                    index.Value,
+                    new Jint.Browser.NavigationOptions { Timeout = remaining })
+                .WaitAsync(remaining).ConfigureAwait(false);
+        if (!clicked)
+        {
+            throw new PlaywrightException("The locator did not resolve to a clickable element.");
+        }
+    }
+
+    private async Task FillAsync(string value, LocatorFillOptions? options)
+    {
+        OptionSupport.EnsureOnly(options, "ILocator.FillAsync", nameof(LocatorFillOptions.Timeout));
+        var timeout = PageTarget.Timeout(options?.Timeout, page.DefaultTimeout);
+        var started = Stopwatch.GetTimestamp();
+        await WaitForAsync(new LocatorWaitForOptions { Timeout = options?.Timeout }).ConfigureAwait(false);
+        var index = await descriptor.ResolveIndexAsync(page.Inner).ConfigureAwait(false);
+        var remaining = RequireRemaining(timeout, started);
+        var filled = index is not null
+            && await page.Inner.FillAsync(descriptor.Selector, index.Value, value)
+                .WaitAsync(remaining).ConfigureAwait(false);
+        if (!filled)
+        {
+            throw new PlaywrightException("The locator did not resolve to an editable element.");
+        }
+    }
+
+    private async Task PressAsync(string key, LocatorPressOptions? options)
+    {
+        OptionSupport.EnsureOnly(options, "ILocator.PressAsync", nameof(LocatorPressOptions.Timeout));
+        var timeout = PageTarget.Timeout(options?.Timeout, page.DefaultTimeout);
+        var started = Stopwatch.GetTimestamp();
+        await WaitForAsync(new LocatorWaitForOptions { Timeout = options?.Timeout }).ConfigureAwait(false);
+        var index = await descriptor.ResolveIndexAsync(page.Inner).ConfigureAwait(false);
+        var remaining = RequireRemaining(timeout, started);
+        var focused = index is not null
+            && await page.Inner.TypeAsync(descriptor.Selector, index.Value, string.Empty)
+                .WaitAsync(remaining).ConfigureAwait(false);
+        if (!focused)
+        {
+            throw new PlaywrightException("The locator did not resolve to a focusable element.");
+        }
+
+        remaining = RequireRemaining(timeout, started);
+        await page.Inner.PressAsync(
+                key,
+                new Jint.Browser.NavigationOptions { Timeout = remaining })
+            .WaitAsync(remaining).ConfigureAwait(false);
+    }
+
+    private static TimeSpan RequireRemaining(TimeSpan timeout, long started)
+    {
+        var remaining = PageTarget.Remaining(timeout, started);
+        if (remaining != System.Threading.Timeout.InfiniteTimeSpan && remaining <= TimeSpan.Zero)
+        {
+            throw new TimeoutException($"Timeout {PageTarget.DisplayTimeout(timeout)} exceeded.");
+        }
+
+        return remaining;
+    }
+
+    private async Task EnsureStrictAsync()
+    {
+        if (descriptor.Index is not null)
+        {
+            return;
+        }
+
+        var count = await CountAsync().ConfigureAwait(false);
+        if (count > 1)
+        {
+            throw new PlaywrightException(
+                $"Strict mode violation: locator '{descriptor.Selector}' resolved to {count} elements.");
+        }
+    }
+}
+
+internal sealed class ResponseTarget(PageTarget page, JintResponse response) : ProxyTarget
+{
+    internal override object? Invoke(MethodInfo method, object?[] arguments)
+    {
+        return method.Name switch
+        {
+            "get_Frame" => page.MainFrame,
+            "get_FromServiceWorker" => false,
+            "get_Headers" => response.Headers
+                .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(x => x.Key.ToLowerInvariant(), x => string.Join(", ", x.Select(v => v.Value))),
+            "get_Ok" => response.Ok,
+            "get_Status" => response.Status,
+            "get_StatusText" => response.StatusText,
+            "get_Url" => response.Url,
+            nameof(IResponse.AllHeadersAsync) => Task.FromResult(response.Headers
+                .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(x => x.Key, x => string.Join(", ", x.Select(v => v.Value)))),
+            nameof(IResponse.HeaderValueAsync) => Task.FromResult(response.Header((string) arguments[0]!)),
+            nameof(IResponse.HeadersArrayAsync) => Task.FromResult<IReadOnlyList<Header>>(
+                response.Headers.Select(x => new Header { Name = x.Name, Value = x.Value }).ToArray()),
+            nameof(IResponse.FinishedAsync) => Task.FromResult<string?>(null),
+            _ => Unsupported(method),
+        };
+    }
+}
+
+internal sealed class JsHandleTarget(object? value) : ProxyTarget
+{
+    private static readonly MethodInfo JsonValueMethod = typeof(JsHandleTarget)
+        .GetMethod(nameof(JsonValue), BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    internal override object? Invoke(MethodInfo method, object?[] arguments)
+    {
+        return method.Name switch
+        {
+            nameof(IJSHandle.AsElement) => null,
+            nameof(IJSHandle.JsonValueAsync) => JsonValueMethod
+                .MakeGenericMethod(method.ReturnType.GenericTypeArguments[0])
+                .Invoke(this, null)!,
+            nameof(IJSHandle.DisposeAsync) => ValueTask.CompletedTask,
+            _ => Unsupported(method),
+        };
+    }
+
+    private Task<T> JsonValue<T>()
+    {
+        if (value is T typed)
+        {
+            return Task.FromResult(typed);
+        }
+
+        var json = JsonSerializer.Serialize(value);
+        return Task.FromResult(JsonSerializer.Deserialize<T>(json)!);
+    }
+}
+
+internal readonly record struct LocatorDescriptor(
+    string Selector,
+    int? Index,
+    string? Name,
+    Regex? NameRegex,
+    bool Exact,
+    bool IncludeHidden)
+{
+    internal static LocatorDescriptor Css(string selector)
+        => new(selector, null, null, null, false, true);
+
+    internal static LocatorDescriptor Role(AriaRole role, PageGetByRoleOptions? options)
+    {
+        var selector = role switch
+        {
+            AriaRole.Button => "button,input[type=button],input[type=submit],input[type=reset],[role=button]",
+            AriaRole.Checkbox => "input[type=checkbox],[role=checkbox]",
+            AriaRole.Heading => "h1,h2,h3,h4,h5,h6,[role=heading]",
+            AriaRole.Link => "a[href],[role=link]",
+            AriaRole.Listitem => "li,[role=listitem]",
+            AriaRole.Option => "option,[role=option]",
+            AriaRole.Radio => "input[type=radio],[role=radio]",
+            AriaRole.Textbox => "input:not([type]),input[type=text],input[type=email],input[type=search],textarea,[role=textbox]",
+            _ => $"[role={role.ToString().ToLowerInvariant()}]",
+        };
+
+        return new(
+            selector,
+            null,
+            options?.Name ?? options?.NameString,
+            options?.NameRegex,
+            options?.Exact ?? false,
+            options?.IncludeHidden ?? false);
+    }
+
+    internal string CountScript()
+        => Index is null
+            ? $"({MatchesScript()}).length"
+            : $"({ElementScript()} === null ? 0 : 1)";
+
+    internal string TextContentsScript()
+        => Index is null
+            ? $"Array.from({MatchesScript()}, element => element.textContent ?? '')"
+            : $"(() => {{ const element = {ElementScript()}; return element === null ? [] : [element.textContent ?? '']; }})()";
+
+    internal string PropertyScript(string property)
+        => $"(() => {{ const element = {ElementScript()}; return element == null ? null : element.{property}; }})()";
+
+    internal string ExistsScript() => $"{ElementScript()} !== null";
+
+    internal string VisibleScript()
+        => $"(() => {{ const element = {ElementScript()}; if (element == null) return false; "
+            + "const box = element.getBoundingClientRect(); "
+            + "return (box.width !== 0 || box.height !== 0) && getComputedStyle(element).visibility === 'visible'; })()";
+
+    internal async Task<int?> ResolveIndexAsync(JintPage page)
+    {
+        if (Name is null && NameRegex is null)
+        {
+            return Index ?? 0;
+        }
+
+        var index = await page.EvaluateAsync<int>(
+            $"(() => {{ const all = Array.from(document.querySelectorAll({JsonSerializer.Serialize(Selector)})); "
+            + $"const matches = {MatchesScript()}; const element = matches[{ResolvedIndexScript("matches")}]; "
+            + "return element == null ? -1 : all.indexOf(element); })()").ConfigureAwait(false);
+        return index < 0 ? null : index;
+    }
+
+    private string ElementScript()
+        => $"(() => {{ const matches = {MatchesScript()}; return matches[{ResolvedIndexScript("matches")}] ?? null; }})()";
+
+    private string MatchesScript()
+    {
+        var selector = JsonSerializer.Serialize(Selector);
+        if (Name is null && NameRegex is null && IncludeHidden)
+        {
+            return $"Array.from(document.querySelectorAll({selector}))";
+        }
+
+        var name = JsonSerializer.Serialize(Name);
+        var regex = NameRegex is null
+            ? "null"
+            : $"new RegExp({JsonSerializer.Serialize(NameRegex.ToString())}, {JsonSerializer.Serialize(NameRegex.Options.HasFlag(RegexOptions.IgnoreCase) ? "i" : "")})";
+
+        return $"Array.from(document.querySelectorAll({selector})).filter(element => {{ "
+            + "if (!" + IncludeHidden.ToString().ToLowerInvariant() + " && (element.closest('[aria-hidden=true]') || getComputedStyle(element).visibility !== 'visible')) return false; "
+            + "const accessibleName = (element.getAttribute('aria-label') "
+            + "?? (element.tagName === 'INPUT' ? element.value : element.textContent) ?? '').trim().replace(/\\s+/g, ' '); "
+            + $"const expected = {name}; const pattern = {regex}; "
+            + "if (pattern !== null) return pattern.test(accessibleName); "
+            + "if (expected === null) return true; "
+            + (Exact
+                ? "return accessibleName === expected;"
+                : "return accessibleName.toLowerCase().includes(expected.toLowerCase());")
+            + " })";
+    }
+
+    private string ResolvedIndexScript(string collection)
+        => Index is >= 0 ? Index.Value.ToString(CultureInfo.InvariantCulture)
+            : Index is < 0 ? $"{collection}.length + {Index.Value.ToString(CultureInfo.InvariantCulture)}"
+            : "0";
+}
+
+internal static class Scripts
+{
+    internal static string Invocation(string expression, object? argument)
+    {
+        var serialized = JsonSerializer.Serialize(argument, argument?.GetType() ?? typeof(object));
+        return $"(() => {{ const value = ({expression}); return typeof value === 'function' ? value({serialized}) : value; }})()";
+    }
+
+    internal static string WaitInvocation(string expression, object? argument)
+    {
+        var serialized = JsonSerializer.Serialize(argument, argument?.GetType() ?? typeof(object));
+        return $"(async () => {{ const candidate = ({expression}); "
+            + $"const value = typeof candidate === 'function' ? await candidate({serialized}) : await candidate; "
+            + "return { truthy: Boolean(value), value }; })()";
+    }
+}

--- a/Jint.Browser.Playwright/ProxyInfrastructure.cs
+++ b/Jint.Browser.Playwright/ProxyInfrastructure.cs
@@ -1,0 +1,169 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using Microsoft.Playwright;
+
+namespace Jint.Browser.Playwright;
+
+internal abstract class ProxyTarget
+{
+    internal object Proxy { get; set; } = null!;
+
+    internal abstract object? Invoke(MethodInfo method, object?[] arguments);
+
+    protected static object? Unsupported(MethodInfo method)
+        => UnsupportedOperation.For(method);
+}
+
+[SuppressMessage(
+    "Performance",
+    "CA1852:Seal internal types",
+    Justification = "DispatchProxy generates a runtime subclass of this type.")]
+internal class PlaywrightDispatchProxy : DispatchProxy
+{
+    internal ProxyTarget Target { get; set; } = null!;
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        ArgumentNullException.ThrowIfNull(targetMethod);
+
+        if (targetMethod.DeclaringType == typeof(object))
+        {
+            return targetMethod.Name switch
+            {
+                nameof(ToString) => Target.GetType().Name,
+                nameof(GetHashCode) => RuntimeHelpers.GetHashCode(this),
+                nameof(Equals) => ReferenceEquals(this, args![0]),
+                _ => throw new NotSupportedException(targetMethod.Name),
+            };
+        }
+
+        return Target.Invoke(targetMethod, args ?? []);
+    }
+}
+
+internal static class ProxyFactory
+{
+    internal static T Create<T>(ProxyTarget target) where T : class
+    {
+        var proxy = DispatchProxy.Create<T, PlaywrightDispatchProxy>();
+        target.Proxy = proxy;
+        ((PlaywrightDispatchProxy) (object) proxy).Target = target;
+        return proxy;
+    }
+}
+
+internal static class UnsupportedOperation
+{
+    private static readonly MethodInfo FaultedTaskMethod = typeof(UnsupportedOperation)
+        .GetMethod(nameof(FaultedTask), BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    internal static object? For(MethodInfo method)
+    {
+        var exception = new NotSupportedException(
+            $"Jint.Browser.Playwright does not support {method.DeclaringType?.Name}.{DisplayName(method)}.");
+
+        if (method.ReturnType == typeof(Task))
+        {
+            return Task.FromException(exception);
+        }
+
+        if (method.ReturnType.IsGenericType && method.ReturnType.GetGenericTypeDefinition() == typeof(Task<>))
+        {
+            return FaultedTaskMethod.MakeGenericMethod(method.ReturnType.GenericTypeArguments[0])
+                .Invoke(null, [exception]);
+        }
+
+        if (method.ReturnType == typeof(ValueTask))
+        {
+            return new ValueTask(Task.FromException(exception));
+        }
+
+        throw exception;
+    }
+
+    private static Task<T> FaultedTask<T>(Exception exception) => Task.FromException<T>(exception);
+
+    private static string DisplayName(MethodInfo method)
+        => method.IsSpecialName && method.Name.StartsWith("get_", StringComparison.Ordinal)
+            ? method.Name[4..]
+            : method.Name;
+}
+
+internal static class OptionSupport
+{
+    internal static void EnsureOnly(object? options, string operation, params string[] supported)
+    {
+        if (options is null)
+        {
+            return;
+        }
+
+        foreach (var property in options.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            var value = property.GetValue(options);
+            if (value is null || IsDefaultValue(value, property.PropertyType))
+            {
+                continue;
+            }
+
+            if (supported.Contains(property.Name, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            throw new NotSupportedException(
+                $"Jint.Browser.Playwright does not support option {options.GetType().Name}.{property.Name} for {operation}.");
+        }
+    }
+
+    private static bool IsDefaultValue(object value, Type type)
+        => type.IsValueType && Equals(value, Activator.CreateInstance(type));
+}
+
+internal sealed class CleanupErrors
+{
+    private List<Exception>? _exceptions;
+
+    internal bool HasAny => _exceptions is { Count: > 0 };
+
+    internal void Run(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception exception)
+        {
+            (_exceptions ??= []).Add(exception);
+        }
+    }
+
+    internal async Task RunAsync(Func<Task> action)
+    {
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            (_exceptions ??= []).Add(exception);
+        }
+    }
+
+    internal void ThrowIfAny()
+    {
+        if (_exceptions is not { Count: > 0 } exceptions)
+        {
+            return;
+        }
+
+        if (exceptions.Count == 1)
+        {
+            ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+        }
+
+        throw new AggregateException(exceptions);
+    }
+}

--- a/Jint.Browser.Playwright/README.md
+++ b/Jint.Browser.Playwright/README.md
@@ -1,0 +1,34 @@
+# Jint.Browser.Playwright
+
+`Jint.Browser.Playwright` implements the public Microsoft.Playwright browser interfaces directly over
+[`Jint.Browser`](https://github.com/sebastienros/jint/tree/main/Jint.Browser). It starts no browser or Node
+process and uses no Chrome DevTools Protocol connection.
+
+```csharp
+using Jint.Browser.Playwright;
+using Microsoft.Playwright;
+
+IBrowserType browserType = JintPlaywright.BrowserType;
+
+await using var browser = await browserType.LaunchAsync();
+var page = await browser.NewPageAsync();
+
+await page.SetContentAsync("<button id='save'>Save</button>");
+await page.Locator("#save").ClickAsync();
+```
+
+The adapter is an evolving compatibility layer. Operations backed by `Jint.Browser` execute in-process;
+features that require pixels, a native browser, or an operating-system window fail with
+`NotSupportedException`. This includes screenshots, PDF generation, video, browser extensions and CDP
+sessions.
+
+Locator support currently covers CSS selectors and a first set of role locators, with strict matching,
+waiting and trusted input dispatch. It does not yet reproduce Playwright's complete actionability,
+accessibility-name or atomic locator-resolution semantics.
+
+The package is built and tested against Microsoft.Playwright 1.62. Applications can use Playwright's public
+browser, context, page, frame and locator interfaces, but Playwright features that downcast those interfaces
+to its internal implementation, including its built-in assertions, cannot use a third-party implementation.
+
+The package references Microsoft.Playwright for its public API contracts but excludes its build assets, so
+the bundled Node runtime and driver are not copied to the consuming application.

--- a/Jint.Browser/NavigationOptions.cs
+++ b/Jint.Browser/NavigationOptions.cs
@@ -48,13 +48,18 @@ public sealed class NavigationOptions
     /// whichever document it had reached: a timeout during the fetch leaves the previous document in place,
     /// and one during the parse leaves the new one part-built, exactly as the page itself would see it.
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">The value is not positive.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The value is neither positive nor <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
     public TimeSpan Timeout
     {
         get => _timeout;
-        set => _timeout = value > TimeSpan.Zero
+        set => _timeout = value > TimeSpan.Zero || value == System.Threading.Timeout.InfiniteTimeSpan
             ? value
-            : throw new ArgumentOutOfRangeException(nameof(value), value, "Timeout must be positive.");
+            : throw new ArgumentOutOfRangeException(
+                nameof(value),
+                value,
+                "Timeout must be positive or infinite.");
     }
 
     /// <summary>

--- a/Jint.Browser/Page.Content.cs
+++ b/Jint.Browser/Page.Content.cs
@@ -52,7 +52,8 @@ public sealed partial class Page
     /// <param name="mainContentOnly">Whether to walk only the document's main content, when it has one.</param>
     /// <param name="maxLength">The greatest number of characters to return, or zero for no limit.</param>
     /// <param name="includeReferences">
-    /// Whether each element node carries <c>[ref=<i>n</i>]</c>, which <see cref="ClickAsync"/> and the rest
+    /// Whether each element node carries <c>[ref=<i>n</i>]</c>, which
+    /// <see cref="ClickAsync(string, NavigationOptions)"/> and the rest
     /// of the input members accept in place of a selector.
     /// </param>
     /// <returns>The snapshot, or an empty string when the page holds no document.</returns>
@@ -110,7 +111,9 @@ public sealed partial class Page
                 return true;
             }
 
-            if (_closed || Stopwatch.GetElapsedTime(started) >= timeout)
+            if (_closed
+                || (timeout != System.Threading.Timeout.InfiniteTimeSpan
+                    && Stopwatch.GetElapsedTime(started) >= timeout))
             {
                 return false;
             }

--- a/Jint.Browser/Page.Input.cs
+++ b/Jint.Browser/Page.Input.cs
@@ -57,14 +57,22 @@ public sealed partial class Page
     /// </para>
     /// </remarks>
     /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
-    public async Task<bool> ClickAsync(string target, NavigationOptions? options = null)
+    public Task<bool> ClickAsync(string target, NavigationOptions? options = null) => ClickAsync(target, 0, options);
+
+    /// <summary>Clicks the indexed element that <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="index">The zero-based match, or a negative offset from the last match.</param>
+    /// <param name="options">How far to wait for a navigation the click causes; the defaults when omitted.</param>
+    /// <returns><see langword="true"/> when the indexed element matched and was clicked.</returns>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public async Task<bool> ClickAsync(string target, int index, NavigationOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(target);
         ObjectDisposedException.ThrowIf(_closed, this);
 
         var captured = await _loop.PostAsync((bool Clicked, NavigationRequest? Navigation) (engine) =>
         {
-            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target) is not { } element)
+            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target, index) is not { } element)
             {
                 return (Clicked: false, Navigation: (NavigationRequest?) null);
             }
@@ -117,14 +125,21 @@ public sealed partial class Page
     /// against <c>mousemove</c> does.
     /// </remarks>
     /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
-    public Task<bool> HoverAsync(string target)
+    public Task<bool> HoverAsync(string target) => HoverAsync(target, 0);
+
+    /// <summary>Moves the pointer over the indexed element that <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="index">The zero-based match, or a negative offset from the last match.</param>
+    /// <returns><see langword="true"/> when the indexed element matched and had a box to move to.</returns>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> HoverAsync(string target, int index)
     {
         ArgumentNullException.ThrowIfNull(target);
         ObjectDisposedException.ThrowIf(_closed, this);
 
         return _loop.PostAsync(engine =>
         {
-            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target) is not { } element)
+            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target, index) is not { } element)
             {
                 return false;
             }
@@ -148,12 +163,21 @@ public sealed partial class Page
     /// <returns><see langword="true"/> when an editable element matched.</returns>
     /// <remarks>
     /// Focus, select all, then insert — which is one <c>beforeinput</c> and one <c>input</c> rather than the
-    /// one per character <see cref="TypeAsync"/> fires, and is what a client library's <c>fill</c> does. Use
-    /// it when the value is what matters; use <see cref="TypeAsync"/> when the page is listening for the
+    /// one per character <see cref="TypeAsync(string, string)"/> fires, and is what a client library's
+    /// <c>fill</c> does. Use it when the value is what matters; use <see cref="TypeAsync(string, string)"/>
+    /// when the page is listening for the
     /// keys.
     /// </remarks>
     /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
-    public Task<bool> FillAsync(string target, string text)
+    public Task<bool> FillAsync(string target, string text) => FillAsync(target, 0, text);
+
+    /// <summary>Replaces the value of the indexed control that <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="index">The zero-based match, or a negative offset from the last match.</param>
+    /// <param name="text">The value to leave in the control.</param>
+    /// <returns><see langword="true"/> when the indexed editable element matched.</returns>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> FillAsync(string target, int index, string text)
     {
         ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(text);
@@ -161,7 +185,7 @@ public sealed partial class Page
 
         return _loop.PostAsync(engine =>
         {
-            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target) is not { } element)
+            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target, index) is not { } element)
             {
                 return false;
             }
@@ -188,10 +212,19 @@ public sealed partial class Page
     /// The control is focused and each character becomes a <c>keydown</c>, a <c>keypress</c>, the insertion
     /// with its <c>beforeinput</c> and <c>input</c>, and a <c>keyup</c> — so a page filtering keystrokes, an
     /// autocomplete listening for <c>input</c> and a form's <c>maxlength</c> all see what they would see from
-    /// a user. It does <b>not</b> clear the control first; <see cref="FillAsync"/> is the one that does.
+    /// a user. It does <b>not</b> clear the control first; <see cref="FillAsync(string, string)"/> is the one
+    /// that does.
     /// </remarks>
     /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
-    public Task<bool> TypeAsync(string target, string text)
+    public Task<bool> TypeAsync(string target, string text) => TypeAsync(target, 0, text);
+
+    /// <summary>Types into the indexed element that <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="index">The zero-based match, or a negative offset from the last match.</param>
+    /// <param name="text">The characters to type.</param>
+    /// <returns><see langword="true"/> when the indexed element matched and was focused.</returns>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> TypeAsync(string target, int index, string text)
     {
         ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(text);
@@ -199,7 +232,7 @@ public sealed partial class Page
 
         return _loop.PostAsync(engine =>
         {
-            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target) is not { } element)
+            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target, index) is not { } element)
             {
                 return false;
             }
@@ -223,7 +256,8 @@ public sealed partial class Page
     /// <returns><see langword="true"/> always, because a key always reaches something — the body when nothing is focused.</returns>
     /// <remarks>
     /// <c>Enter</c> in a single-line control is HTML's implicit submission, so a form it submits is navigated
-    /// and awaited here the way <see cref="ClickAsync"/> awaits a link's. <c>Tab</c> moves focus along the
+    /// and awaited here the way <see cref="ClickAsync(string, NavigationOptions)"/> awaits a link's.
+    /// <c>Tab</c> moves focus along the
     /// sequential focus order, the editing keys edit, and everything else fires its events and does nothing.
     /// </remarks>
     /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
@@ -273,7 +307,15 @@ public sealed partial class Page
     /// <c>onChange</c> is bound to.
     /// </remarks>
     /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
-    public Task<bool> SelectAsync(string target, string value)
+    public Task<bool> SelectAsync(string target, string value) => SelectAsync(target, 0, value);
+
+    /// <summary>Selects an option in the indexed <c>&lt;select&gt;</c> that <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="index">The zero-based match, or a negative offset from the last match.</param>
+    /// <param name="value">The option's value, or its text when no option carries that value.</param>
+    /// <returns><see langword="true"/> when the indexed select matched and had such an option.</returns>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> SelectAsync(string target, int index, string value)
     {
         ArgumentNullException.ThrowIfNull(target);
         ArgumentNullException.ThrowIfNull(value);
@@ -281,7 +323,7 @@ public sealed partial class Page
 
         return _loop.PostAsync(engine =>
         {
-            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target) is not IHtmlSelectElement select)
+            if (PageRuntime.Find(engine) is not { } runtime || ElementLocator.Find(runtime.Document, target, index) is not IHtmlSelectElement select)
             {
                 return false;
             }
@@ -333,12 +375,20 @@ public sealed partial class Page
     /// while the wait lasts.
     /// </remarks>
     /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
-    public Task<bool> WaitForSelectorAsync(string selector, TimeSpan timeout)
+    public Task<bool> WaitForSelectorAsync(string selector, TimeSpan timeout) => WaitForSelectorAsync(selector, 0, timeout);
+
+    /// <summary>Waits until the indexed element matching <paramref name="selector"/> is in the document.</summary>
+    /// <param name="selector">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="index">The zero-based match, or a negative offset from the last match.</param>
+    /// <param name="timeout">The ceiling on the wait.</param>
+    /// <returns><see langword="true"/> when it appeared, <see langword="false"/> when the timeout won.</returns>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> WaitForSelectorAsync(string selector, int index, TimeSpan timeout)
     {
         ArgumentNullException.ThrowIfNull(selector);
         ObjectDisposedException.ThrowIf(_closed, this);
 
-        return WaitForAsync(engine => ElementLocator.Find(PageRuntime.Find(engine)?.Document, selector) is not null, timeout);
+        return WaitForAsync(engine => ElementLocator.Find(PageRuntime.Find(engine)?.Document, selector, index) is not null, timeout);
     }
 
     /// <summary>Waits until <paramref name="text"/> appears in the document's rendered text.</summary>
@@ -424,7 +474,9 @@ public sealed partial class Page
                 return true;
             }
 
-            if (_closed || System.Diagnostics.Stopwatch.GetElapsedTime(started) >= timeout)
+            if (_closed
+                || (timeout != System.Threading.Timeout.InfiniteTimeSpan
+                    && System.Diagnostics.Stopwatch.GetElapsedTime(started) >= timeout))
             {
                 return false;
             }

--- a/Jint.Browser/Page.cs
+++ b/Jint.Browser/Page.cs
@@ -4,6 +4,8 @@ using AngleSharp;
 using Jint.Browser.Runtime;
 using Jint.Browser.Workers;
 using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime.Interop;
 using Jint.WebApi;
 
 namespace Jint.Browser;
@@ -232,6 +234,92 @@ public sealed partial class Page : IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(script);
         return _loop.PostAsync(engine => Convert<T>(engine.Evaluate(script)));
+    }
+
+    /// <summary>Evaluates <paramref name="script"/> and awaits its completion value when it is a promise.</summary>
+    /// <param name="script">The script to run.</param>
+    /// <param name="cancellationToken">Cancellation to observe while a promise is pending.</param>
+    /// <returns>The resolved result converted on the page's thread — never a <c>JsValue</c>.</returns>
+    /// <remarks>
+    /// The synchronous part runs as one page turn. A pending promise then leaves the page loop free to run
+    /// its timers, microtasks and network completions; its settlement reaction converts the result on that
+    /// same loop, so no engine-owned value crosses the page-thread boundary.
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<object?> EvaluateAndAwaitAsync(string script, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(script);
+        return EvaluateAndAwaitCoreAsync(script, static value => value.ToObject(), cancellationToken);
+    }
+
+    /// <summary>Evaluates <paramref name="script"/>, awaits a promise result, and converts it to <typeparamref name="T"/>.</summary>
+    /// <typeparam name="T">The type to convert the resolved result to.</typeparam>
+    /// <param name="script">The script to run.</param>
+    /// <param name="cancellationToken">Cancellation to observe while a promise is pending.</param>
+    /// <returns>The converted resolved result, or the default when it is <c>null</c> or <c>undefined</c>.</returns>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<T?> EvaluateAndAwaitAsync<T>(string script, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(script);
+        return EvaluateAndAwaitCoreAsync(script, Convert<T>, cancellationToken);
+    }
+
+    private async Task<T> EvaluateAndAwaitCoreAsync<T>(
+        string script,
+        Func<JsValue, T> convert,
+        CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_closed, this);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var completion = new TaskCompletionSource<T>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var documentClosing = CancellationToken.None;
+
+        await _loop.PostAsync(engine =>
+        {
+            documentClosing = _loop.DocumentClosing;
+            var value = engine.Evaluate(script);
+            if (value is not JsPromise promise)
+            {
+                completion.TrySetResult(convert(value));
+                return;
+            }
+
+            var onFulfilled = new ClrFunction(engine, "", (_, arguments) =>
+            {
+                try
+                {
+                    completion.TrySetResult(convert(arguments[0]));
+                }
+                catch (Exception exception)
+                {
+                    completion.TrySetException(exception);
+                }
+
+                return JsValue.Undefined;
+            });
+
+            var onRejected = new ClrFunction(engine, "", (_, arguments) =>
+            {
+                completion.TrySetException(
+                    new InvalidOperationException($"Promise was rejected with value {arguments[0]}"));
+                return JsValue.Undefined;
+            });
+
+            PromiseOperations.PerformPromiseThen(
+                engine,
+                promise,
+                onFulfilled,
+                onRejected,
+                resultCapability: null);
+        }).ConfigureAwait(false);
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            _loop.Closing,
+            documentClosing);
+        return await completion.Task.WaitAsync(linked.Token).ConfigureAwait(false);
     }
 
     /// <summary>The document's serialized markup, including the doctype.</summary>

--- a/Jint.Browser/Runtime/ElementLocator.cs
+++ b/Jint.Browser/Runtime/ElementLocator.cs
@@ -33,7 +33,10 @@ internal static class ElementLocator
     /// asking about an element that is not there and a caller asking wrongly both want "no", and a selector
     /// arriving from a protocol client or an agent is input rather than code.
     /// </remarks>
-    internal static IElement? Find(IDocument? document, string target)
+    internal static IElement? Find(IDocument? document, string target) => Find(document, target, 0);
+
+    /// <summary>The indexed element <paramref name="target"/> names, or <see langword="null"/>.</summary>
+    internal static IElement? Find(IDocument? document, string target, int index)
     {
         if (document is null || string.IsNullOrWhiteSpace(target))
         {
@@ -42,6 +45,11 @@ internal static class ElementLocator
 
         if (target.StartsWith(ReferencePrefix, StringComparison.Ordinal))
         {
+            if (index is not 0 and not -1)
+            {
+                return null;
+            }
+
             var text = target[ReferencePrefix.Length..].Trim();
             return int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out var id)
                 ? AccessibilityTree.ElementFor(document, id)
@@ -50,7 +58,9 @@ internal static class ElementLocator
 
         try
         {
-            return document.QuerySelector(target);
+            var elements = document.QuerySelectorAll(target);
+            var resolved = index >= 0 ? index : elements.Length + index;
+            return (uint) resolved < (uint) elements.Length ? elements[resolved] : null;
         }
         catch (DomException)
         {

--- a/Jint.Browser/Runtime/PageLoop.cs
+++ b/Jint.Browser/Runtime/PageLoop.cs
@@ -38,6 +38,7 @@ internal sealed class PageLoop : IDisposable
         new UnboundedChannelOptions { SingleReader = true, AllowSynchronousContinuations = false });
 
     private readonly CancellationTokenSource _closing = new();
+    private CancellationTokenSource _documentClosing = new();
     private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource _stopped = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Func<Engine> _engineFactory;
@@ -68,6 +69,10 @@ internal sealed class PageLoop : IDisposable
 
     /// <summary>Whether the loop has been asked to stop.</summary>
     internal bool IsClosed => _closed;
+
+    /// <summary>Cancellation for work tied to the engine and document the loop currently owns.</summary>
+    /// <remarks>Read only from a mailbox request running on the loop thread.</remarks>
+    internal CancellationToken DocumentClosing => _documentClosing.Token;
 
     /// <summary>The thread this loop runs on, which is the only thread allowed to touch the engine.</summary>
     internal Thread Thread => _thread;
@@ -175,7 +180,11 @@ internal sealed class PageLoop : IDisposable
     }
 
     /// <summary>Releases the cancellation source, after <see cref="CloseAsync"/> has completed.</summary>
-    public void Dispose() => _closing.Dispose();
+    public void Dispose()
+    {
+        _documentClosing.Dispose();
+        _closing.Dispose();
+    }
 
     private static ObjectDisposedException Disposed()
         => new(nameof(Page), "The page has been closed; its engine and its document no longer exist.");
@@ -191,6 +200,17 @@ internal sealed class PageLoop : IDisposable
     internal Engine ReplaceEngine(Func<Engine> factory)
     {
         var previous = _engine;
+        var previousDocumentClosing = _documentClosing;
+        _documentClosing = new CancellationTokenSource();
+
+        try
+        {
+            previousDocumentClosing.Cancel();
+        }
+        catch (AggregateException exception)
+        {
+            _onPumpError(exception);
+        }
 
         // Before the swap, and before the new engine is built: a constraint belongs to one engine, so the
         // turn the request opened has to be closed on the engine it was opened on. Building the replacement

--- a/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
+++ b/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
@@ -325,7 +325,7 @@ public class PlaywrightCourseTests
             await protocol.AddBrowser(pages).ConfigureAwait(false);
             await protocol.StartAsync().ConfigureAwait(false);
 
-            var playwright = await Playwright.CreateAsync().ConfigureAwait(false);
+            var playwright = await Microsoft.Playwright.Playwright.CreateAsync().ConfigureAwait(false);
 
             // The HTTP form, which is the one Playwright's own documentation gives and the one the recording
             // was made with: it reads webSocketDebuggerUrl out of /json/version and connects to that.

--- a/Jint.Tests.Browser/Events/PageInputTests.cs
+++ b/Jint.Tests.Browser/Events/PageInputTests.cs
@@ -117,6 +117,46 @@ public sealed class PageInputTests
     }
 
     [Test]
+    public async Task IndexedTargetsSelectOneMatchAndAcceptOffsetsFromTheEnd()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <!doctype html>
+            <button class="click">first</button><button class="click">second</button>
+            <div class="hover">first</div><div class="hover">second</div>
+            <input class="field" value="first"><input class="field" value="second">
+            <select class="pick"><option value="a">A</option><option value="b">B</option></select>
+            <select class="pick"><option value="a">A</option><option value="b">B</option></select>
+            <span class="late">first</span>
+            <script>
+              document.querySelectorAll('.click')[1].onclick = () => document.body.dataset.clicked = 'second';
+              document.querySelectorAll('.hover')[1].onmousemove = () => document.body.dataset.hovered = 'second';
+              setTimeout(() => {
+                const span = document.createElement('span');
+                span.className = 'late';
+                span.textContent = 'second';
+                document.body.appendChild(span);
+              }, 20);
+            </script>
+            """);
+
+        (await page.ClickAsync(".click", -1)).Should().BeTrue();
+        (await page.HoverAsync(".hover", 1)).Should().BeTrue();
+        (await page.FillAsync(".field", -1, "changed")).Should().BeTrue();
+        (await page.TypeAsync(".field", 0, "+typed")).Should().BeTrue();
+        (await page.SelectAsync(".pick", -1, "b")).Should().BeTrue();
+        (await page.WaitForSelectorAsync(".late", 1, Patience)).Should().BeTrue();
+
+        (await page.EvaluateAsync<string>("document.body.dataset.clicked")).Should().Be("second");
+        (await page.EvaluateAsync<string>("document.body.dataset.hovered")).Should().Be("second");
+        (await page.EvaluateAsync<string>("document.querySelectorAll('.field')[0].value")).Should().Be("+typedfirst");
+        (await page.EvaluateAsync<string>("document.querySelectorAll('.field')[1].value")).Should().Be("changed");
+        (await page.EvaluateAsync<string>("document.querySelectorAll('.pick')[1].value")).Should().Be("b");
+    }
+
+    [Test]
     public async Task TypeFiresOneInputEventPerCharacter()
     {
         await using var browser = new Browser();

--- a/Jint.Tests.Browser/Jint.Tests.Browser.csproj
+++ b/Jint.Tests.Browser/Jint.Tests.Browser.csproj
@@ -29,6 +29,9 @@
       passes there is a test about the protocol rather than about a method call.
     -->
     <ProjectReference Include="..\Jint.Browser.Mcp\Jint.Browser.Mcp.csproj" />
+    <!-- The direct Playwright interface adapter. Tests here prove that ordinary Microsoft.Playwright
+         client code can select Jint instead of Chromium without starting Node or speaking CDP. -->
+    <ProjectReference Include="..\Jint.Browser.Playwright\Jint.Browser.Playwright.csproj" />
     <!--
       The web-platform-tests corpus, its server and its exclusion vocabulary, which Wpt/ runs the browser lane
       on. One corpus and one pin: copying WptCorpus, WptServer and WptExclusion here would give the two lanes

--- a/Jint.Tests.Browser/Playwright/DirectPlaywrightTests.cs
+++ b/Jint.Tests.Browser/Playwright/DirectPlaywrightTests.cs
@@ -1,0 +1,407 @@
+using Jint.Tests.Browser.Navigation;
+using Microsoft.Playwright;
+
+namespace Jint.Tests.Browser.PlaywrightAdapter;
+
+/// <summary>
+/// Microsoft.Playwright's public interfaces backed directly by Jint.Browser, without its Node driver or CDP.
+/// </summary>
+public sealed class DirectPlaywrightTests
+{
+    [Test]
+    public async Task BrowserTypeCreatesTheExpectedObjectGraph()
+    {
+        IBrowserType browserType = global::Jint.Browser.Playwright.JintPlaywright.BrowserType;
+        browserType.Name.Should().Be("jint");
+        browserType.ExecutablePath.Should().BeEmpty();
+
+        await using var browser = await browserType.LaunchAsync();
+        IBrowserContext? createdContext = null;
+        IPage? createdPage = null;
+        var disconnected = false;
+        var contextClosed = false;
+        var pageClosed = false;
+
+        browser.Context += (_, context) => createdContext = context;
+        browser.Disconnected += (_, _) => disconnected = true;
+
+        var context = await browser.NewContextAsync();
+        context.Page += (_, page) => createdPage = page;
+        context.Close += (_, _) => contextClosed = true;
+
+        var page = await context.NewPageAsync();
+        page.Close += (_, _) => pageClosed = true;
+
+        createdContext.Should().BeSameAs(context);
+        createdPage.Should().BeSameAs(page);
+        browser.Contexts.Should().ContainSingle().Which.Should().BeSameAs(context);
+        context.Pages.Should().ContainSingle().Which.Should().BeSameAs(page);
+        context.Browser.Should().BeSameAs(browser);
+        page.Context.Should().BeSameAs(context);
+        page.MainFrame.Page.Should().BeSameAs(page);
+        page.Frames.Should().ContainSingle().Which.Should().BeSameAs(page.MainFrame);
+        browser.IsConnected.Should().BeTrue();
+        context.IsClosed.Should().BeFalse();
+        page.IsClosed.Should().BeFalse();
+
+        await browser.CloseAsync();
+
+        browser.IsConnected.Should().BeFalse();
+        context.IsClosed.Should().BeTrue();
+        page.IsClosed.Should().BeTrue();
+        browser.Contexts.Should().BeEmpty();
+        disconnected.Should().BeTrue();
+        contextClosed.Should().BeTrue();
+        pageClosed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task PageSupportsContentEvaluationAndIndexedLocators()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <!doctype html>
+            <title>Direct Playwright</title>
+            <ul>
+              <li>first</li>
+              <li>second</li>
+              <li>third</li>
+            </ul>
+            """);
+
+        (await page.TitleAsync()).Should().Be("Direct Playwright");
+        (await page.ContentAsync()).Should().Contain("<li>second</li>");
+        (await page.EvaluateAsync<int>("() => 6 * 7")).Should().Be(42);
+        (await page.EvaluateAsync<string>("value => value + '!'", "jint")).Should().Be("jint!");
+        (await page.EvaluateAsync<int>("() => Promise.resolve(42)")).Should().Be(42);
+
+        var items = page.Locator("li");
+        (await items.CountAsync()).Should().Be(3);
+        (await items.AllTextContentsAsync()).Should().Equal("first", "second", "third");
+        (await items.First.TextContentAsync()).Should().Be("first");
+        (await items.Nth(1).TextContentAsync()).Should().Be("second");
+        (await items.Nth(1).CountAsync()).Should().Be(1);
+        (await items.Nth(1).AllTextContentsAsync()).Should().Equal("second");
+        (await items.Last.TextContentAsync()).Should().Be("third");
+        (await items.Nth(-2).TextContentAsync()).Should().Be("second");
+        (await items.First.IsVisibleAsync()).Should().BeTrue();
+
+        var strict = async () => await items.TextContentAsync();
+        await strict.Should().ThrowAsync<PlaywrightException>().WithMessage("*resolved to 3 elements*");
+    }
+
+    [Test]
+    public async Task LocatorValueReadsWaitForElementsToAttach()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <script>
+              setTimeout(() => {
+                document.body.insertAdjacentHTML(
+                  'beforeend',
+                  '<p id="late-text">ready</p><input id="late-input" value="filled">');
+              }, 20);
+            </script>
+            """);
+
+        (await page.Locator("#late-text").TextContentAsync(
+            new LocatorTextContentOptions { Timeout = 1_000 })).Should().Be("ready");
+        (await page.Locator("#late-input").InputValueAsync(
+            new LocatorInputValueOptions { Timeout = 1_000 })).Should().Be("filled");
+    }
+
+    [Test]
+    public async Task BrowserConfigurationFlowsIntoJintBrowserOptions()
+    {
+        var browserType = global::Jint.Browser.Playwright.JintPlaywright.CreateBrowserType(
+            options => options.UserAgent = "Jint.Browser.Playwright test");
+
+        await using var browser = await browserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<p>configured</p>");
+
+        (await page.EvaluateAsync<string>("() => navigator.userAgent")).Should().Be("Jint.Browser.Playwright test");
+    }
+
+    [Test]
+    public async Task BrowserNewPageClosesItsImplicitContextWithThePage()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        var context = page.Context;
+
+        browser.Contexts.Should().ContainSingle().Which.Should().BeSameAs(context);
+
+        await page.CloseAsync();
+
+        page.IsClosed.Should().BeTrue();
+        context.IsClosed.Should().BeTrue();
+        browser.Contexts.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ThrowingCreationHandlersCloseTheCreatedResources()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        IBrowserContext? createdContext = null;
+        EventHandler<IBrowserContext> contextHandler = (_, context) =>
+        {
+            createdContext = context;
+            throw new InvalidOperationException("context creation failed");
+        };
+        browser.Context += contextHandler;
+
+        var newContext = async () => await browser.NewContextAsync();
+
+        await newContext.Should().ThrowAsync<InvalidOperationException>().WithMessage("context creation failed");
+        createdContext.Should().NotBeNull();
+        createdContext!.IsClosed.Should().BeTrue();
+        browser.Contexts.Should().BeEmpty();
+
+        browser.Context -= contextHandler;
+        var context = await browser.NewContextAsync();
+        IPage? createdPage = null;
+        context.Page += (_, page) =>
+        {
+            createdPage = page;
+            throw new InvalidOperationException("page creation failed");
+        };
+
+        var newPage = async () => await context.NewPageAsync();
+
+        await newPage.Should().ThrowAsync<InvalidOperationException>().WithMessage("page creation failed");
+        createdPage.Should().NotBeNull();
+        createdPage!.IsClosed.Should().BeTrue();
+        context.Pages.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ThrowingPageCloseHandlerDoesNotLeakTheImplicitContext()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        var context = page.Context;
+        page.Close += (_, _) => throw new InvalidOperationException("handler failed");
+
+        var close = async () => await page.CloseAsync();
+
+        await close.Should().ThrowAsync<InvalidOperationException>().WithMessage("handler failed");
+        page.IsClosed.Should().BeTrue();
+        context.IsClosed.Should().BeTrue();
+        browser.Contexts.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ThrowingCloseHandlersDoNotStopContextCleanup()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var context = await browser.NewContextAsync();
+        var first = await context.NewPageAsync();
+        var second = await context.NewPageAsync();
+        var secondClosed = false;
+        var contextClosed = false;
+
+        first.Close += (_, _) => throw new InvalidOperationException("page handler failed");
+        second.Close += (_, _) => secondClosed = true;
+        context.Close += (_, _) =>
+        {
+            contextClosed = true;
+            throw new InvalidOperationException("context handler failed");
+        };
+
+        var close = async () => await context.CloseAsync();
+
+        await close.Should().ThrowAsync<AggregateException>();
+        first.IsClosed.Should().BeTrue();
+        second.IsClosed.Should().BeTrue();
+        secondClosed.Should().BeTrue();
+        contextClosed.Should().BeTrue();
+        context.IsClosed.Should().BeTrue();
+        context.Pages.Should().BeEmpty();
+        browser.Contexts.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ThrowingPageCloseHandlerDoesNotStopBrowserCleanup()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var firstContext = await browser.NewContextAsync();
+        var secondContext = await browser.NewContextAsync();
+        var first = await firstContext.NewPageAsync();
+        var second = await secondContext.NewPageAsync();
+        var secondClosed = false;
+        var disconnected = false;
+
+        first.Close += (_, _) => throw new InvalidOperationException("page handler failed");
+        second.Close += (_, _) => secondClosed = true;
+        browser.Disconnected += (_, _) => disconnected = true;
+
+        var close = async () => await browser.CloseAsync();
+
+        await close.Should().ThrowAsync<InvalidOperationException>().WithMessage("page handler failed");
+        first.IsClosed.Should().BeTrue();
+        second.IsClosed.Should().BeTrue();
+        secondClosed.Should().BeTrue();
+        firstContext.IsClosed.Should().BeTrue();
+        secondContext.IsClosed.Should().BeTrue();
+        browser.Contexts.Should().BeEmpty();
+        browser.IsConnected.Should().BeFalse();
+        disconnected.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task LocatorActionsUseJintsTrustedInputPath()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <!doctype html>
+            <input class="editor" value="first">
+            <input class="editor" value="second">
+            <button>Save</button>
+            <button>Save</button>
+            <p id="log"></p>
+            <script>
+              document.querySelectorAll('button')[1].addEventListener('click', event => {
+                document.getElementById('log').textContent = event.isTrusted ? 'trusted' : 'synthetic';
+              });
+              document.querySelectorAll('.editor')[1].addEventListener('keydown', event => {
+                if (event.key === 'Enter') document.body.dataset.entered = 'yes';
+              });
+            </script>
+            """);
+
+        var editor = page.Locator(".editor").Last;
+        await editor.FillAsync("changed");
+        await editor.PressAsync("Enter");
+        await page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { Name = "Save" }).Last.ClickAsync();
+
+        (await editor.InputValueAsync()).Should().Be("changed");
+        (await page.EvaluateAsync<string>("() => document.body.dataset.entered")).Should().Be("yes");
+        (await page.Locator("#log").TextContentAsync()).Should().Be("trusted");
+    }
+
+    [Test]
+    public async Task LocatorClickTimeoutIncludesNavigation()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/index.html", "<a href='/slow.html'>slow</a>");
+        server.Map("/slow.html", _ =>
+        {
+            Thread.Sleep(200);
+            return LoopbackResponse.Html("<title>slow</title>");
+        });
+
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        await page.GotoAsync(server.Url("/index.html"));
+
+        var click = async () => await page.Locator("a").ClickAsync(
+            new LocatorClickOptions { Timeout = 50 });
+
+        await click.Should().ThrowAsync<System.TimeoutException>();
+    }
+
+    [Test]
+    public async Task WaitsNavigationAndHandlesRunInProcess()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml(
+            "/index.html",
+            "<title>navigated</title><script>setTimeout(() => window.answer = 42, 20)</script>");
+
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+
+        var response = await page.GotoAsync(server.Url("/index.html"), new PageGotoOptions { Timeout = 0 });
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+        response.Ok.Should().BeTrue();
+        response.Url.Should().Be(server.Url("/index.html"));
+        response.Frame.Should().BeSameAs(page.MainFrame);
+        (await response.FinishedAsync()).Should().BeNull();
+        (await page.TitleAsync()).Should().Be("navigated");
+
+        await using var handle = await page.WaitForFunctionAsync("() => window.answer");
+        (await handle.JsonValueAsync<int>()).Should().Be(42);
+
+        await page.SetContentAsync(
+            "<title>replacement</title>",
+            new PageSetContentOptions { Timeout = 0 });
+        page.Url.Should().Be(server.Url("/index.html"));
+        (await page.TitleAsync()).Should().Be("replacement");
+    }
+
+    [Test]
+    public async Task WaitForFunctionReturnsTheValueThatSatisfiedTheWait()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            "<script>window.calls = 0; setTimeout(() => window.ready = true, 20)</script>");
+
+        await using var handle = await page.WaitForFunctionAsync("() => Promise.resolve(++window.calls)");
+        await page.WaitForFunctionAsync(
+            "() => window.ready",
+            options: new PageWaitForFunctionOptions { Timeout = 0 });
+
+        (await handle.JsonValueAsync<int>()).Should().Be(1);
+        (await page.EvaluateAsync<int>("() => window.calls")).Should().Be(1);
+    }
+
+    [Test]
+    public async Task WaitForFunctionTimeoutInterruptsAPendingPromise()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+
+        var wait = async () => await page.WaitForFunctionAsync(
+            "() => new Promise(() => {})",
+            options: new PageWaitForFunctionOptions { Timeout = 50 });
+
+        await wait.Should().ThrowAsync<System.TimeoutException>();
+    }
+
+    [Test]
+    public async Task WaitForFunctionTimeoutDoesNotWaitForSynchronousEvaluation()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        var started = System.Diagnostics.Stopwatch.GetTimestamp();
+
+        var wait = async () => await page.WaitForFunctionAsync(
+            "() => { const end = Date.now() + 1000; while (Date.now() < end) {} return false; }",
+            options: new PageWaitForFunctionOptions { Timeout = 50 });
+
+        await wait.Should().ThrowAsync<System.TimeoutException>();
+        System.Diagnostics.Stopwatch.GetElapsedTime(started).Should().BeLessThan(TimeSpan.FromMilliseconds(500));
+    }
+
+    [Test]
+    public async Task UnsupportedOperationsNameThePlaywrightMember()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+
+        var act = async () => await page.ScreenshotAsync();
+
+        await act.Should().ThrowAsync<NotSupportedException>()
+            .WithMessage("*IPage.ScreenshotAsync*");
+
+        var option = () => page.Locator("p", new PageLocatorOptions { HasText = "text" });
+        option.Should().Throw<NotSupportedException>().WithMessage("*PageLocatorOptions.HasText*");
+
+        var frameOption = () => page.MainFrame.Locator(
+            "p",
+            new FrameLocatorOptions { HasText = "text" });
+        frameOption.Should().Throw<NotSupportedException>().WithMessage("*FrameLocatorOptions.HasText*");
+    }
+}

--- a/Jint.Tests.Browser/Playwright/PlaywrightPublicApiTest.cs
+++ b/Jint.Tests.Browser/Playwright/PlaywrightPublicApiTest.cs
@@ -1,0 +1,39 @@
+#if PUBLIC_API_BASELINES
+
+using PublicApiGenerator;
+using VerifyNUnit;
+
+namespace Jint.Tests.Browser.PlaywrightAdapter;
+
+/// <summary>Snapshots the public entry point exposed by the Jint.Browser.Playwright package.</summary>
+public sealed class PlaywrightPublicApiTest
+{
+    [Test]
+    public async Task PublicApiHasNotChangedUnintentionally()
+    {
+        var options = new ApiGeneratorOptions
+        {
+            ExcludeAttributes =
+            [
+                "System.Diagnostics.DebuggerDisplayAttribute",
+                "System.Reflection.AssemblyMetadataAttribute",
+                "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+                "System.Runtime.CompilerServices.InternalsVisibleToAttribute",
+                "System.Runtime.CompilerServices.IsReadOnlyAttribute",
+                "System.Runtime.CompilerServices.NullableAttribute",
+                "System.Runtime.CompilerServices.NullableContextAttribute",
+                "System.Runtime.CompilerServices.RefSafetyRulesAttribute",
+                "System.Runtime.Versioning.TargetFrameworkAttribute",
+            ],
+        };
+
+        var publicApi = typeof(global::Jint.Browser.Playwright.JintPlaywright).Assembly.GeneratePublicApi(options);
+
+        await Verifier.Verify(publicApi, extension: "txt")
+            .UseDirectory("../Verify")
+            .UseFileName("PlaywrightPublicApiTest")
+            .DisableRequireUniquePrefix();
+    }
+}
+
+#endif

--- a/Jint.Tests.Browser/Runtime/PageTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageTests.cs
@@ -81,6 +81,43 @@ public sealed class PageTests
     }
 
     [Test]
+    public async Task EvaluateAndAwaitResolvesPromisesWithoutExposingEngineValues()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        (await page.EvaluateAndAwaitAsync<int>("Promise.resolve(42)")).Should().Be(42);
+        (await page.EvaluateAndAwaitAsync<string>(
+            "new Promise(resolve => setTimeout(() => resolve('settled'), 20))")).Should().Be("settled");
+
+        await page.SetContentAsync("<title>before</title>");
+        (await page.EvaluateAndAwaitAsync<string>(
+            "new Promise(resolve => setTimeout(() => { document.title = 'after'; resolve(document.title); }, 20))"))
+            .Should().Be("after");
+        (await page.TitleAsync()).Should().Be("after");
+
+        var value = await page.EvaluateAndAwaitAsync("Promise.resolve({ name: 'jint' })");
+        value.Should().BeAssignableTo<IDictionary<string, object?>>();
+        value!.GetType().Assembly.Should().NotBeSameAs(typeof(global::Jint.Native.JsValue).Assembly);
+    }
+
+    [Test]
+    public async Task NavigationCancelsAnEvaluationOwnedByThePreviousDocument()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        var pending = page.EvaluateAndAwaitAsync(
+            "new Promise(() => { globalThis.pendingEvaluationStarted = true; })");
+        (await page.EvaluateAsync<bool>("pendingEvaluationStarted")).Should().BeTrue();
+
+        await page.NavigateAsync("data:text/html,<title>replacement</title>");
+
+        var waitForPreviousDocument = async () => await pending;
+        await waitForPreviousDocument.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task TheDocumentUrlIsAboutBlankUntilSomethingElseIsLoaded()
     {
         await using var browser = new Browser();

--- a/Jint.Tests.Browser/Verify/PlaywrightPublicApiTest.verified.txt
+++ b/Jint.Tests.Browser/Verify/PlaywrightPublicApiTest.verified.txt
@@ -1,0 +1,9 @@
+﻿[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+namespace Jint.Browser.Playwright
+{
+    public static class JintPlaywright
+    {
+        public static Microsoft.Playwright.IBrowserType BrowserType { get; }
+        public static Microsoft.Playwright.IBrowserType CreateBrowserType(System.Action<Jint.Browser.BrowserOptions>? configure = null) { }
+    }
+}

--- a/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
+++ b/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
@@ -120,31 +120,39 @@ namespace Jint.Browser
         public event System.EventHandler<Jint.Browser.DialogEventArgs>? DialogOpened;
         public System.Threading.Tasks.Task<string> AccessibilitySnapshotAsync(bool mainContentOnly = false, int maxLength = 0, bool includeReferences = false) { }
         public System.Threading.Tasks.Task<bool> ClickAsync(string target, Jint.Browser.NavigationOptions? options = null) { }
+        public System.Threading.Tasks.Task<bool> ClickAsync(string target, int index, Jint.Browser.NavigationOptions? options = null) { }
         public System.Threading.Tasks.Task CloseAsync() { }
         public System.Threading.Tasks.Task<string> ContentAsync() { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
+        public System.Threading.Tasks.Task<object?> EvaluateAndAwaitAsync(string script, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T?> EvaluateAndAwaitAsync<T>(string script, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<object?> EvaluateAsync(string script) { }
         public System.Threading.Tasks.Task<T?> EvaluateAsync<T>(string script) { }
         public System.Threading.Tasks.Task<bool> FillAsync(string target, string text) { }
+        public System.Threading.Tasks.Task<bool> FillAsync(string target, int index, string text) { }
         public System.Threading.Tasks.Task<bool> GoBackAsync(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> GoForwardAsync(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> HoverAsync(string target) { }
+        public System.Threading.Tasks.Task<bool> HoverAsync(string target, int index) { }
         public System.Threading.Tasks.Task<string> MarkdownAsync(bool mainContentOnly = false, int maxLength = 0) { }
         public System.Threading.Tasks.Task<Jint.Browser.PageResponse?> NavigateAsync(string url, Jint.Browser.NavigationOptions? options = null) { }
         public System.Threading.Tasks.Task<bool> PressAsync(string key, Jint.Browser.NavigationOptions? options = null) { }
         public System.Threading.Tasks.Task<Jint.Browser.PageResponse?> ReloadAsync(Jint.Browser.NavigationOptions? options = null) { }
         public System.Threading.Tasks.Task ScrollToAsync(double y) { }
         public System.Threading.Tasks.Task<bool> SelectAsync(string target, string value) { }
+        public System.Threading.Tasks.Task<bool> SelectAsync(string target, int index, string value) { }
         public System.Threading.Tasks.Task SetContentAsync(string html, string? baseUrl = null) { }
         public System.Threading.Tasks.Task<Jint.Browser.PageResponse?> SubmitFormAsync(string selector, Jint.Browser.NavigationOptions? options = null) { }
         public System.Threading.Tasks.Task<string> TextAsync(bool mainContentOnly = false, int maxLength = 0) { }
         public System.Threading.Tasks.Task<string> TitleAsync() { }
         public System.Threading.Tasks.Task<bool> TypeAsync(string target, string text) { }
+        public System.Threading.Tasks.Task<bool> TypeAsync(string target, int index, string text) { }
         public System.Threading.Tasks.Task<bool> WaitForAsync(string expression, System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> WaitForIdleAsync(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> WaitForNavigationAsync(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> WaitForNetworkIdleAsync(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> WaitForSelectorAsync(string selector, System.TimeSpan timeout) { }
+        public System.Threading.Tasks.Task<bool> WaitForSelectorAsync(string selector, int index, System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<bool> WaitForTextAsync(string text, System.TimeSpan timeout) { }
     }
     public sealed class PageError

--- a/Jint.slnx
+++ b/Jint.slnx
@@ -25,6 +25,7 @@
   <Project Path="Jint.Browser.Mcp/Jint.Browser.Mcp.csproj" />
   <Project Path="Jint.Browser.Tool/Jint.Browser.Tool.csproj" />
   <Project Path="Jint.DevTools/Jint.DevTools.csproj" />
+  <Project Path="Jint.Browser.Playwright/Jint.Browser.Playwright.csproj" />
   <Project Path="Jint.Repl/Jint.Repl.csproj" />
   <Project Path="Jint.SourceGenerators/Jint.SourceGenerators.csproj" />
   <Project Path="Jint.SourceGenerators.Interop/Jint.SourceGenerators.Interop.csproj" />

--- a/README.md
+++ b/README.md
@@ -2403,7 +2403,29 @@ neither an element nor a piece of text can state — a URL a router moved, a lis
 expression that throws is *not yet true*, so a condition written against an element a framework has not
 rendered is usable; a timeout reports that failure rather than a bare `false`.
 
-**An automation client**, over the protocol. `AddBrowser` publishes every page of a browser on a
+**A direct Playwright .NET adapter.** For applications that use Playwright's public browser interfaces,
+`Jint.Browser.Playwright` removes
+the protocol and Playwright driver from that path as well. It implements `IBrowserType`, `IBrowser`,
+`IBrowserContext`, `IPage`, `IFrame` and an initial `ILocator` subset directly over `Jint.Browser`:
+
+```c#
+using Jint.Browser.Playwright;
+using Microsoft.Playwright;
+
+IBrowserType browserType = JintPlaywright.BrowserType;
+await using var client = await browserType.LaunchAsync();
+var page = await client.NewPageAsync();
+
+await page.SetContentAsync("<button id='save'>Save</button>");
+await page.Locator("#save").ClickAsync();
+```
+
+That direct adapter starts no Node process and opens no CDP or WebSocket connection. It is built against
+Playwright 1.62's public contracts; operations it has not implemented fail with `NotSupportedException`,
+and Playwright features that downcast those interfaces to its internal implementation — including its
+built-in assertions — cannot use a third-party provider.
+
+**An automation client, over the protocol.** `AddBrowser` publishes every page of a browser on a
 `Jint.DevTools` server as a Chrome DevTools Protocol `page` target, so Puppeteer, PuppeteerSharp, Playwright
 and Playwright for .NET drive it — in the same process, with no native binary and nothing to download:
 

--- a/docs/releases/headless-browser.md
+++ b/docs/releases/headless-browser.md
@@ -3,7 +3,7 @@
 **This is a draft for the maintainer to lift into the v5 release announcement**, not a published changelog —
 the repository keeps no changelog, and `.github/workflows/release.yml` produces packages from a `vX.Y.Z` tag
 and nothing else. It records what the campaign tracked by
-[#3575](https://github.com/sebastienros/jint/issues/3575) shipped: four new packages, the engine seams they
+[#3575](https://github.com/sebastienros/jint/issues/3575) shipped: five new packages, the engine seams they
 were built on, the upstream contributions the work produced, and what is knowingly left.
 
 Reader-facing documentation is [`README.md`](../../README.md#chrome-devtools-protocol-opt-in-package) and
@@ -17,6 +17,7 @@ what was built against them are [`docs/design/devtools-protocol.md`](../design/d
 | --- | --- | --- |
 | `Jint.DevTools` | A Chrome DevTools Protocol server over a WebSocket, so a debugging client attaches to an engine the host is already running. `Runtime`, `Debugger`, `Profiler`, `Console`, `Log`, `Target`, `Browser`, `Schema`. Native AOT compatible, measured by a published binary a CI leg drives over a real socket. | `net8.0`, `net10.0` |
 | `Jint.Browser` | A headless browser: AngleSharp's parser, DOM and CSSOM under Jint, with a page runtime, HTML's script scheduling, custom elements, navigation, forms, cookies, storage, workers, a deterministic box model in place of a layout, and the page-level protocol domains that make a page drivable by Puppeteer, PuppeteerSharp, Playwright and Playwright for .NET. Not trim- or AOT-compatible in this version, because AngleSharp is not trim-annotated. | `net8.0`, `net10.0` |
+| `Jint.Browser.Playwright` | Playwright for .NET's public browser interfaces implemented directly over `Jint.Browser`, with no Node driver, CDP connection or WebSocket. Unsupported interfaces and options fail explicitly; rendering-dependent features remain outside the package. | `net8.0`, `net10.0` |
 | `Jint.Browser.Tool` | The `jint-browser` dotnet tool: `serve` publishes the protocol, `fetch` dumps a page as HTML, text, CommonMark or its accessibility tree, `eval` answers an expression evaluated in the page, and `mcp` serves the MCP server on stdio. It consumes only the package's published surface. | `net8.0`, `net10.0` |
 | `Jint.Browser.Mcp` | A Model Context Protocol server over the same `Page` API: eighteen tools, an accessibility snapshot carrying a `ref=` on every element that the input tools take in place of a CSS selector, and the page as a resource. A host running a server of its own composes the same tools with `AddJintBrowser()`. | `net8.0`, `net10.0` |
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5376,6 +5376,7 @@ none of it changes an engine that does not.
 | Watching and intercepting every request, response and body chunk | `options.WebApi.Fetch.Observer = …`, plus `<NoWarn>$(NoWarn);JINT0002</NoWarn>` | [§5.10](#510-fetch-can-behave-as-a-documents-fetch-3617) |
 | The Chrome DevTools Protocol over a WebSocket, so a debugging client can attach to an engine your host is already running | `dotnet add package Jint.DevTools`, then `options.UseDevTools()` | [Chrome DevTools Protocol (opt-in package)](../README.md#chrome-devtools-protocol-opt-in-package) |
 | A headless browser — AngleSharp's DOM under Jint, drivable by Puppeteer and Playwright, plus a `jint-browser` command line | `dotnet add package Jint.Browser`, or `dotnet tool install -g Jint.Browser.Tool` | [Headless browser (opt-in package)](../README.md#headless-browser-opt-in-package) |
+| Playwright for .NET's public browser interfaces over that headless browser, without Node, CDP or a WebSocket | `dotnet add package Jint.Browser.Playwright`, then use `JintPlaywright.BrowserType` | [Headless browser (opt-in package)](../README.md#headless-browser-opt-in-package) |
 | A Model Context Protocol server over that browser, so an agent reads a page as its accessibility tree and clicks its way through it | `jint-browser mcp`, or `AddMcpServer().AddJintBrowser()` in a host of your own | [Headless browser (opt-in package)](../README.md#headless-browser-opt-in-package) |
 | The names of the global `let`/`const`/`class` declarations, which `globalThis` does not carry | `engine.Advanced.GetGlobalLexicalNames()` | [§5.27](#527-a-host-can-list-the-global-lexical-bindings-3610) |
 | The program a function value was parsed in, so a tooling protocol resolves its script by identity | `function.Program`, beside `FunctionDeclaration` | [§5.28](#528-a-function-value-names-the-program-it-was-parsed-in-3666) |
@@ -6183,13 +6184,15 @@ has none.
 guard can only fire for an event a host's own `createEvent` produced — `Jint.Browser`'s — and a re-entrant
 dispatch still reports the message it always did.
 
-### 5.26 Four packages of their own, outside the engine's contract ([#3575](https://github.com/sebastienros/jint/issues/3575))
+### 5.26 Five packages of their own, outside the engine's contract ([#3575](https://github.com/sebastienros/jint/issues/3575))
 
-Four new packages ship beside `Jint`, and nothing about them reaches an engine that does not reference one.
+Five new packages ship beside `Jint`, and nothing about them reaches an engine that does not reference one.
 `Jint.DevTools` serves the Chrome DevTools Protocol for an engine your host is already running;
 `Jint.Browser` adds AngleSharp's DOM, a page runtime and the page-level protocol domains on top of it;
+`Jint.Browser.Playwright` implements Playwright for .NET's public browser interfaces directly over that
+runtime, without Playwright's Node driver or a CDP connection;
 `Jint.Browser.Mcp` is a Model Context Protocol server over that, for an agent rather than a client; and
-`Jint.Browser.Tool` is the `jint-browser` command line over both, installed rather than referenced. All four
+`Jint.Browser.Tool` is the `jint-browser` command line over both, installed rather than referenced. All five
 are `net8.0` and later.
 
 **There is nothing to migrate.** They are additive, they are separate packages, and they are outside the


### PR DESCRIPTION
## Summary

- add the `Jint.Browser.Playwright` package implementing Playwright for .NET's public browser interfaces directly over `Jint.Browser`
- avoid the Playwright Node driver, CDP transport, WebSocket connection, and browser binary for supported operations
- support browser/context/page/frame/locator lifecycles, navigation, promise-aware evaluation, waiting, trusted input, indexed locators, responses, handles, and explicit unsupported-operation errors
- add the public `Jint.Browser` seams required for promise settlement and indexed trusted input
- package the adapter in preview and release workflows and document both the direct and existing CDP integration paths

## Compatibility

The adapter is built against Microsoft.Playwright 1.62. It targets applications using Playwright's public interfaces. Features that require rendering or downcast to Playwright's internal implementations, including built-in assertions, remain unsupported and fail explicitly where applicable.

## Validation

- focused adapter and browser tests on `net8.0` and `net10.0`
- complete Release solution build
- clean NuGet consumer using `JintPlaywright.BrowserType`
- confirmed the consumer output contains no `.playwright` directory, Node runtime, or Playwright driver assets
