### PR TITLE
Navigation: a navigation that ran out of time says so, so a client library reports its own timeout rather than the page's

### DIFF
--- a/Jint.Browser.Playwright/PageAdapters.cs
+++ b/Jint.Browser.Playwright/PageAdapters.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
@@ -116,7 +116,9 @@ internal sealed class PageTarget(BrowserContextTarget context, JintPage inner) :
     {
         var timeout = Timeout(options?.Timeout, DefaultNavigationTimeout);
         var started = Stopwatch.GetTimestamp();
-        var response = await inner.NavigateAsync(url, NavigationOptions(options, timeout)).ConfigureAwait(false);
+        var response = await AsActionTimeoutAsync(
+            inner.NavigateAsync(url, NavigationOptions(options, timeout)),
+            timeout).ConfigureAwait(false);
         await WaitForNetworkIdleAsync(options?.WaitUntil, timeout, started).ConfigureAwait(false);
         return response is null ? null : ProxyFactory.Create<IResponse>(new ResponseTarget(this, response));
     }
@@ -125,11 +127,13 @@ internal sealed class PageTarget(BrowserContextTarget context, JintPage inner) :
     {
         var timeout = Timeout(options?.Timeout, DefaultNavigationTimeout);
         var started = Stopwatch.GetTimestamp();
-        var response = await inner.ReloadAsync(new Jint.Browser.NavigationOptions
-        {
-            Timeout = timeout,
-            WaitUntil = Map(options?.WaitUntil),
-        }).ConfigureAwait(false);
+        var response = await AsActionTimeoutAsync(
+            inner.ReloadAsync(new Jint.Browser.NavigationOptions
+            {
+                Timeout = timeout,
+                WaitUntil = Map(options?.WaitUntil),
+            }),
+            timeout).ConfigureAwait(false);
         await WaitForNetworkIdleAsync(options?.WaitUntil, timeout, started).ConfigureAwait(false);
         return response is null ? null : ProxyFactory.Create<IResponse>(new ResponseTarget(this, response));
     }
@@ -264,6 +268,44 @@ internal sealed class PageTarget(BrowserContextTarget context, JintPage inner) :
         Timeout = timeout,
         WaitUntil = Map(options?.WaitUntil),
     };
