### PR TITLE
AbortSignal, TaskSignal, BroadcastChannel, MessagePort and the worker façades read their event handler attributes through EventHandlerAttributes

### DIFF
--- a/Jint.Tests/Runtime/WebApi/EventHandlerAttributeTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventHandlerAttributeTests.cs
@@ -1,0 +1,103 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// What an event handler IDL attribute is, read on every interface that has one —
+/// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three rules, and one definition of them (<c>Jint/WebApi/Events/EventHandlerAttributes.cs</c>): the handler
+/// is <b>one entry of the target's own event listener list</b> that keeps the position it first took,
+/// <c>EventHandler</c> is <c>[LegacyTreatNonObjectAsNull]</c> so a non-object clears it rather than raising a
+/// <c>TypeError</c>, and an object that is not callable is stored and read back but never invoked.
+/// </para>
+/// <para>
+/// <b>Every case dispatches the event by hand.</b> These interfaces reach their events by wildly different
+/// routes — a socket frame, an entangled port, an abort algorithm — and none of that is what is under test:
+/// what is under test is the listener list the attribute writes to, which <c>dispatchEvent</c> reaches on
+/// every one of them because every one of them is an <c>EventTarget</c>. The interface-specific arrivals are
+/// pinned in each interface's own file, and <c>MessagePort</c>'s implicit <c>start()</c> — the one handler
+/// attribute in the engine with a side effect — in
+/// <see cref="MessagingTests.AssigningOnMessageStartsThePortEvenForAListenerRegisteredSeparately"/>.
+/// </para>
+/// </remarks>
+public class EventHandlerAttributeTests
+{
+    [TestCase(WebApiFeatures.Events, "new AbortController().signal", "onabort", "abort")]
+    [TestCase(WebApiFeatures.Scheduler, "new TaskController().signal", "onprioritychange", "prioritychange")]
+    [TestCase(WebApiFeatures.Messaging, "new BroadcastChannel('handlers')", "onmessage", "message")]
+    [TestCase(WebApiFeatures.Messaging, "new BroadcastChannel('handlers')", "onmessageerror", "messageerror")]
+    [TestCase(WebApiFeatures.Messaging, "new MessageChannel().port1", "onmessage", "message")]
+    [TestCase(WebApiFeatures.Messaging, "new MessageChannel().port1", "onmessageerror", "messageerror")]
+    public void AHandlerAttributeKeepsItsPositionAndTakesANonObjectAsNull(
+        WebApiFeatures features,
+        string construct,
+        string attribute,
+        string type)
+    {
+        var engine = new Engine(options => options.UseWebApis(features | WebApiFeatures.Events));
+
+        engine.Execute($$"""
+            var log = [];
+            var target = {{construct}};
+            var fire = () => target.dispatchEvent(new Event('{{type}}'));
+
+            target.{{attribute}} = () => log.push('handler');
+            target.addEventListener('{{type}}', () => log.push('listener'));
+            target.{{attribute}} = () => log.push('replaced');
+            fire();
+            """);
+
+        // Reassigning replaced the callback in place, so the handler still runs before a listener added after
+        // it — a remove-and-add would have put it last.
+        Log(engine).Should().Be("replaced|listener");
+
+        engine.Execute($"target.{attribute} = 42; fire();");
+        engine.Evaluate($"target.{attribute}").IsNull().Should().BeTrue("EventHandler is [LegacyTreatNonObjectAsNull]");
+        Log(engine).Should().Be("replaced|listener|listener");
+
+        // An object that is not callable is kept and read back, and the dispatch simply passes it over.
+        engine.Execute($"var bag = {{}}; target.{attribute} = bag; fire();");
+        engine.Evaluate($"target.{attribute} === bag").AsBoolean().Should().BeTrue();
+        Log(engine).Should().Be("replaced|listener|listener|listener");
+
+        // And a handler assigned after it was cleared appends a fresh entry, so it now runs last.
+        engine.Execute($"target.{attribute} = null; target.{attribute} = () => log.push('appended'); fire();");
+        Log(engine).Should().Be("replaced|listener|listener|listener|listener|appended");
+    }
+
+    /// <summary>
+    /// The handler is invisible to <c>removeEventListener</c>, because in the specification its callback is
+    /// the event handler processing algorithm rather than the function the script assigned.
+    /// </summary>
+    [TestCase(WebApiFeatures.Events, "new AbortController().signal", "onabort", "abort")]
+    [TestCase(WebApiFeatures.Scheduler, "new TaskController().signal", "onprioritychange", "prioritychange")]
+    [TestCase(WebApiFeatures.Messaging, "new BroadcastChannel('handlers')", "onmessage", "message")]
+    [TestCase(WebApiFeatures.Messaging, "new MessageChannel().port1", "onmessage", "message")]
+    public void RemoveEventListenerCannotReachAHandlerAttribute(
+        WebApiFeatures features,
+        string construct,
+        string attribute,
+        string type)
+    {
+        var engine = new Engine(options => options.UseWebApis(features | WebApiFeatures.Events));
+
+        engine.Execute($$"""
+            var log = [];
+            var target = {{construct}};
+            var handler = () => log.push('handler');
+            target.{{attribute}} = handler;
+            target.removeEventListener('{{type}}', handler);
+            target.dispatchEvent(new Event('{{type}}'));
+            """);
+
+        Log(engine).Should().Be("handler");
+        engine.Evaluate($"target.{attribute} === handler").AsBoolean().Should().BeTrue();
+    }
+
+    private static string Log(Engine engine) => engine.Evaluate("log.join('|')").AsString();
+}
+#endif

