### PR TITLE
Navigation: a refused preflight records its error through the recorder, so the branch that could not compile does

### DIFF
--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -1,4 +1,4 @@
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using AngleSharp.Html.Dom;
@@ -475,7 +475,7 @@ public sealed partial class Page
             return;
         }
 
-        _recorder.Add(new PageError(PageErrorKind.ReportedError, failure.Message, "Navigation"));
+        _recorder.Add(PageErrorKind.ReportedError, failure.Message, "Navigation");
     }
 
     /// <summary>The commit half of <see cref="SetContentAsync"/>, under the navigation gate.</summary>


### PR DESCRIPTION
`main` does not compile. #3786 added `RejectBeforeStart`, which built a `PageError` with the three-argument constructor; #3749 had already replaced that constructor with the five-argument one carrying a timestamp and the document the error belongs to, and made `PageRecorder.Add` **the one place a `PageError` is built** — precisely so no call site can forget the stamp.

The two merged in that order and #3786's checks had run against a merge ref from before #3749, so nothing ever compiled the combination:

```
Jint.Browser/Page.Navigation.cs(478,27): error CS7036: There is no argument given that corresponds to
the required parameter 'timestamp' of 'PageError.PageError(PageErrorKind, string, string?,
DateTimeOffset, string)'
```

on every target framework.

The preflight rejection now reports through `_recorder.Add(kind, message, source)` like the other twenty-odd call sites, which stamps it with `DateTimeOffset.UtcNow` and the current document URL — the behaviour #3786 intended.

Verified with `dotnet build -c Release Jint.Browser/Jint.Browser.csproj` on `net8.0` and `net10.0`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz