### PR TITLE
StaticRange is an interface a page can construct, because a static range is four values AngleSharp has no reason to model

### DIFF
--- a/Jint.Browser/Dom/DomConstructors.cs
+++ b/Jint.Browser/Dom/DomConstructors.cs
@@ -22,7 +22,9 @@ namespace Jint.Browser.Dom;
 /// and the three DOM has given a constructor since 2014 —
 /// <c>Comment</c> (https://dom.spec.whatwg.org/#dom-comment-comment),
 /// <c>Text</c> (https://dom.spec.whatwg.org/#dom-text-text) and
-/// <c>Range</c> (https://dom.spec.whatwg.org/#dom-range-range).
+/// <c>Range</c> (https://dom.spec.whatwg.org/#dom-range-range); plus
+/// <c>StaticRange</c> (https://dom.spec.whatwg.org/#dom-staticrange-staticrange), which is not a generated
+/// interface at all — see <see cref="DomStaticRange"/>.
 /// </para>
 /// <para>
 /// <b>Every one of them says "the current global object's associated <c>Document</c>".</b> That is the page's
@@ -76,6 +78,14 @@ internal static class DomConstructors
             // The new range's start and end are (that document, 0), which is what AngleSharp's own
             // CreateRange answers.
             instance = (ObjectInstance) realm.Wrap(NodeDocument(realm).CreateRange());
+            return true;
+        }
+
+        // https://dom.spec.whatwg.org/#dom-staticrange-staticrange, and the one row here that is not a
+        // generated interface: AngleSharp models no StaticRange, so this constructs the binding's own.
+        if (ReferenceEquals(definition, DomManualInterfaces.StaticRange))
+        {
+            instance = DomStaticRange.Construct(realm, arguments);
             return true;
         }
 

--- a/Jint.Browser/Dom/DomInterfaceDefinition.cs
+++ b/Jint.Browser/Dom/DomInterfaceDefinition.cs
@@ -33,9 +33,11 @@ internal sealed class DomInterfaceDefinition
         bool hasInterfaceObject,
         DomWrapperKind wrapperKind,
         DomCollectionAccessor? collectionAccessor = null,
-        DomConstant[]? constants = null)
+        DomConstant[]? constants = null,
+        int constructorLength = 0)
     {
         Constants = constants ?? [];
+        ConstructorLength = constructorLength;
         Name = name;
         ClrInterface = clrInterface;
         _shapeFactory = shapeFactory;
@@ -45,6 +47,15 @@ internal sealed class DomInterfaceDefinition
         WrapperKind = wrapperKind;
         CollectionAccessor = collectionAccessor;
     }
+
+    /// <summary>
+    /// https://webidl.spec.whatwg.org/#es-interface-call — the interface object's <c>length</c>, which is
+    /// the number of arguments the constructor <em>requires</em>. Zero for every interface the generator
+    /// produces: an interface with no constructor has no required arguments, and the handful
+    /// <c>DomConstructors</c> gives one to all take optional arguments only. <c>StaticRange</c> is the
+    /// exception, and the reason this is a value rather than a constant.
+    /// </summary>
+    internal int ConstructorLength { get; }
 
     /// <summary>The WebIDL interface name — <c>HTMLDivElement</c>, the value of <c>[DomName]</c>.</summary>
     internal string Name { get; }

--- a/Jint.Browser/Dom/DomInterfaceObject.cs
+++ b/Jint.Browser/Dom/DomInterfaceObject.cs
@@ -35,7 +35,7 @@ internal sealed class DomInterfaceObject : Constructor
         _domRealm = realm;
         _definition = definition;
         _prototype = realm.PrincipalRealm.Intrinsics.Function.PrototypeObject;
-        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Configurable);
+        _length = new PropertyDescriptor(JsNumber.Create(definition.ConstructorLength), PropertyFlag.Configurable);
 
         // https://webidl.spec.whatwg.org/#interface-object — { writable: false, enumerable: false,
         // configurable: false }, so a script cannot repoint an interface at another prototype.

--- a/Jint.Browser/Dom/DomManualInterfaces.cs
+++ b/Jint.Browser/Dom/DomManualInterfaces.cs
@@ -10,7 +10,10 @@ namespace Jint.Browser.Dom;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>There is exactly one, and it is chosen by local name rather than by CLR type.</b> AngleSharp models
+/// <b>There are two, and they are here for opposite reasons.</b> <c>HTMLFrameSetElement</c> is a node
+/// AngleSharp builds and cannot name, so it is chosen by <em>local name</em> where everything else is chosen
+/// by CLR type; <c>StaticRange</c> is not AngleSharp's at all, so it is chosen by a CLR type of this
+/// package's own that no node ever takes. The first is the harder one to see, and is this: AngleSharp models
 /// <c>&lt;frameset&gt;</c> with the plain <c>IHtmlElement</c> — there is no <c>IHtmlFrameSetElement</c> and no
 /// <c>[DomName("HTMLFrameSetElement")]</c> anywhere in the pinned assemblies — so <c>DomTypeMap</c>, which
 /// keys on the CLR type, cannot tell a frameset from a <c>&lt;div&gt;</c>. The events bridge already makes the
@@ -49,8 +52,28 @@ internal static class DomManualInterfaces
         Index = DomInterfaces.All.Length,
     };
 
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#staticrange. AngleSharp has no <c>StaticRange</c> and no
+    /// <c>AbstractRange</c> — the interface is four values a page hands over, so there is nothing for it to
+    /// model — which is why this one is declared by CLR type where <c>HTMLFrameSetElement</c> is declared by
+    /// local name: the type is <see cref="DomStaticRange.State"/>, ours, and no node ever takes it.
+    /// <see cref="DomStaticRange"/> carries the algorithm and the shape.
+    /// </summary>
+    internal static readonly DomInterfaceDefinition StaticRange = new(
+        "StaticRange",
+        typeof(DomStaticRange.State),
+        DomStaticRange.Shape,
+        parent: null,
+        rootsAtEventTarget: false,
+        hasInterfaceObject: true,
+        DomWrapperKind.Object,
+        constructorLength: DomStaticRange.ConstructorLength)
+    {
+        Index = DomInterfaces.All.Length + 1,
+    };
+
     /// <summary>Every manual interface, in index order.</summary>
-    internal static readonly DomInterfaceDefinition[] All = [HTMLFrameSetElement];
+    internal static readonly DomInterfaceDefinition[] All = [HTMLFrameSetElement, StaticRange];
 
     /// <summary>
     /// The interface a node takes when its CLR type does not decide it, or <see langword="null"/> when

--- a/Jint.Browser/Dom/DomStaticRange.cs
+++ b/Jint.Browser/Dom/DomStaticRange.cs
@@ -1,0 +1,184 @@
+using AngleSharp.Dom;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.WebApi.DomException;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>
+/// <a href="https://dom.spec.whatwg.org/#staticrange">DOM §5.3's <c>StaticRange</c></a>: the four values a
+/// page hands over, and the five <a href="https://dom.spec.whatwg.org/#abstractrange">§5.1
+/// <c>AbstractRange</c></a> attributes it answers them with.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is the whole interface, and its emptiness is the point.</b> A <c>Range</c> is live — the tree's
+/// to move when a mutation happens under it, which is why AngleSharp models one and why the binding projects
+/// that model. A <c>StaticRange</c> is four values and nothing else: it is never validated against a
+/// container's length, it does not move when the tree does, and it goes stale rather than following. So
+/// there is nothing here for AngleSharp to own, which is also why it has no type for it — no
+/// <c>StaticRange</c>, no <c>AbstractRange</c>, no <c>[DomName]</c> the generator could ever see.
+/// </para>
+/// <para>
+/// It is therefore a <see cref="DomManualInterfaces"/> row, the way <c>HTMLFrameSetElement</c> is, and the
+/// backing object is <see cref="State"/> rather than anything of AngleSharp's. Nothing else in the binding
+/// wraps one: an instance is only ever created by <c>new</c>, so it never reaches <c>DomTypeMap</c> and
+/// needs no entry there.
+/// </para>
+/// <para>
+/// <b>The endpoints are kept exactly as handed over.</b> An offset past the container's length, an end that
+/// precedes its start, and endpoints in two disconnected trees are all ordinary static ranges — step 1's
+/// refusal is the constructor's only one, and every other check a <c>Range</c> makes belongs to the live
+/// interface rather than to this one.
+/// </para>
+/// </remarks>
+internal static class DomStaticRange
+{
+    /// <summary>
+    /// The four values, which are the whole of a static range. A record so the wrapper has one immutable
+    /// thing to read and nothing to keep in step with the tree.
+    /// </summary>
+    internal sealed record State(INode StartContainer, uint StartOffset, INode EndContainer, uint EndOffset)
+    {
+        /// <summary>
+        /// https://dom.spec.whatwg.org/#dom-abstractrange-collapsed — derived rather than stored, because it
+        /// is only ever a question about the two endpoints a page set.
+        /// </summary>
+        internal bool Collapsed
+            => ReferenceEquals(StartContainer, EndContainer) && StartOffset == EndOffset;
+    }
+
+    /// <summary>
+    /// The one required argument, which is what <c>StaticRange.length</c> reports. Every other constructible
+    /// interface in the binding takes only optional arguments and so reports zero.
+    /// </summary>
+    internal const int ConstructorLength = 1;
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-staticrange-staticrange. WebIDL converts the dictionary first, so a
+    /// missing or non-<c>Node</c> member is a <c>TypeError</c> raised before step 1 runs; step 1's
+    /// <c>InvalidNodeTypeError</c> is then the only refusal the constructor makes of its own.
+    /// </summary>
+    internal static ObjectInstance Construct(DomRealm realm, JsValue[] arguments)
+    {
+        var init = arguments.Length > 0 ? arguments[0] : JsValue.Undefined;
+
+        // https://webidl.spec.whatwg.org/#es-dictionary: null and undefined convert to an empty dictionary,
+        // whose required members are then missing, and anything else that is not an object is refused
+        // outright. Both land on the same TypeError here, because every member of StaticRangeInit is
+        // required and so an empty dictionary can never be accepted.
+        var members = init as ObjectInstance;
+
+        var startContainer = RequiredNode(realm, members, "startContainer");
+        var startOffset = RequiredOffset(realm, members, "startOffset");
+        var endContainer = RequiredNode(realm, members, "endContainer");
+        var endOffset = RequiredOffset(realm, members, "endOffset");
+
+        // Step 1. A DocumentType has no position inside the tree a range names, and an Attr is not in the
+        // node tree at all, so neither can be a boundary point.
+        RefuseBoundary(realm, startContainer, "startContainer");
+        RefuseBoundary(realm, endContainer, "endContainer");
+
+        return new DomObject(
+            realm,
+            DomManualInterfaces.StaticRange,
+            new State(startContainer, startOffset, endContainer, endOffset));
+    }
+
+    /// <summary>
+    /// <c>StaticRange.prototype</c>: the five <c>AbstractRange</c> attributes as readonly accessors, which
+    /// is where WebIDL puts them, and nothing else — <c>StaticRange</c> declares no member of its own.
+    /// </summary>
+    internal static JsObjectShape Shape()
+        => new JsObjectShape.Builder()
+            .ToStringTag("StaticRange")
+            .PerRealmSlot("constructor", enumerable: false)
+            .Accessor("startContainer", static (thisObject, _) =>
+            {
+                var (realm, state) = Self(thisObject, "startContainer");
+                return realm.WrapNode(state.StartContainer);
+            })
+            .Accessor("startOffset", static (thisObject, _) => DomConvert.Number(Self(thisObject, "startOffset").State.StartOffset))
+            .Accessor("endContainer", static (thisObject, _) =>
+            {
+                var (realm, state) = Self(thisObject, "endContainer");
+                return realm.WrapNode(state.EndContainer);
+            })
+            .Accessor("endOffset", static (thisObject, _) => DomConvert.Number(Self(thisObject, "endOffset").State.EndOffset))
+            .Accessor("collapsed", static (thisObject, _) => DomConvert.Bool(Self(thisObject, "collapsed").State.Collapsed))
+            .Build();
+
+    /// <summary>
+    /// The receiver's realm and state, or WebIDL's <c>TypeError</c> — the brand check every attribute of a
+    /// platform object makes before it reads anything.
+    /// </summary>
+    private static (DomRealm Realm, State State) Self(JsValue thisObject, string member)
+    {
+        if (thisObject is DomObject { DomTarget: State state } wrapper)
+        {
+            return (wrapper.DomRealm, state);
+        }
+
+        var qualified = "StaticRange." + member;
+
+        if (thisObject is ObjectInstance instance)
+        {
+            Jint.Runtime.Throw.TypeError(instance.Engine.Realm, "Failed to execute '" + qualified + "': Illegal invocation");
+        }
+
+        Jint.Runtime.Throw.TypeErrorNoEngine("Failed to execute '" + qualified + "': Illegal invocation");
+        return default;
+    }
+
+    /// <summary>
+    /// A <c>required Node</c> member. WebIDL refuses an absent one and a value that is not a <c>Node</c>
+    /// alike, and <c>null</c> with them, because the declared type is not nullable.
+    /// </summary>
+    private static INode RequiredNode(DomRealm realm, ObjectInstance? members, string member)
+    {
+        if (members?.Get(member) is IDomWrapper { DomTarget: INode node })
+        {
+            return node;
+        }
+
+        Jint.Runtime.Throw.TypeError(
+            realm.PrincipalRealm,
+            "Failed to construct 'StaticRange': member " + member + " is not of type Node.");
+
+        return null!;
+    }
+
+    /// <summary>
+    /// A <c>required unsigned long</c> member. The conversion is WebIDL's, so a negative number wraps rather
+    /// than being refused — a static range is never held to a container's length, and the only thing that
+    /// can fail here is the member being absent.
+    /// </summary>
+    private static uint RequiredOffset(DomRealm realm, ObjectInstance? members, string member)
+    {
+        var value = members?.Get(member) ?? JsValue.Undefined;
+
+        if (value.IsUndefined())
+        {
+            Jint.Runtime.Throw.TypeError(
+                realm.PrincipalRealm,
+                "Failed to construct 'StaticRange': member " + member + " is required.");
+        }
+
+        return Jint.Runtime.TypeConverter.ToUint32(value);
+    }
+
+    /// <summary>Step 1's refusal, which is the only one this constructor makes.</summary>
+    private static void RefuseBoundary(DomRealm realm, INode node, string member)
+    {
+        if (node is not (IDocumentType or IAttr))
+        {
+            return;
+        }
+
+        DomFailures.Refuse(
+            realm.Engine,
+            "StaticRange",
+            DomExceptionNames.InvalidNodeType,
+            "member " + member + " is " + (node is IAttr ? "an Attr" : "a DocumentType") + ", which cannot be a boundary point.");
+    }
+}