--- a/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WorkerMechanismTests.cs
@@ -1179,6 +1179,48 @@ public class WorkerMechanismTests
         parent.Evaluate("Object.prototype.toString.call(w)").AsString().Should().Be("[object Worker]");
     }
 
+    /// <summary>
+    /// And they are the same three rules every other event handler IDL attribute obeys
+    /// (https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes), read on the one
+    /// façade that needs a thread to exist at all: the handler is a single entry of the worker object's own
+    /// listener list that keeps the position it first took, a non-object clears it, and an object that is not
+    /// callable is stored and read back but never invoked.
+    /// </summary>
+    /// <remarks>
+    /// The event is dispatched by hand rather than posted from the worker, because what is under test is the
+    /// listener list the attribute writes to and not the arrival — <c>EventHandlerAttributeTests</c> reads the
+    /// same three rules on every interface that can be built without a thread.
+    /// </remarks>
+    [Test]
+    public void TheWorkerObjectsHandlerAttributeKeepsItsPositionAndTakesANonObjectAsNull()
+    {
+        var host = new TestWorkerHost(Module(""));
+        var parent = Parent(host);
+
+        parent.Execute("""
+            var log = [];
+            var w = new Worker('./worker.js', { type: 'module' });
+            var fire = () => w.dispatchEvent(new Event('message'));
+
+            w.onmessage = () => log.push('handler');
+            w.addEventListener('message', () => log.push('listener'));
+            w.onmessage = () => log.push('replaced');
+            fire();
+            """);
+
+        parent.Evaluate("log.join('|')").AsString().Should().Be("replaced|listener");
+
+        parent.Execute("w.onmessage = 42; fire();");
+        parent.Evaluate("w.onmessage").IsNull().Should().BeTrue();
+        parent.Evaluate("log.join('|')").AsString().Should().Be("replaced|listener|listener");
+
+        parent.Execute("var bag = {}; w.onmessage = bag; fire();");
+        parent.Evaluate("w.onmessage === bag").AsBoolean().Should().BeTrue();
+        parent.Evaluate("log.join('|')").AsString().Should().Be("replaced|listener|listener|listener");
+
+        parent.Execute("w.terminate();");
+    }
+
     // -------------------------------------------------------------------------------------------------------
     // Threading and the transferable-stream interaction
     // -------------------------------------------------------------------------------------------------------

--- a/Jint/WebApi/Abort/AbortSignalPrototype.cs
+++ b/Jint/WebApi/Abort/AbortSignalPrototype.cs
@@ -59,53 +59,20 @@ internal sealed partial class AbortSignalPrototype : Prototype
     /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes.
     /// </summary>
     /// <remarks>