+
+    /// <summary>
+    /// Awaits an action that may start a navigation, reporting a navigation that ran out of time as this
+    /// API's own timeout.
+    /// </summary>
+    /// <remarks>
+    /// A Playwright action's <c>Timeout</c> covers the navigation the action starts, and the page is handed
+    /// that same deadline for the navigation itself — so the two clocks expire together and which one is
+    /// seen first is a race the caller has no way to predict. Playwright's contract is that an action which
+    /// ran out of time throws <see cref="TimeoutException"/> whatever it was waiting on, so the page's own
+    /// <see cref="Jint.Browser.NavigationFailedException"/> is translated here when, and only when, it says
+    /// it timed out. A refused URL or a network failure is a real failure of the navigation and stays what
+    /// it is.
+    /// </remarks>
+    internal static async Task<T> AsActionTimeoutAsync<T>(Task<T> action, TimeSpan timeout)
+    {
+        try
+        {
+            return await action.ConfigureAwait(false);
+        }
+        catch (Jint.Browser.NavigationFailedException failure) when (failure.TimedOut)
+        {
+            throw new TimeoutException($"Timeout {DisplayTimeout(timeout)} exceeded.", failure);
+        }
+    }
+
+    /// <inheritdoc cref="AsActionTimeoutAsync{T}(Task{T}, TimeSpan)"/>
+    internal static async Task AsActionTimeoutAsync(Task action, TimeSpan timeout)
+    {
+        try
+        {
+            await action.ConfigureAwait(false);
+        }
+        catch (Jint.Browser.NavigationFailedException failure) when (failure.TimedOut)
+        {
+            throw new TimeoutException($"Timeout {DisplayTimeout(timeout)} exceeded.", failure);
+        }
+    }
 
     internal static TimeSpan Timeout(float? milliseconds, float defaultMilliseconds)
     {
@@ -461,11 +503,14 @@ internal sealed class LocatorTarget(PageTarget page, LocatorDescriptor descripto
         var index = await descriptor.ResolveIndexAsync(page.Inner).ConfigureAwait(false);
         var remaining = RequireRemaining(timeout, started);
         var clicked = index is not null
-            && await page.Inner.ClickAsync(
-                    descriptor.Selector,
-                    index.Value,
-                    new Jint.Browser.NavigationOptions { Timeout = remaining })
-                .WaitAsync(remaining).ConfigureAwait(false);
+            && await PageTarget.AsActionTimeoutAsync(
+                    page.Inner.ClickAsync(
+                            descriptor.Selector,
+                            index.Value,
+                            new Jint.Browser.NavigationOptions { Timeout = remaining })
+                        .WaitAsync(remaining),
+                    timeout)
+                .ConfigureAwait(false);
         if (!clicked)
         {
             throw new PlaywrightException("The locator did not resolve to a clickable element.");
@@ -506,10 +551,13 @@ internal sealed class LocatorTarget(PageTarget page, LocatorDescriptor descripto
         }
 
         remaining = RequireRemaining(timeout, started);
-        await page.Inner.PressAsync(
-                key,
-                new Jint.Browser.NavigationOptions { Timeout = remaining })
-            .WaitAsync(remaining).ConfigureAwait(false);
+        await PageTarget.AsActionTimeoutAsync(
+                page.Inner.PressAsync(
+                        key,
+                        new Jint.Browser.NavigationOptions { Timeout = remaining })
+                    .WaitAsync(remaining),
+                timeout)
+            .ConfigureAwait(false);
     }
 
     private static TimeSpan RequireRemaining(TimeSpan timeout, long started)

--- a/Jint.Browser/DevTools/PageDomain.cs
+++ b/Jint.Browser/DevTools/PageDomain.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Net.Sockets;
 using Jint.Browser.Runtime;
 using Jint.DevTools;
@@ -432,7 +432,7 @@ internal sealed partial class PageDomain : PageDomainBase, IDetachableDomain
             return "net::ERR_BLOCKED_BY_CLIENT";
         }
 
-        if (failure.Message.Contains("timed out", StringComparison.Ordinal))
+        if (failure.TimedOut)
         {
             return "net::ERR_ABORTED";
         }

--- a/Jint.Browser/NavigationFailedException.cs
+++ b/Jint.Browser/NavigationFailedException.cs
@@ -1,4 +1,4 @@
-namespace Jint.Browser;
+﻿namespace Jint.Browser;
 
 /// <summary>
 /// A navigation that never produced a document: a refused URL, a network failure, a timeout, or a page that
@@ -38,12 +38,28 @@ public sealed class NavigationFailedException : Exception
         Url = "";
     }
 
-    internal NavigationFailedException(string url, string message, Exception? innerException = null)
+    internal NavigationFailedException(string url, string message, Exception? innerException = null, bool timedOut = false)
         : base(message, innerException)
     {
         Url = url;
+        TimedOut = timedOut;
     }
 
     /// <summary>The URL the navigation was aimed at, or the empty string when none was known.</summary>
     public string Url { get; }
+
+    /// <summary>Whether the navigation ran out of its <see cref="NavigationOptions.Timeout"/>.</summary>
+    /// <remarks>
+    /// <para>
+    /// A timeout is the one failure a caller routinely has to tell apart, because it is the only one that
+    /// says nothing about the page: a client library whose own action timeout covers the navigation reports
+    /// its own timeout for it, and a host that retries retries this and not a refused URL.
+    /// </para>
+    /// <para>
+    /// It is a flag rather than an exception type because the two are the same failure to everything that
+    /// does not care — nothing was shown — and matching on the message to find out, which is what the
+    /// <c>Page</c> domain did, breaks the moment the message is reworded.
+    /// </para>
+    /// </remarks>
+    public bool TimedOut { get; }
 }

--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -521,7 +521,10 @@ public sealed partial class Page
         }
         catch (OperationCanceledException) when (timeout.IsCancellationRequested)
         {
-            throw new NavigationFailedException(request.Target, "Navigation to '" + request.Target + "' timed out waiting for the previous one.");
+            throw new NavigationFailedException(
+                request.Target,
+                "Navigation to '" + request.Target + "' timed out waiting for the previous one.",
+                timedOut: true);
         }
 
         try
@@ -671,7 +674,10 @@ public sealed partial class Page
         }
         catch (OperationCanceledException) when (timeout.IsCancellationRequested)
         {
-            throw new NavigationFailedException(target.Serialize(), "Navigation to '" + target.Serialize() + "' timed out.");
+            throw new NavigationFailedException(
+                target.Serialize(),
+                "Navigation to '" + target.Serialize() + "' timed out.",
+                timedOut: true);
         }
     }
 

--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -1,4 +1,4 @@
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using AngleSharp.Html.Dom;
@@ -475,7 +475,7 @@ public sealed partial class Page
             return;
         }
 
-        _recorder.Add(new PageError(PageErrorKind.ReportedError, failure.Message, "Navigation"));
+        _recorder.Add(PageErrorKind.ReportedError, failure.Message, "Navigation");
     }
 
     /// <summary>The commit half of <see cref="SetContentAsync"/>, under the navigation gate.</summary>

--- a/Jint.Tests.Browser/Navigation/NavigationTests.cs
+++ b/Jint.Tests.Browser/Navigation/NavigationTests.cs
@@ -1,4 +1,4 @@
-using Jint.Browser;
+﻿using Jint.Browser;
 
 namespace Jint.Tests.Browser.Navigation;
 
@@ -423,6 +423,48 @@ public sealed class NavigationTests
         var requests = fixture.Page.Requests;
         requests.Should().Contain(r => r.Url == fixture.Url("/index.html") && r.Initiator == RequestInitiator.Document && r.Status == 200);
         requests.Should().Contain(r => r.Url == fixture.Url("/api") && r.Initiator == RequestInitiator.Script && r.Status == 200);
+    }
+
+    /// <summary>A navigation that ran out of its deadline says so, rather than only saying it in English.</summary>
+    /// <remarks>
+    /// A timeout is the one failure a caller routinely tells apart — it says nothing about the page — and
+    /// the flag is what makes telling it apart possible: the <c>Page</c> domain matched on the message, and
+    /// a client library that reports its own timeout for the navigation it started needs the same answer.
+    /// </remarks>
+    [Test]
+    public async Task ANavigationThatRanOutOfTimeSaysItTimedOut()
+    {
+        using var release = new SemaphoreSlim(0, 1);
+
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.Map("/slow.html", _ =>
+        {
+            release.Wait(TimeSpan.FromSeconds(10));
+            return LoopbackResponse.Html("<title>too late</title>");
+        }));
+
+        var act = async () => await fixture.Page.NavigateAsync(
+            fixture.Url("/slow.html"),
+            new NavigationOptions { Timeout = TimeSpan.FromMilliseconds(50) });
+
+        var failure = await act.Should().ThrowAsync<NavigationFailedException>();
+        failure.Which.TimedOut.Should().BeTrue();
+        failure.Which.Url.Should().Be(fixture.Url("/slow.html"));
+
+        release.Release();
+    }
+
+    /// <summary>Every other failure is not a timeout, so a caller that retries a timeout does not retry it.</summary>
+    [Test]
+    public async Task ANavigationRefusedByTheFilterIsNotATimeout()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/forbidden.html", "<title>no</title>"),
+            options => options.UrlFilter = _ => false);
+
+        var act = async () => await fixture.Page.NavigateAsync(fixture.Url("/forbidden.html"));
+
+        var failure = await act.Should().ThrowAsync<NavigationFailedException>();
+        failure.Which.TimedOut.Should().BeFalse();
     }
 
     [Test]

--- a/Jint.Tests.Browser/Playwright/DirectPlaywrightTests.cs
+++ b/Jint.Tests.Browser/Playwright/DirectPlaywrightTests.cs
@@ -1,4 +1,4 @@
-using Jint.Tests.Browser.Navigation;
+﻿using Jint.Tests.Browser.Navigation;
 using Microsoft.Playwright;
 
 namespace Jint.Tests.Browser.PlaywrightAdapter;
@@ -286,6 +286,43 @@ public sealed class DirectPlaywrightTests
         (await editor.InputValueAsync()).Should().Be("changed");
         (await page.EvaluateAsync<string>("() => document.body.dataset.entered")).Should().Be("yes");
         (await page.Locator("#log").TextContentAsync()).Should().Be("trusted");