--- a/Jint.Tests.Browser/Dom/StaticRangeTests.cs
+++ b/Jint.Tests.Browser/Dom/StaticRangeTests.cs
@@ -1,0 +1,205 @@
+namespace Jint.Tests.Browser.Dom;
+
+/// <summary>
+/// <a href="https://dom.spec.whatwg.org/#staticrange">DOM §5.3's <c>StaticRange</c></a> and the
+/// <a href="https://dom.spec.whatwg.org/#abstractrange">§5.1 <c>AbstractRange</c></a> members it answers
+/// with, as a page sees them.
+/// </summary>
+/// <remarks>
+/// AngleSharp has no <c>StaticRange</c> at all — no type, no <c>[DomName]</c> — so the generator can never
+/// see one and this is a <c>DomManualInterfaces</c> row, the way <c>HTMLFrameSetElement</c> is. The
+/// distinction the interface exists for is that a static range is <b>four values and nothing else</b>: it
+/// holds no reference the tree can invalidate, it is never validated against a container's length, and
+/// unlike a <c>Range</c> it does not move when the tree beneath it does.
+/// </remarks>
+public sealed class StaticRangeTests
+{
+    private const string Page = """
+        <!doctype html>
+        <html><body><div id="testDiv">abc<span>def</span>ghi</div></body></html>
+        """;
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-staticrange-staticrange: the interface object is on the window, it
+    /// is constructible, and an instance reports itself as one.
+    /// </summary>
+    [TestCase("typeof StaticRange", "function")]
+    [TestCase("StaticRange.name", "StaticRange")]
+    [TestCase("StaticRange.length", "1")]
+    [TestCase("new StaticRange({startContainer: document, startOffset: 0, endContainer: document, endOffset: 0}) instanceof StaticRange", "true")]
+    [TestCase("Object.prototype.toString.call(new StaticRange({startContainer: document, startOffset: 0, endContainer: document, endOffset: 0}))", "[object StaticRange]")]
+    [TestCase("StaticRange.prototype.constructor === StaticRange", "true")]
+    public void TheInterfaceObjectIsOnTheWindowAndConstructible(string source, string expected)
+    {
+        Answer(source).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#abstractrange: the five readonly attributes, answered from the four
+    /// values the constructor was handed and never from the tree.
+    /// </summary>
+    [TestCase("Start(1, 2).startContainer === testDiv", "true")]
+    [TestCase("Start(1, 2).startOffset", "1")]
+    [TestCase("Start(1, 2).endContainer === testDiv", "true")]
+    [TestCase("Start(1, 2).endOffset", "2")]
+    [TestCase("Start(1, 2).collapsed", "false")]
+    [TestCase("Start(0, 0).collapsed", "true")]
+    [TestCase("Start(2, 2).collapsed", "true")]
+    public void TheFourValuesRoundTripAndCollapsedIsDerived(string source, string expected)
+    {
+        Answer(source).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The wrapper identity a page compares against: the container it gets back is the very object it
+    /// passed in, which is what <c>staticRange.startContainer === testDiv</c> asks.
+    /// </summary>
+    [TestCase("text", TestName = "a Text container round-trips")]
+    [TestCase("document", TestName = "a Document container round-trips")]
+    [TestCase("document.createComment('abc')", TestName = "a Comment container round-trips")]
+    [TestCase("document.createDocumentFragment()", TestName = "a DocumentFragment container round-trips")]
+    [TestCase("document.createElement('div')", TestName = "a detached Element container round-trips")]
+    [TestCase("document.createProcessingInstruction('foo', 'abc')", TestName = "a ProcessingInstruction container round-trips")]
+    public void AContainerIsHandedBackAsTheSameObject(string container)
+    {
+        Answer($$"""
+            (function () {
+              var n = {{container}};
+              var r = new StaticRange({startContainer: n, startOffset: 0, endContainer: n, endOffset: 0});
+              return r.startContainer === n && r.endContainer === n;
+            })()
+            """).Should().Be("true");
+    }
+
+    /// <summary>
+    /// The offsets are WebIDL <c>unsigned long</c>s and nothing else: a static range is never validated
+    /// against its container's length, so an offset past the end is kept as given.
+    /// </summary>
+    [TestCase("Start(0, 15).endOffset", "15")]
+    [TestCase("Start(1, 0).startOffset", "1")]
+    public void AnOffsetIsNeverValidatedAgainstTheContainer(string source, string expected)
+    {
+        Answer(source).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-staticrange-staticrange step 1: a <c>DocumentType</c> or an
+    /// <c>Attr</c> is an <c>InvalidNodeTypeError</c>, and it is the only refusal the constructor makes.
+    /// </summary>
+    [TestCase("document.doctype", TestName = "a DocumentType container is refused")]
+    [TestCase("document.getElementById('testDiv').getAttributeNode('id')", TestName = "an Attr container is refused")]
+    public void ADocumentTypeOrAttrContainerIsAnInvalidNodeTypeError(string container)
+    {
+        Refusal($$"""
+            (function () {
+              var n = {{container}};
+              return new StaticRange({startContainer: n, startOffset: 0, endContainer: n, endOffset: 0});
+            })()
+            """).Should().Be("InvalidNodeTypeError");
+    }
+
+    /// <summary>
+    /// Every member of <c>StaticRangeInit</c> is <c>required</c> and the containers are non-nullable
+    /// <c>Node</c>s, so WebIDL's conversion refuses before the constructor's own step 1 ever runs — which is
+    /// why these are <c>TypeError</c>s and not <c>InvalidNodeTypeError</c>s.
+    /// </summary>
+    [TestCase("new StaticRange()", TestName = "no argument at all is a TypeError")]
+    [TestCase("new StaticRange({startOffset: 0, endContainer: testDiv, endOffset: 0})", TestName = "a missing startContainer is a TypeError")]
+    [TestCase("new StaticRange({startContainer: testDiv, endContainer: testDiv, endOffset: 0})", TestName = "a missing startOffset is a TypeError")]
+    [TestCase("new StaticRange({startContainer: testDiv, startOffset: 0, endOffset: 0})", TestName = "a missing endContainer is a TypeError")]
+    [TestCase("new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: testDiv})", TestName = "a missing endOffset is a TypeError")]
+    [TestCase("new StaticRange({startContainer: null, startOffset: 0, endContainer: testDiv, endOffset: 0})", TestName = "a null startContainer is a TypeError")]
+    [TestCase("new StaticRange({startContainer: testDiv, startOffset: 0, endContainer: null, endOffset: 0})", TestName = "a null endContainer is a TypeError")]
+    [TestCase("new StaticRange({startContainer: 'div', startOffset: 0, endContainer: testDiv, endOffset: 0})", TestName = "a container that is not a Node is a TypeError")]
+    public void AMissingOrNonNodeMemberIsATypeError(string source)
+    {
+        Refusal(source).Should().Be("TypeError");
+    }
+
+    /// <summary>Calling the constructor without <c>new</c> is WebIDL's <c>TypeError</c>.</summary>
+    [Test]
+    public void TheConstructorRefusesToBeCalledAsAFunction()
+    {
+        Refusal("StaticRange({startContainer: document, startOffset: 0, endContainer: document, endOffset: 0})")
+            .Should().Be("TypeError");
+    }
+
+    /// <summary>
+    /// The endpoints are kept as handed over, so a range whose end precedes its start, and one whose
+    /// endpoints are in different trees, are both ordinary static ranges rather than refusals.
+    /// </summary>
+    [Test]
+    public void InvertedAndDisconnectedEndpointsAreKept()
+    {
+        Answer("""
+            (function () {
+              var other = document.createElement('div');
+              var inverted = new StaticRange({startContainer: testDiv, startOffset: 1, endContainer: document.body, endOffset: 0});
+              var split = new StaticRange({startContainer: testDiv, startOffset: 1, endContainer: other, endOffset: 2});
+              return [
+                inverted.startContainer === testDiv,
+                inverted.endContainer === document.body,
+                inverted.collapsed,
+                split.endContainer === other,
+                split.endOffset,
+              ].join('|');
+            })()
+            """).Should().Be("true|true|false|true|2");
+    }
+
+    /// <summary>
+    /// The five attributes are readonly accessors on the prototype, which is where WebIDL puts them — not
+    /// own properties of the instance.
+    /// </summary>
+    [Test]
+    public void TheAttributesLiveOnThePrototype()
+    {
+        Answer("""
+            (function () {
+              var r = new StaticRange({startContainer: document, startOffset: 0, endContainer: document, endOffset: 0});
+              var names = ['startContainer', 'startOffset', 'endContainer', 'endOffset', 'collapsed'];
+              return names.map(function (n) {
+                var d = Object.getOwnPropertyDescriptor(StaticRange.prototype, n);
+                return d && typeof d.get === 'function' && d.set === undefined
+                  && !Object.prototype.hasOwnProperty.call(r, n);
+              }).join('|');
+            })()
+            """).Should().Be("true|true|true|true|true");
+    }
+
+    private const string Preamble = """
+        var testDiv = document.getElementById('testDiv');
+        var text = testDiv.firstChild;
+        function Start(a, b) {
+          return new StaticRange({startContainer: testDiv, startOffset: a, endContainer: testDiv, endOffset: b});
+        }
+        """;
+
+    private static string? Answer(string source)
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        return fixture.Text($$"""
+            (function () {
+              {{Preamble}}
+              try { return String({{source}}); }
+              catch (e) { return e.constructor.name + ': ' + e.message; }
+            })()
+            """);
+    }
+
+    private static string? Refusal(string source)
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        var answer = fixture.Text($$"""
+            (function () {
+              {{Preamble}}
+              try { {{source}}; return ''; }
+              catch (e) { return e.name || String(e); }
+            })()
+            """);
+
+        return string.IsNullOrEmpty(answer) ? null : answer;
+    }
+}

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -30,7 +30,7 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `dom/collections/` | 8 | 0 | 43 | 25 |
 | `dom/lists/` | 5 | 0 | 189 | 5 |
 | `dom/traversal/` | 13 | 0 | 52 | 7 |
-| `dom/ranges/` | 17 | 0 | 82 | 25 |
+| `dom/ranges/` | 17 | 0 | 82 | 10 |
 | `html/dom/` | 5 | 0 | 85 | 31 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 14 |
@@ -38,7 +38,7 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 200 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **340** | **9** | **6,664** | **2,042** |
+| **total** | **340** | **9** | **6,664** | **2,027** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -1169,6 +1169,8 @@ internal static class WptBrowserExclusions
         new("dom/nodes/ParentNode-prepend.html", "*null as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
         new("dom/nodes/ParentNode-prepend.html", "*text as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
         new("dom/nodes/ParentNode-prepend.html", "*undefined as an argument, on a parent having no child.", WptDivergence.NeedsTriage),
+        new("dom/ranges/StaticRange-constructor.html", "Construct static range with DocumentFragment container", WptDivergence.NeedsTriage),
+        new("dom/ranges/StaticRange-constructor.html", "Construct static range with endpoints in disconnected trees", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- DOM's validate-and-extract, and the XML name productions
         // DOM's validate-and-extract, and the XML name productions
@@ -1237,12 +1239,11 @@ internal static class WptBrowserExclusions
         new("dom/nodes/Node-nodeValue.html", "Text*", WptDivergence.NeedsTriage),
         new("dom/nodes/attributes.html", "null*", WptDivergence.NeedsTriage),
 
-        // ---------------------------------------------------------------- Range's own algorithms, and StaticRange
-        // Range's remaining algorithms, and the StaticRange interface that is not there
+        // ---------------------------------------------------------------- Range's own algorithms
+        // Range's remaining algorithms
         new("dom/ranges/Range-comparePoint-2.html", "*2", WptDivergence.NeedsTriage),
         new("dom/ranges/Range-extractContents-dynamic-end.html", "*", WptDivergence.NeedsTriage),
         new("dom/ranges/Range-in-shadow-after-the-shadow-removed.html", "*", WptDivergence.NeedsTriage),
-        new("dom/ranges/StaticRange-constructor.html", "*", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- an event interface this browser does not build
         // an event interface this package deliberately does not build


### PR DESCRIPTION
`new StaticRange({startContainer, startOffset, endContainer, endOffset})` was `StaticRange is not defined`, and `dom/ranges/StaticRange-constructor.html` reported 0 of its 17 tests. It now reports 15.

## Why AngleSharp has no type for it, and why that is the right shape

[DOM §5.3](https://dom.spec.whatwg.org/#staticrange)'s `StaticRange` is the boundary pair that deliberately does **not** follow the tree: it is never validated against a container's length, it does not move when the tree beneath it does, and it goes stale rather than tracking. A `Range` is the opposite — live, and the tree's to move — which is why AngleSharp models one and why the binding projects that model.

So there is nothing here for AngleSharp to own, and it owns nothing: no `StaticRange`, no `AbstractRange`, no `[DomName]` anywhere in the pinned assemblies. The generator could never see one.

It is therefore a `DomManualInterfaces` row, the way `HTMLFrameSetElement` is — and the two are there for **opposite** reasons, which is now what that file's remarks say. A frameset is a node AngleSharp builds and cannot name, so it is chosen by *local name* where everything else is chosen by CLR type. A static range is not AngleSharp's at all, so it is chosen by a CLR type of this package's own that no node ever takes, and it never reaches `DomTypeMap`.

`Jint.Browser/Dom/DomStaticRange.cs` is the whole of it: the state record, the constructor algorithm, and the prototype shape — the five [§5.1 `AbstractRange`](https://dom.spec.whatwg.org/#abstractrange) attributes as readonly accessors, which is where WebIDL puts them rather than on the instance.

**No `overrides.json` change, and none was possible.** The generator only ever reads AngleSharp's `[DomName]` attributes, so there is nothing for it to skip or add; `HTMLFrameSetElement` has no entry there either, for the same reason. `Jint.Browser/Dom/Generated/` is untouched.

## The refusals are WebIDL's before they are DOM's

Every member of `StaticRangeInit` is `required` and the containers are non-nullable `Node`s, so the dictionary conversion refuses first: a missing member, a `null` container and a container that is not a node are all `TypeError`s raised **before** step 1 runs. [Step 1](https://dom.spec.whatwg.org/#dom-staticrange-staticrange)'s `InvalidNodeTypeError` for a `DocumentType` or an `Attr` is then the only refusal the constructor makes of its own — a `DocumentType` has no position inside the tree a range names, and an `Attr` is not in the node tree at all.

Everything else is kept exactly as handed over. An offset past the container's length, an end that precedes its start, and endpoints in two disconnected trees are all ordinary static ranges; every other check a `Range` makes belongs to the live interface.

## `StaticRange.length` is 1, and that needed one small change

`DomInterfaceObject` reported a hard-coded `0` for every interface object. Zero is right for all of them but this one: an interface with no constructor requires no arguments, and the handful `DomConstructors` gives a constructor to — `Document`, `DocumentFragment`, `Comment`, `Text`, `Range` — take optional arguments only. `DomInterfaceDefinition` now carries the arity as an optional parameter defaulting to zero, so no generated call site moves, and `StaticRange` is the single row that sets it.

## Web platform tests: 0 of 17 → 15 of 17

The whole-document `NeedsTriage` exclusion goes. **The two survivors are not about `StaticRange` at all** — both call `ParentNode.append()` with a string:

```
[FAIL] Construct static range with DocumentFragment container
    Failed to execute 'DocumentFragment.append': parameter 1 is not of the expected type.
[FAIL] Construct static range with endpoints in disconnected trees
    Failed to execute 'Element.append': parameter 1 is not of the expected type.
```

So they move to the group that already names their real cause — *a `(Node or DOMString)` union parameter takes only a Node* — rather than staying under a heading about an interface that now exists.

Census **re-derived from the run** with `JINT_WPT_BROWSER_CENSUS=update`, not edited by hand: `dom/ranges/` 25 not passing → **10**, total 2,042 → **2,027**. That is the only change to `Jint.Tests.Browser/Wpt/README.md` — two count cells in the table at lines 30–41, written by the census tool. It does not touch the region further down that carries the committed conflict markers, so it should not collide with the repair in flight there.

## Tests

`Jint.Tests.Browser/Dom/StaticRangeTests.cs`, 34 cases, **verified red against the unfixed tree first** (34 failed, 0 passed) and green after. They pin what the wpt document cannot: that the containers come back as the *same* JS objects a page passed in, that the five attributes are readonly accessors on the prototype and not own properties of the instance, that the constructor refuses to be called without `new`, and that a `TypeError` and an `InvalidNodeTypeError` are raised for the right reasons rather than interchangeably.

The whole `Jint.Tests.Browser` suite passes: 1,721 passed, 0 failed. Full `dotnet build -c Release` succeeds with 0 errors.

Part of #3772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