-    /// The handler is one entry of the signal's own event listener list, so it takes its turn in registration
-    /// order among the <c>addEventListener('abort', …)</c> listeners rather than running before or after all
-    /// of them. Reassigning the attribute replaces the value in place — the entry keeps the position it was
-    /// first given, which is HTML's "activate an event handler" doing nothing once a listener exists — and
-    /// assigning a non-object removes the entry outright, so a later assignment appends a fresh one at the
-    /// end. It is invisible to <c>removeEventListener</c>, because in the specification its callback is the
-    /// event handler processing algorithm rather than the function the script assigned.
+    /// <see cref="EventHandlerAttributes"/> is what one is, on every interface that has one: the handler is a
+    /// single entry of the signal's own event listener list, so it takes its turn in registration order among
+    /// the <c>addEventListener('abort', …)</c> listeners rather than running before or after all of them.
     /// </remarks>
     [JsAccessor("onabort", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnAbortGet(JsValue thisObject)
-    {
-        return Brand(thisObject).FindEventHandler(JsAbortSignal.AbortEventType)?.Callback ?? Null;
-    }
+        => EventHandlerAttributes.Get(Brand(thisObject), JsAbortSignal.AbortEventType);
 
     /// <summary>
-    /// https://dom.spec.whatwg.org/#dom-abortsignal-onabort, setter half. <c>EventHandler</c> is a nullable
-    /// callback function annotated <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything that is not an
-    /// object clears the handler rather than raising a <c>TypeError</c>. An object that is not callable is
-    /// stored and read back — the getter returns what was assigned — but is never invoked, which is what
-    /// HTML's processing algorithm amounts to for a value that cannot be called.
+    /// https://dom.spec.whatwg.org/#dom-abortsignal-onabort, setter half.
     /// </summary>
     [JsAccessor("onabort", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnAbortSet(JsValue thisObject, JsValue value)
-    {
-        var signal = Brand(thisObject);
-        var existing = signal.FindEventHandler(JsAbortSignal.AbortEventType);
-
-        if (value is not ObjectInstance)
-        {
-            // "Deactivate an event handler": the listener goes away entirely.
-            if (existing is not null)
-            {
-                signal.RemoveListener(existing);
-            }
-
-            return Undefined;
-        }
-
-        if (existing is not null)
-        {
-            existing.Callback = value;
-            return Undefined;
-        }
-
-        signal.AddListener(new EventListenerRegistration(JsAbortSignal.AbortEventType, value) { IsEventHandler = true });
-        return Undefined;
-    }
+        => EventHandlerAttributes.Set(Brand(thisObject), JsAbortSignal.AbortEventType, value);
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#dom-abortsignal-throwifaborted

--- a/Jint/WebApi/Events/EventHandlerAttributes.cs
+++ b/Jint/WebApi/Events/EventHandlerAttributes.cs
@@ -22,6 +22,23 @@ namespace Jint.WebApi.Events;
 /// is why assigning a number or a string clears the handler rather than raising a <c>TypeError</c>; an object
 /// that is not callable is stored and read back but never invoked.
 /// </para>
+/// <para>
+/// <b>The entry is invisible to <c>removeEventListener</c></b>, because in the specification its callback is
+/// the event handler processing algorithm rather than the function the script assigned. Clearing it and
+/// assigning again therefore <i>appends</i> a fresh entry at the end of the list, since the one it had is
+/// gone: "activate an event handler" does nothing once a listener exists, and "deactivate" removes it
+/// outright.
+/// </para>
+/// <para>
+/// <b>Setting a handler starts nothing.</b> Exactly one interface in the engine disagrees —
+/// <c>MessagePort</c>, whose <c>onmessage</c> setter must also enable the port message queue
+/// (https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-onmessage) — and it says so by
+/// calling <see cref="Set"/> and then <c>start()</c>, in that order, rather than by this method growing a
+/// hook. The rule is scoped to that interface: the <c>MessageEventTarget</c> mixin a <c>Worker</c> and a
+/// worker's global scope include carries no such rule, so on those <c>addEventListener('message', …)</c>
+/// alone has to receive and both façades are enabled by the engine instead. A caller that needs a post-set
+/// step writes it beside the call, where a reader can see it.
+/// </para>
 /// </remarks>
 internal static class EventHandlerAttributes
 {

--- a/Jint/WebApi/Messaging/BroadcastChannelPrototype.cs
+++ b/Jint/WebApi/Messaging/BroadcastChannelPrototype.cs
@@ -94,9 +94,7 @@ internal sealed partial class BroadcastChannelPrototype : Prototype
     /// </remarks>
     [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageGet(JsValue thisObject)
-    {
-        return Brand(thisObject).FindEventHandler(JsBroadcastChannel.MessageEventType)?.Callback ?? Null;
-    }
+        => EventHandlerAttributes.Get(Brand(thisObject), JsBroadcastChannel.MessageEventType);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage, setter
@@ -104,10 +102,7 @@ internal sealed partial class BroadcastChannelPrototype : Prototype
     /// </summary>
     [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageSet(JsValue thisObject, JsValue value)
-    {
-        SetEventHandler(Brand(thisObject), JsBroadcastChannel.MessageEventType, value);
-        return Undefined;
-    }
+        => EventHandlerAttributes.Set(Brand(thisObject), JsBroadcastChannel.MessageEventType, value);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror.
@@ -117,9 +112,7 @@ internal sealed partial class BroadcastChannelPrototype : Prototype
     /// </remarks>
     [JsAccessor("onmessageerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageErrorGet(JsValue thisObject)
-    {
-        return Brand(thisObject).FindEventHandler(JsBroadcastChannel.MessageErrorEventType)?.Callback ?? Null;
-    }
+        => EventHandlerAttributes.Get(Brand(thisObject), JsBroadcastChannel.MessageErrorEventType);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror,
@@ -127,40 +120,7 @@ internal sealed partial class BroadcastChannelPrototype : Prototype
     /// </summary>
     [JsAccessor("onmessageerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageErrorSet(JsValue thisObject, JsValue value)
-    {
-        SetEventHandler(Brand(thisObject), JsBroadcastChannel.MessageErrorEventType, value);
-        return Undefined;
-    }
-
-    /// <summary>
-    /// HTML's "set the current value of the event handler". <c>EventHandler</c> is a nullable callback
-    /// function annotated <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything that is not an object
-    /// clears the handler rather than raising a <c>TypeError</c>. Reassigning replaces the value in place, so
-    /// the listener keeps the position it was first given.
-    /// </summary>
-    private static void SetEventHandler(JsBroadcastChannel channel, string type, JsValue value)
-    {
-        var existing = channel.FindEventHandler(type);
-
-        if (value is not ObjectInstance)
-        {
-            // "Deactivate an event handler": the listener goes away entirely.
-            if (existing is not null)
-            {
-                channel.RemoveListener(existing);
-            }
-
-            return;
-        }
-
-        if (existing is not null)
-        {
-            existing.Callback = value;
-            return;
-        }
-
-        channel.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
-    }
+        => EventHandlerAttributes.Set(Brand(thisObject), JsBroadcastChannel.MessageErrorEventType, value);
 
     private JsBroadcastChannel Brand(JsValue thisObject)
     {

--- a/Jint/WebApi/Messaging/MessagePortPrototype.cs
+++ b/Jint/WebApi/Messaging/MessagePortPrototype.cs
@@ -104,9 +104,7 @@ internal sealed partial class MessagePortPrototype : Prototype
     /// </remarks>
     [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageGet(JsValue thisObject)
-    {
-        return Brand(thisObject).FindEventHandler(JsMessagePort.MessageEventType)?.Callback ?? Null;
-    }
+        => EventHandlerAttributes.Get(Brand(thisObject), JsMessagePort.MessageEventType);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageport-onmessage, setter half.
@@ -119,11 +117,18 @@ internal sealed partial class MessagePortPrototype : Prototype
     /// including one that clears the handler, which is what the specification's "is set" says and what
     /// browsers do.
     /// </remarks>
+    /// <remarks>
+    /// <b>This is the one handler attribute in the engine with a step after the set</b>, and it is written
+    /// here rather than as a hook on <see cref="EventHandlerAttributes"/>: the shared half is the same three
+    /// rules every other attribute obeys, and the port-specific half is one line a reader can see. The order
+    /// matters - the handler is in place before the queue is enabled, so a message the enabling delivers
+    /// finds it.
+    /// </remarks>
     [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageSet(JsValue thisObject, JsValue value)
     {
         var port = Brand(thisObject);
-        SetEventHandler(port, JsMessagePort.MessageEventType, value);
+        EventHandlerAttributes.Set(port, JsMessagePort.MessageEventType, value);
         port.Start();
         return Undefined;
     }
@@ -137,9 +142,7 @@ internal sealed partial class MessagePortPrototype : Prototype
     /// </remarks>
     [JsAccessor("onmessageerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageErrorGet(JsValue thisObject)
-    {
-        return Brand(thisObject).FindEventHandler(JsMessagePort.MessageErrorEventType)?.Callback ?? Null;
-    }
+        => EventHandlerAttributes.Get(Brand(thisObject), JsMessagePort.MessageErrorEventType);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageport-onmessageerror, setter
@@ -147,40 +150,7 @@ internal sealed partial class MessagePortPrototype : Prototype
     /// </summary>
     [JsAccessor("onmessageerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageErrorSet(JsValue thisObject, JsValue value)
-    {
-        SetEventHandler(Brand(thisObject), JsMessagePort.MessageErrorEventType, value);
-        return Undefined;
-    }
-
-    /// <summary>
-    /// HTML's "set the current value of the event handler". <c>EventHandler</c> is a nullable callback
-    /// function annotated <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything that is not an object
-    /// clears the handler rather than raising a <c>TypeError</c>. Reassigning replaces the value in place, so
-    /// the listener keeps the position it was first given.
-    /// </summary>
-    private static void SetEventHandler(JsMessagePort port, string type, JsValue value)
-    {
-        var existing = port.FindEventHandler(type);
-
-        if (value is not ObjectInstance)
-        {
-            // "Deactivate an event handler": the listener goes away entirely.
-            if (existing is not null)
-            {
-                port.RemoveListener(existing);
-            }
-
-            return;
-        }
-
-        if (existing is not null)
-        {
-            existing.Callback = value;
-            return;
-        }
-
-        port.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
-    }
+        => EventHandlerAttributes.Set(Brand(thisObject), JsMessagePort.MessageErrorEventType, value);
 
     /// <summary>
     /// Resolves <c>postMessage</c>'s second argument to a transfer list. See the operation's remarks for the

--- a/Jint/WebApi/Scheduling/TaskSignalPrototype.cs
+++ b/Jint/WebApi/Scheduling/TaskSignalPrototype.cs
@@ -56,47 +56,19 @@ internal sealed partial class TaskSignalPrototype : Prototype
     /// event handler event type is <c>prioritychange</c>.
     /// </summary>
     /// <remarks>
-    /// The same registration mechanics <c>onabort</c> has: the handler is one entry of the signal's own
-    /// listener list, so it takes its turn in registration order among the
-    /// <c>addEventListener('prioritychange', …)</c> listeners; reassigning replaces the value in place, and
-    /// assigning a non-object removes the entry outright.
+    /// The same registration mechanics <c>onabort</c> has, and for the same reason: both are
+    /// <see cref="EventHandlerAttributes"/>.
     /// </remarks>
     [JsAccessor("onprioritychange", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnPriorityChangeGet(JsValue thisObject)
-    {
-        return Brand(thisObject).FindEventHandler(JsTaskSignal.PriorityChangeEventType)?.Callback ?? Null;
-    }
+        => EventHandlerAttributes.Get(Brand(thisObject), JsTaskSignal.PriorityChangeEventType);
 
     /// <summary>
-    /// https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange, setter half. <c>EventHandler</c>
-    /// is a nullable callback function annotated <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything
-    /// that is not an object clears the handler rather than raising a <c>TypeError</c>.
+    /// https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange, setter half.
     /// </summary>
     [JsAccessor("onprioritychange", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnPriorityChangeSet(JsValue thisObject, JsValue value)
-    {
-        var signal = Brand(thisObject);
-        var existing = signal.FindEventHandler(JsTaskSignal.PriorityChangeEventType);
-
-        if (value is not ObjectInstance)
-        {
-            if (existing is not null)
-            {
-                signal.RemoveListener(existing);
-            }
-
-            return Undefined;
-        }
-
-        if (existing is not null)
-        {
-            existing.Callback = value;
-            return Undefined;
-        }
-
-        signal.AddListener(new EventListenerRegistration(JsTaskSignal.PriorityChangeEventType, value) { IsEventHandler = true });
-        return Undefined;
-    }
+        => EventHandlerAttributes.Set(Brand(thisObject), JsTaskSignal.PriorityChangeEventType, value);
 
     private JsTaskSignal Brand(JsValue thisObject)
     {

--- a/Jint/WebApi/Workers/WorkerErrors.cs
+++ b/Jint/WebApi/Workers/WorkerErrors.cs
@@ -1,15 +1,11 @@
 #if NET8_0_OR_GREATER
-using Jint.Native;
-using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.WebApi.DomException;
-using Jint.WebApi.Events;
 
 namespace Jint.WebApi.Workers;
 
 /// <summary>
-/// The two refusals this feature raises at script, and the one-line event-handler attribute plumbing its two
-/// façades share.
+/// The two refusals this feature raises at script.
 /// </summary>
 internal static class WorkerErrors
 {
@@ -35,51 +31,6 @@ internal static class WorkerErrors
         var exception = realm.Intrinsics.DomException.CreateException(name, message);
         var location = engine._lastSyntaxElement?.Location ?? default;
         Throw.JavaScriptException(engine, exception, in location);
-    }
-
-    /// <summary>
-    /// The getter half of an event handler IDL attribute,
-    /// https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes.
-    /// </summary>
-    internal static JsValue GetEventHandler(JsEventTarget target, string type)
-        => target.FindEventHandler(type)?.Callback ?? JsValue.Null;
-
-    /// <summary>
-    /// HTML's "set the current value of the event handler". <c>EventHandler</c> is a nullable callback
-    /// function annotated <c>[LegacyTreatNonObjectAsNull]</c>, so assigning anything that is not an object
-    /// clears the handler rather than raising a <c>TypeError</c>; reassigning replaces the value in place, so
-    /// the listener keeps the position it was first given among the <c>addEventListener</c> ones.
-    /// </summary>
-    /// <remarks>
-    /// <b>It deliberately does not start anything.</b> <c>MessagePort</c>'s <c>onmessage</c> setter enables
-    /// that port's queue, because the specification scopes that rule to the <c>MessagePort</c> interface; the
-    /// <c>MessageEventTarget</c> mixin a <c>Worker</c> and a worker's global scope include carries no such
-    /// rule, so on those two <c>addEventListener('message', …)</c> alone has to receive — the exact opposite
-    /// of a <c>MessageChannel</c>, where <c>start()</c> is required. Both façades are therefore enabled by the
-    /// engine rather than by an assignment.
-    /// </remarks>
-    internal static void SetEventHandler(JsEventTarget target, string type, JsValue value)
-    {
-        var existing = target.FindEventHandler(type);
-
-        if (value is not ObjectInstance)
-        {
-            // "Deactivate an event handler": the listener goes away entirely.
-            if (existing is not null)
-            {
-                target.RemoveListener(existing);
-            }
-
-            return;
-        }
-
-        if (existing is not null)
-        {
-            existing.Callback = value;
-            return;
-        }
-
-        target.AddListener(new EventListenerRegistration(type, value) { IsEventHandler = true });
     }
 }
 #endif

--- a/Jint/WebApi/Workers/WorkerGlobalScope.cs
+++ b/Jint/WebApi/Workers/WorkerGlobalScope.cs
@@ -5,6 +5,7 @@ using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
+using Jint.WebApi.Events;
 using Jint.WebApi.GlobalEvents;
 using Jint.WebApi.Messaging;
 using Jint.WebApi.StructuredClone;
@@ -215,12 +216,8 @@ internal sealed class WorkerGlobalScope
     /// </summary>
     private void InstallEventHandler(ObjectInstance global, string attribute, string eventType)
     {
-        var getter = CreateFunction(attribute, 0, (_, _) => WorkerErrors.GetEventHandler(Target, eventType));
-        var setter = CreateFunction(attribute, 1, (_, arguments) =>
-        {
-            WorkerErrors.SetEventHandler(Target, eventType, arguments.At(0));
-            return JsValue.Undefined;
-        });
+        var getter = CreateFunction(attribute, 0, (_, _) => EventHandlerAttributes.Get(Target, eventType));
+        var setter = CreateFunction(attribute, 1, (_, arguments) => EventHandlerAttributes.Set(Target, eventType, arguments.At(0)));
 
         InstallDescriptor(global, attribute, new GetSetPropertyDescriptor(getter, setter, PropertyFlag.Configurable | PropertyFlag.Enumerable));
     }

--- a/Jint/WebApi/Workers/WorkerPrototype.cs
+++ b/Jint/WebApi/Workers/WorkerPrototype.cs
@@ -4,6 +4,7 @@ using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.WebApi.Events;
 using Jint.WebApi.StructuredClone;
 
 namespace Jint.WebApi.Workers;
@@ -94,22 +95,23 @@ internal sealed partial class WorkerPrototype : Prototype
     /// https://html.spec.whatwg.org/multipage/workers.html#handler-worker-onmessage.
     /// </summary>
     /// <remarks>
-    /// The handler is one entry of this object's own event listener list, so it takes its turn in registration
-    /// order among the <c>addEventListener('message', …)</c> listeners. <b>Assigning it starts nothing</b> —
-    /// the parent's queue is enabled by the engine when the worker is created, so a listener registered either
-    /// way receives; see <c>WorkerErrors.SetEventHandler</c>.
+    /// <see cref="EventHandlerAttributes"/> is what one is: the handler is one entry of this object's own
+    /// event listener list, so it takes its turn in registration order among the
+    /// <c>addEventListener('message', …)</c> listeners. <b>Assigning it starts nothing</b>, and that is a
+    /// difference from <c>MessagePort</c> rather than an oversight — the specification scopes the implicit
+    /// <c>start()</c> to the <c>MessagePort</c> interface, and the <c>MessageEventTarget</c> mixin a
+    /// <c>Worker</c> and a worker's global scope include carries no such rule. So on both façades
+    /// <c>addEventListener('message', …)</c> alone has to receive, which is why the engine enables the
+    /// parent's queue when the worker is created.
     /// </remarks>
     [JsAccessor("onmessage", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageGet(JsValue thisObject)
-        => WorkerErrors.GetEventHandler(Brand(thisObject), JsWorker.MessageEventType);
+        => EventHandlerAttributes.Get(Brand(thisObject), JsWorker.MessageEventType);
 
     /// <inheritdoc cref="OnMessageGet" />
     [JsAccessor("onmessage", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageSet(JsValue thisObject, JsValue value)
-    {
-        WorkerErrors.SetEventHandler(Brand(thisObject), JsWorker.MessageEventType, value);
-        return Undefined;
-    }
+        => EventHandlerAttributes.Set(Brand(thisObject), JsWorker.MessageEventType, value);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/workers.html#handler-worker-onmessageerror. Present because the
@@ -117,15 +119,12 @@ internal sealed partial class WorkerPrototype : Prototype
     /// </summary>
     [JsAccessor("onmessageerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageErrorGet(JsValue thisObject)
-        => WorkerErrors.GetEventHandler(Brand(thisObject), JsWorker.MessageErrorEventType);
+        => EventHandlerAttributes.Get(Brand(thisObject), JsWorker.MessageErrorEventType);
 
     /// <inheritdoc cref="OnMessageErrorGet" />
     [JsAccessor("onmessageerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnMessageErrorSet(JsValue thisObject, JsValue value)
-    {
-        WorkerErrors.SetEventHandler(Brand(thisObject), JsWorker.MessageErrorEventType, value);
-        return Undefined;
-    }
+        => EventHandlerAttributes.Set(Brand(thisObject), JsWorker.MessageErrorEventType, value);
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/workers.html#handler-abstractworker-onerror — the <i>plain</i>
@@ -156,15 +155,12 @@ internal sealed partial class WorkerPrototype : Prototype
     /// </remarks>
     [JsAccessor("onerror", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnErrorGet(JsValue thisObject)
-        => WorkerErrors.GetEventHandler(Brand(thisObject), JsWorker.ErrorEventType);
+        => EventHandlerAttributes.Get(Brand(thisObject), JsWorker.ErrorEventType);
 
     /// <inheritdoc cref="OnErrorGet" />
     [JsAccessor("onerror", AccessorKind.Set, Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsValue OnErrorSet(JsValue thisObject, JsValue value)
-    {
-        WorkerErrors.SetEventHandler(Brand(thisObject), JsWorker.ErrorEventType, value);
-        return Undefined;
-    }
+        => EventHandlerAttributes.Set(Brand(thisObject), JsWorker.ErrorEventType, value);
 
     /// <summary>
     /// Resolves <c>postMessage</c>'s second argument to a transfer list. See the operation's remarks for the


### PR DESCRIPTION
Closes #3752

Follows #3748, which did `EventSource` and `WebSocket`. These are the last five private copies of HTML's [event handler IDL attribute](https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes).

## What was duplicated

`AbortSignalPrototype`, `TaskSignalPrototype`, `BroadcastChannelPrototype` and `MessagePortPrototype` each carried the same three rules inline — the entry is one listener that keeps the position it first took, `[LegacyTreatNonObjectAsNull]` means a non-object clears it, and a non-callable object is stored and read back but never invoked. `WorkerErrors` carried a sixth copy over `JsEventTarget`, shared by the `Worker` object and the worker global scope. All five are gone: **232 lines deleted for 62**.

## The `MessagePort` decision — no hook is needed

The issue called this one out because the setter has a side effect, and asked whether the helper should grow a post-set hook or the port keep a two-line wrapper. **Neither question turned out to be open**: the `port.Start()` step was never inside the copied algorithm. `OnMessageSet` already read "set the handler, then start the port", so the substitution replaces only the first line and leaves the second exactly where it was.

Growing `EventHandlerAttributes` a hook would have moved a port-specific step into the one place that has to stay the same for every interface, to serve one caller. The wrapper now says why the order matters instead — the handler is in place *before* the queue is enabled, so a message the enabling delivers finds it. `MessagingTests.AssigningOnMessageStartsThePortEvenForAListenerRegisteredSeparately` already pinned that and still passes.

So there is **no sanctioned exception to record in `Jint/WebApi/AGENTS.md`**, and that file is untouched. What the argument needed was a home, and the helper is it: `EventHandlerAttributes` now states that setting a handler starts nothing, names `MessagePort` as the single interface that adds a step and why the rule is scoped to that interface, and carries over from the deleted `WorkerErrors` remark the reason a `Worker` and a worker's global scope must *not* do the same (the `MessageEventTarget` mixin has no such rule, so `addEventListener` alone has to receive there — the opposite of a `MessageChannel`). The entry being invisible to `removeEventListener` moved there too, from `AbortSignalPrototype`.

## The premise about tests, stated plainly

**Nothing here is a defect fix, so no test can be red.** The five copies were behaviourally identical to the helper — I checked each against it line by line, and then checked it the other way as well:

- New `Jint.Tests/Runtime/WebApi/EventHandlerAttributeTests.cs` — ten cases, parameterised over `AbortSignal.onabort`, `TaskSignal.onprioritychange`, `BroadcastChannel.onmessage`/`onmessageerror` and `MessagePort.onmessage`/`onmessageerror`, covering the three rules plus two more the copies stated in prose and nothing checked: a handler assigned after being cleared *appends* a fresh entry, and `removeEventListener` cannot reach one.
- `WorkerMechanismTests.TheWorkerObjectsHandlerAttributeKeepsItsPositionAndTakesANonObjectAsNull` — the same rules on the one façade that needs a thread to exist.

All eleven were run against `upstream/main` with the source change reverted and the tests in place: **11 passed, 0 failed**. That is deliberate, and it is what makes them a check on this change rather than a description of it — exactly what #3748 said about its own two.

Every case dispatches its event by hand. These interfaces reach their events by wildly different routes (a socket frame, an entangled port, an abort algorithm) and none of that is what is under test; the listener list the attribute writes to is, and `dispatchEvent` reaches it on all of them because all of them are `EventTarget`s. The interface-specific arrivals stay pinned in each interface's own file.

## What was verified

- `Jint.Tests` — 12 296 passed on `net8.0` and `net10.0`, 8 492 on `net472`, 0 failed.
- `Jint.Tests.PublicInterface` — 3 597 / 3 607 / 2 879, 0 failed.
- `Jint.Tests.Browser` — 1 680 / 1 684, 0 failed.

> Note: `upstream/main` does not currently compile (`Page.Navigation.cs(478,27)`, from #3786 merging on a stale merge ref); the fix is #3804. This branch was built and tested with that one-line fix applied locally and not committed, and wants a rebase once #3804 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
