### PR TITLE
Closing a page ends a navigation in flight with the cancellation the API promises, not the loop's disposal

### DIFF
--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -513,7 +513,8 @@ public sealed partial class Page
         }
 
         using var timeout = new CancellationTokenSource(request.Options.Timeout);
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, _loop.Closing);
+        var closing = _loop.Closing;
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, closing);
 
         try
         {
@@ -530,6 +531,18 @@ public sealed partial class Page
         try
         {
             return await RunAsync(request, timeout, linked.Token).ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException) when (closing.IsCancellationRequested)
+        {
+            // A navigation runs off the page's thread and comes back to it several times - to fire
+            // `beforeunload`, to resolve the client, to commit - and a close can win any one of those races.
+            // Which one it won is not something the caller can act on: they closed the page, so what they are
+            // owed is the cancellation this method documents. Without this, a loaded machine turns the
+            // documented OperationCanceledException into the loop's internal "the page has been closed"
+            // (https://github.com/sebastienros/jint/issues/3802).
+            throw new OperationCanceledException(
+                "The page was closed while the navigation to '" + request.Target + "' was in flight.",
+                closing);
         }
         finally
         {

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -36,7 +36,14 @@ Four rules follow, and each of them is a way to break the package silently:
   empty action, purely for its documented side effect of ending a `WaitForScheduledWork`. Without it a request
   waits out `PumpIdle`; the channel write happens first, so the wake can never be lost.
 - **A request that arrives after the loop stopped fails with `ObjectDisposedException`.** It is never left to
-  hang, and the pending queue is failed the same way on the way down.
+  hang, and the pending queue is failed the same way on the way down. **A navigation translates that one
+  exception into `OperationCanceledException`**, and it is the only caller that does: it comes back to the
+  loop several times — `beforeunload`, the client, the commit — so a close wins whichever of those races it
+  reaches first, and which one it won is nothing the caller can act on. `Page.NavigateAsync` documents the
+  cancellation, so a loaded machine may not hand out the loop's internal disposal instead
+  ([#3802](https://github.com/sebastienros/jint/issues/3802)). That is also why `PageLoop.Closing` hands out a
+  token taken once at construction: the caller who most needs to read it is running after the source is
+  disposed.
 - **Teardown is not a request.** `PageLoop.CloseAsync` takes the action that releases the document and the
   browsing context and runs it in the loop's own shutdown, because a request would queue behind whatever is
   running — and what is running may be the very wait the close is ending. Posting it instead deadlocks.

--- a/Jint.Browser/Runtime/PageLoop.cs
+++ b/Jint.Browser/Runtime/PageLoop.cs
@@ -38,6 +38,7 @@ internal sealed class PageLoop : IDisposable
         new UnboundedChannelOptions { SingleReader = true, AllowSynchronousContinuations = false });
 
     private readonly CancellationTokenSource _closing = new();
+    private readonly CancellationToken _closingToken;
     private CancellationTokenSource _documentClosing = new();
     private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource _stopped = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -81,10 +82,17 @@ internal sealed class PageLoop : IDisposable
         _onPumpError = onPumpError;
         _onTurnEnd = onTurnEnd;
         _thread = new Thread(Run) { IsBackground = true, Name = name };
+        _closingToken = _closing.Token;
     }
 
     /// <summary>The page's cancellation token, cancelled when the page closes.</summary>
-    internal CancellationToken Closing => _closing.Token;
+    /// <remarks>
+    /// Taken from the source once, at construction, rather than read from it per call: the source is
+    /// disposed as the page finishes closing, and the caller who most needs to see the cancellation is
+    /// exactly the one still running then — a navigation the close overtook. A token already handed out
+    /// keeps answering after its source is disposed; the <c>Token</c> property does not.
+    /// </remarks>
+    internal CancellationToken Closing => _closingToken;
 
     /// <summary>Whether the loop has been asked to stop.</summary>
     internal bool IsClosed => _closed;
@@ -215,15 +223,22 @@ internal sealed class PageLoop : IDisposable
             _beforeStop = beforeStop;
             _closed = true;
             _mailbox.Writer.TryComplete();
+        }
 
-            try
-            {
-                _closing.Cancel();
-            }
-            catch (AggregateException)
-            {
-                // A registration threw on its way out; the loop is stopping either way.
-            }
+        // Outside the guard, because the flag is also set by a loop whose engine failed to build, and a
+        // token that is disposed without ever having been cancelled is one nothing can wait on. Cancel
+        // is idempotent, so calling it on the way through a second close costs nothing.
+        try
+        {
+            _closing.Cancel();
+        }
+        catch (AggregateException)
+        {
+            // A registration threw on its way out; the loop is stopping either way.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Closed and disposed already; the token it handed out is cancelled and stays readable.
         }
 
         return _stopped.Task;

--- a/Jint.Tests.Browser/Navigation/NavigationTests.cs
+++ b/Jint.Tests.Browser/Navigation/NavigationTests.cs
@@ -495,6 +495,48 @@ public sealed class NavigationTests
     }
 
     [Test]