+    }
+
+    /// <summary>A navigation that runs out of the action's time is this API's timeout, not the page's.</summary>
+    /// <remarks>
+    /// <para>
+    /// <c>GotoAsync</c> hands the page the caller's deadline and waits on nothing else, so before the
+    /// translation existed the only thing a caller could catch was <c>Jint.Browser</c>'s own
+    /// <c>NavigationFailedException</c> — a type Playwright's contract never mentions.
+    /// </para>
+    /// <para>
+    /// It is the deterministic half of <see cref="LocatorClickTimeoutIncludesNavigation"/>, which had two
+    /// clocks expiring together: the action's <c>WaitAsync</c> and the page's navigation deadline. Which one
+    /// was seen first was a race, so the click reported <see cref="TimeoutException"/> on one platform and
+    /// <c>NavigationFailedException</c> on another. Both are the timeout now.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task GotoTimeoutIsAPlaywrightTimeout()
+    {
+        using var release = new SemaphoreSlim(0, 1);
+        using var server = new LoopbackServer();
+        server.Map("/slow.html", _ =>
+        {
+            release.Wait(TimeSpan.FromSeconds(10));
+            return LoopbackResponse.Html("<title>slow</title>");
+        });
+
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+
+        var goTo = async () => await page.GotoAsync(
+            server.Url("/slow.html"),
+            new PageGotoOptions { Timeout = 50 });
+
+        await goTo.Should().ThrowAsync<System.TimeoutException>();
+
+        release.Release();
     }
 
     [Test]

--- a/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
+++ b/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
@@ -96,6 +96,7 @@ namespace Jint.Browser
         public NavigationFailedException() { }
         public NavigationFailedException(string message) { }
         public NavigationFailedException(string message, System.Exception innerException) { }
+        public bool TimedOut { get; }
         public string Url { get; }
     }
     public sealed class NavigationOptions


### PR DESCRIPTION
`DirectPlaywrightTests.LocatorClickTimeoutIncludesNavigation` failed the Windows leg of #3804 and passed everywhere else. It is a **race**, and it will flake on any PR until it is fixed.

A Playwright action's `Timeout` covers the navigation the action starts, and the adapter hands the page that same deadline for the navigation itself — so `Task.WaitAsync` and the page's navigation deadline expire together and whichever is seen first decides what the caller catches:

| which clock is seen first | what the caller gets |
| --- | --- |
| `WaitAsync` | `TimeoutException` — what Playwright's contract promises |
| the navigation | `NavigationFailedException` — a type Playwright never mentions |

`GotoAsync` is the same defect **without** the race: it waits on nothing but the navigation, so a `PageGotoOptions { Timeout = 50 }` against a slow server could only ever throw `NavigationFailedException`.

## `NavigationFailedException.TimedOut`

The discriminator that was missing. A timeout is the one navigation failure a caller routinely has to tell apart, because it is the only one that says nothing about the page — a refused URL or a network error is a real failure of the navigation and stays what it is.

A flag rather than a second exception type, because the two are the same failure to everything that does not care (nothing was shown), and because matching on the message to find out — which is exactly what `PageDomain.NetworkError` did to answer `net::ERR_ABORTED` — breaks the moment the message is reworded. That call site now reads the flag instead of `failure.Message.Contains("timed out")`.

## The translation

`PageTarget.AsActionTimeoutAsync` turns a timed-out navigation into `TimeoutException` in the four places the adapter hands the page a deadline of its own: `GotoAsync`, `ReloadAsync`, `ILocator.ClickAsync` and `ILocator.PressAsync`. Only a timeout is translated.

## Verification

`GotoTimeoutIsAPlaywrightTimeout` is the deterministic half of the racing test, and was **confirmed red against the unfixed adapter**:

```
Failed GotoTimeoutIsAPlaywrightTimeout [575 ms]
  Expected a <System.TimeoutException> to be thrown, but found <Jint.Browser.NavigationFailedException>
```

Two more cover the flag: set for a navigation that ran out of time, clear for one the URL filter refused.

`dotnet test -c Release Jint.Tests.Browser` — `net10.0`: 1681 passed, `net8.0`: 1677 passed, 0 failed on both. The public API snapshot gains one line.

The first commit is #3804's build fix, without which nothing compiles; it drops out on rebase once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz