### PR TITLE
location.hash assigned the fragment it already has navigates nowhere, and assigned the empty string clears one instead of reloading

### DIFF
--- a/Jint.Browser/Runtime/LocationInstaller.cs
+++ b/Jint.Browser/Runtime/LocationInstaller.cs
@@ -73,9 +73,11 @@ internal static class LocationInstaller
             static runtime => Read(runtime, static url => url.SerializeSearch()),
             static (runtime, value) => Write(runtime, value, static (url, v) => UrlSetters.SetSearch(url, v)));
 
+        // The one component whose setter is not the generic Write: HTML's own hash setter, which both
+        // bails out on an unchanged fragment and refuses to special-case the empty string. WriteHash says why.
         Accessor(engine, wrapper, "hash",
             static runtime => Read(runtime, static url => url.SerializeHash()),
-            static (runtime, value) => Write(runtime, value, static (url, v) => UrlSetters.SetHash(url, v)));
+            static (runtime, value) => WriteHash(runtime, value));
 
         // Read-only: an origin is derived, and HTML declares no setter for it.
         Accessor(engine, wrapper, "origin", static runtime => Read(runtime, static url => url.SerializeOrigin()), setter: null);
@@ -124,9 +126,9 @@ internal static class LocationInstaller
     /// </summary>
     /// <remarks>
     /// It is a navigation even when the component did not change, which is what HTML says: assigning
-    /// <c>location.pathname</c> the value it already has reloads the document. The <c>hash</c> setter is not
-    /// special-cased here either — the navigator recognizes a fragment-only change and keeps the document,
-    /// which is the one place that decision belongs.
+    /// <c>location.pathname</c> the value it already has reloads the document. <c>hash</c> is the one
+    /// exception and has <see cref="WriteHash"/> to itself; every other setter comes through here, and the
+    /// navigator is what recognizes a fragment-only change and keeps the document.
     /// </remarks>
     private static void Write(PageRuntime runtime, string value, Action<UrlRecord, string> setter)
     {
@@ -137,6 +139,62 @@ internal static class LocationInstaller
         }
 
         setter(url, value);