+    public async Task ANavigationThatOutlivesTheCloseStillEndsInCancellation()
+    {
+        var reached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new SemaphoreSlim(0, 1);
+        Func<Uri, bool>? owns = null;
+
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/slow.html", "<title>too late</title>"),
+            options =>
+            {
+                owns = options.UrlFilter;
+                options.UrlFilter = uri =>
+                {
+                    // A host filter that takes a moment - a policy lookup, a name resolved by hand - is the
+                    // ordinary shape, and it is what holds the navigation off the page's own thread while the
+                    // page closes under it.
+                    if (uri.AbsolutePath == "/slow.html")
+                    {
+                        reached.TrySetResult();
+                        release.Wait(TimeSpan.FromSeconds(10));
+                    }
+
+                    return owns!(uri);
+                };
+            });
+
+        var navigation = fixture.Page.NavigateAsync(fixture.Url("/slow.html"));
+
+        await reached.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The whole page - its loop, its engine and the cancellation source behind them - is gone before the
+        // filter returns, so every step the navigation has left meets a page that no longer exists.
+        await fixture.Page.CloseAsync();
+        release.Release();
+
+        var act = async () => await navigation;
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "a caller who closed the page asked for the cancellation, whichever step of the navigation the close won");
+    }
+
+    [Test]
     public async Task ADataUrlAndAboutBlankStillLoadWithoutTheNetwork()
     {
         await using var fixture = await LoopbackPage.CreateAsync();


### PR DESCRIPTION
Closes #3802

## What failed before

`Page.NavigateAsync` documents that closing the page while a navigation is in flight ends the call with `OperationCanceledException`, and `Page.CloseAsync` promises the same from its side. A navigation runs off the page's thread and comes back to it several times — to fire `beforeunload`, to resolve the context's HTTP client, to commit — and a close can win any one of those races. The mailbox request then fails with `PageLoop`'s own `ObjectDisposedException` ("The page has been closed; its engine and its document no longer exist"), which is what the `windows` leg of #3801 saw:

```
ClosingThePageWhileANavigationIsInFlightCancelsIt
Expected a <System.OperationCanceledException> to be thrown, but found <System.ObjectDisposedException>
```

The premise held. A new deterministic test — a host `UrlFilter` that takes a moment, the ordinary shape of a policy lookup, parks the navigation off the page's thread while the page closes under it — reproduces it exactly against unfixed code:

```
Expected a <System.OperationCanceledException> to be thrown …, but found <System.ObjectDisposedException>:
System.ObjectDisposedException: The page has been closed; its engine and its document no longer exist.
   at Jint.Browser.Page.FetchDocumentAsync(…) in Jint.Browser\Page.Navigation.cs:line 576
   at Jint.Browser.Page.RunAsync(…)
   at Jint.Browser.Page.NavigateCoreAsync(…)
```

Line 576 is `await _loop.PostAsync(_network.ClientFor)` — one of the several hops, and the one that race happened to land on.

## What changed

Which step the close won is nothing the caller can act on: they closed the page, so what they are owed is the cancellation. `NavigateCoreAsync` translates that one exception — and only while the page's own token really is cancelled — into the documented `OperationCanceledException`. Nothing else translates it: a call made *after* the page closed still meets the `ObjectDisposedException` guard on the public member, which `PageTests.AClosedPageFailsEveryCall` pins.

Two supporting changes make the cancellation observable before anything is disposed, which is what the issue asked for:

- `PageLoop.Closing` hands out a token taken once at construction rather than read off the source per call. `Page.CloseAsync` disposes that source, and the caller who most needs to read the token is exactly the one still running then.
- `PageLoop.CloseAsync` cancels outside its `!_closed` guard, so a loop whose engine failed to build cannot leave behind a token that is disposed without ever having been cancelled. `Cancel` is idempotent.

`Jint.Browser/Runtime/AGENTS.md` records the one caller that translates the loop's disposal and why, beside the rule it qualifies.

## What was verified

- The new test fails against unfixed code with the reported exception (output above) and passes after.
- `dotnet test -c Release Jint.Tests.Browser\Jint.Tests.Browser.csproj` — 1654 passed on `net8.0`, 1657 on `net10.0`, 0 failed, including the original `ClosingThePageWhileANavigationIsInFlightCancelsIt`.
- `Jint.Tests` `AgentInstructionFileTests` — the instruction file is still inside its budget (27.6 KiB of 32 KiB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