+        runtime.Page.RequestNavigation(url.Serialize(), replace: false, engine: runtime.Engine);
+    }
+
+    /// <summary>
+    /// The <c>hash</c> setter, https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-hash,
+    /// steps 3 to 9.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Step 8 is a bailout, and it is the whole reason this member is not a <see cref="Write"/> call.</b>
+    /// A fragment equal to the one the URL already carries returns without navigating, which the
+    /// specification calls "necessary for compatibility with deployed content, which redundantly sets
+    /// <c>location.hash</c> on scroll" — a scroll handler doing that once a frame would otherwise add a
+    /// session history entry per frame and fire a <c>hashchange</c> per frame, neither of which a browser
+    /// does. It is the <i>only</i> Location member with the bailout: <c>location.href</c> and
+    /// <c>assign()</c> given the URL they already have still navigate, and step 8 says so outright.
+    /// </para>
+    /// <para>
+    /// <b>Step 4 is what makes the empty string the unchanged case for a URL that has no fragment</b>, since
+    /// the value compared against is the URL's fragment or, when that is null, the empty string.
+    /// </para>
+    /// <para>
+    /// <b>And step 6 is why <c>UrlSetters.SetHash</c> cannot be reused</b>: that is the URL standard's
+    /// setter, which maps the empty string to a null fragment. HTML's "does not special case the empty
+    /// string, to remain compatible with deployed scripts", so <c>location.hash = ''</c> on
+    /// <c>/page#section</c> moves to <c>/page#</c> — a same-document move to an empty fragment. Routing it
+    /// through the URL setter produced <c>/page</c>, whose fragment is null, which the navigator can only
+    /// read as a reload: the document, its engine and everything a script had put on them went away.
+    /// </para>
+    /// </remarks>
+    private static void WriteHash(PageRuntime runtime, string value)
+    {
+        // Step 3: a copy of the URL, which parsing the page's own gives us for free.
+        var url = UrlParser.Parse(runtime.DocumentUrl);
+        if (url is null)
+        {
+            return;
+        }
+
+        // Step 4.
+        var thisUrlFragment = url.Fragment ?? "";
+
+        // Step 5: a single leading '#' removed, if any.
+        var input = value.Length != 0 && value[0] == '#' ? value.Substring(1) : value;
+
+        // Steps 6 and 7.
+        url.Fragment = "";
+        UrlParser.ParseInto(input, url, UrlParserState.Fragment);
+
+        // Step 8.
+        if (string.Equals(url.Fragment, thisUrlFragment, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Step 9.
         runtime.Page.RequestNavigation(url.Serialize(), replace: false, engine: runtime.Engine);
     }
 

--- a/Jint.Tests.Browser/History/HistoryTests.cs
+++ b/Jint.Tests.Browser/History/HistoryTests.cs
@@ -113,6 +113,83 @@ public sealed class HistoryTests
         fixture.Server.Received.Count(r => r.Path == "/app").Should().Be(1, "a fragment navigation reaches no network");
     }
 
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-hash, setter step 8: a
+    /// fragment equal to the one the URL already has returns without navigating. The specification calls the
+    /// bailout necessary "for compatibility with deployed content, which redundantly sets location.hash on
+    /// scroll" - a scroll handler doing it once a frame would otherwise fill the session history.
+    /// </summary>
+    [Test]
+    public async Task SettingLocationHashToTheFragmentItAlreadyHasNavigatesNowhere()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml("/app", Router));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/app"));
+        await fixture.NavigateByScriptAsync("location.hash = '#section'");
+
+        var entries = await fixture.Page.EvaluateAsync<double>("history.length");
+
+        // Both spellings the setter's step 5 flattens to the same fragment: with the '#' and without it.
+        var navigated = fixture.Page.WaitForNavigationAsync(TimeSpan.FromSeconds(2));
+        await fixture.Page.EvaluateAsync("location.hash = location.hash");
+        await fixture.Page.EvaluateAsync("location.hash = 'section'");
+
+        (await navigated).Should().BeFalse("the setter returns before it navigates");
+
+        fixture.Page.Url.Should().Be(fixture.Url("/app#section"));
+        (await fixture.Page.EvaluateAsync<double>("history.length"))
+            .Should().Be(entries, "an unchanged fragment adds no session history entry");
+        (await fixture.Page.EvaluateAsync<string>("window.seen.join('|')"))
+            .Should().Be("hashchange:#section", "the only hashchange is the move that really happened");
+    }
+
+    /// <summary>
+    /// Setter step 4: the fragment compared against is the URL's, or the empty string when it has none - so
+    /// the empty string assigned to a URL carrying no fragment is the unchanged case as well.
+    /// </summary>
+    [Test]
+    public async Task SettingLocationHashToEmptyWithNoFragmentNavigatesNowhere()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml("/app", Router));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/app"));
+
+        var entries = await fixture.Page.EvaluateAsync<double>("history.length");
+
+        var navigated = fixture.Page.WaitForNavigationAsync(TimeSpan.FromSeconds(2));
+        await fixture.Page.EvaluateAsync("location.hash = ''");
+
+        (await navigated).Should().BeFalse("the empty string is the fragment this URL already has");
+
+        fixture.Page.Url.Should().Be(fixture.Url("/app"));
+        (await fixture.Page.EvaluateAsync<double>("history.length")).Should().Be(entries);
+        (await fixture.Page.EvaluateAsync<double>("window.seen.length")).Should().Be(0);
+        fixture.Server.Received.Count(r => r.Path == "/app")
+            .Should().Be(1, "and a URL whose fragment is null is not a fragment navigation, so navigating would reload");
+    }
+
+    /// <summary>
+    /// The half of the same algorithm that must keep navigating: "the hash setter does not special case the
+    /// empty string", so emptying a fragment that was there moves to the empty fragment - a same-document
+    /// move to <c>#</c>, and emphatically not a reload.
+    /// </summary>
+    [Test]
+    public async Task SettingLocationHashToEmptyClearsAFragmentWithoutReloading()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml("/app", Router));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/app#section"));
+        fixture.Server.Received.Count(r => r.Path == "/app").Should().Be(1);
+
+        await fixture.NavigateByScriptAsync("location.hash = ''");
+
+        fixture.Page.Url.Should().Be(fixture.Url("/app#"), "the empty fragment is a fragment, so the URL keeps its '#'");
+        (await fixture.Page.EvaluateAsync<string>("location.hash")).Should().Be("");
+        (await fixture.Page.EvaluateAsync<string>("window.seen.join('|')")).Should().Be("hashchange:");
+        fixture.Server.Received.Count(r => r.Path == "/app")
+            .Should().Be(1, "an empty fragment is still a fragment navigation, so the document stays");
+    }
+
     [Test]
     public async Task LocationAssignNavigatesAndLocationReplaceLeavesNoEntry()
     {


### PR DESCRIPTION
Closes #3740

## What failed before

HTML's `hash` setter — https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-hash, steps 3–9 — is not the generic "apply the component setter, then navigate" that every other `location` member is, and `LocationInstaller` was treating it as if it were. Two of its steps were missing.

**Step 8** returns without navigating when the new fragment equals the one the URL already carries. The specification calls the bailout "necessary for compatibility with deployed content, which redundantly sets `location.hash` on scroll" — a scroll handler doing that once a frame added a session history entry *and* fired a `hashchange` per frame here. It is the only Location member with the bailout, and step 8 says so outright: `location.href` and `assign()` given the URL they already have still navigate.

**Step 6**, together with step 4, is why `UrlSetters.SetHash` could not be reused. That is the *URL standard's* setter, which maps the empty string to a **null** fragment; HTML's "does not special case the empty string, to remain compatible with deployed scripts".

## The premise that did not hold, and the defect underneath it

The issue's parenthetical — `location.hash = ""` when there is no fragment — turned out to be right, but not for the reason the body implies, and chasing it down found a second, larger divergence the issue does not name.

- With **no** fragment, the empty string is the unchanged case only because of **step 4**: the value compared against is "copyURL's fragment if it is non-null; otherwise the empty string". So it is step 8 that bails out, and the fix covers it.
- With a fragment, the empty string must **navigate**: `location.hash = ''` on `/page#section` moves to `/page#`. Jint produced `/page`, whose fragment is null — which the navigator can only read as a **reload**. The document, its engine, and every expando a script had left on them were thrown away and the page was re-fetched from the network. That is fixed here too, because it is the same nine steps; separating it would have meant implementing step 8 against a step 6 that is wrong.

## What was verified

Three tests, all three red against unfixed code:

```
Failed SettingLocationHashToTheFragmentItAlreadyHasNavigatesNowhere
  Expected (navigated) to be False because the setter returns before it navigates, but found True.
  (and history.length was 4.0 rather than 2.0)
Failed SettingLocationHashToEmptyWithNoFragmentNavigatesNowhere
  Expected (navigated) to be False because the empty string is the fragment this URL already has, but found True.
Failed SettingLocationHashToEmptyClearsAFragmentWithoutReloading
  Expected fixture.Page.Url to be ".../app#", but they differ at index 26
```

The negative assertions arm `Page.WaitForNavigationAsync` before the assignment rather than polling for idle afterwards, so "nothing navigated" is a real answer rather than a race — an earlier draft that used `WaitForIdleAsync` passed against unfixed code because the reload was still in flight.

`dotnet test -c Release Jint.Tests.Browser\Jint.Tests.Browser.csproj`: 1677 passed on `net8.0`, 1681 on `net10.0`, 0 failed.

> Note: `upstream/main` does not currently compile (`Page.Navigation.cs(478,27)`, from #3786 merging on a stale merge ref); the fix is #3804. This branch was built and tested with that one-line fix applied locally and not committed, and wants a rebase once #3804 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
