### PR TITLE
navigator.userAgent is the host's to name, and one accessor answers it whichever way a page reads it

### DIFF
--- a/Jint.Browser/DevTools/EmulationDomain.cs
+++ b/Jint.Browser/DevTools/EmulationDomain.cs
@@ -172,17 +172,7 @@ internal sealed class EmulationDomain : EmulationDomainBase
         // One override for two commands: Chrome treats Emulation.setUserAgentOverride and
         // Network.setUserAgentOverride as the same setting, and the page's EmulationState is the one place
         // both write — what navigator.userAgent answers and what PageNetworkPolicy puts on every request.
-        State.UserAgent = parameters.UserAgent;
-
-        if (parameters.AcceptLanguage is { Length: > 0 } language)
-        {
-            State.AcceptLanguage = language;
-        }
-
-        if (parameters.Platform is { Length: > 0 } platform)
-        {
-            State.Platform = platform;
-        }
+        State.ApplyUserAgentOverride(parameters.UserAgent, parameters.AcceptLanguage, parameters.Platform);
 
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }

--- a/Jint.Browser/DevTools/NetworkDomain.cs
+++ b/Jint.Browser/DevTools/NetworkDomain.cs
@@ -132,17 +132,7 @@ internal sealed partial class NetworkDomain : NetworkDomainBase, IDetachableDoma
     {
         // The page's EmulationState is the one place either command writes; PageNetworkPolicy reads it while
         // composing a request, and navigator reads it in script, so the two can never disagree.
-        _target.Emulation.UserAgent = parameters.UserAgent;
-
-        if (parameters.AcceptLanguage is { Length: > 0 } language)
-        {
-            _target.Emulation.AcceptLanguage = language;
-        }
-
-        if (parameters.Platform is { Length: > 0 } platform)
-        {
-            _target.Emulation.Platform = platform;
-        }
+        _target.Emulation.ApplyUserAgentOverride(parameters.UserAgent, parameters.AcceptLanguage, parameters.Platform);
 
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }

--- a/Jint.Browser/Runtime/BrowserEngineFactory.cs
+++ b/Jint.Browser/Runtime/BrowserEngineFactory.cs
@@ -180,8 +180,10 @@ internal static class BrowserEngineFactory
         // https://fetch.spec.whatwg.org/#default-user-agent-value: what this document's fetches, its
         // XMLHttpRequests and — through the worker provider — its workers put on the wire is the same string
         // navigator.userAgent answers. An override a client sets *after* the engine was built reaches the
-        // wire through PageNetworkState.Apply, which rewrites the header per hop.
+        // wire through PageNetworkState.Apply, which rewrites the header per hop, and reaches script through
+        // Engine.WebApi.UserAgent, which EmulationState publishes to the engine showing the document.
         fetch.UserAgent = request.Emulation.EffectiveUserAgent;
+        options.WebApi.Navigator.UserAgent = request.Emulation.EffectiveUserAgent;
 
         if (request.Network.Client is { } client)
         {

--- a/Jint.Browser/Runtime/EmulationState.cs
+++ b/Jint.Browser/Runtime/EmulationState.cs
@@ -99,6 +99,48 @@ internal sealed class EmulationState
     /// </remarks>
     internal string EffectiveUserAgent => UserAgent is { Length: > 0 } overridden ? overridden : DefaultUserAgent;
 
+    /// <summary>
+    /// Called on the page loop whenever <see cref="EffectiveUserAgent"/> may have changed, so the engine
+    /// showing the document can be told. Set by the page runtime for the engine it currently owns.
+    /// </summary>
+    /// <remarks>
+    /// <b>It is a publish rather than a second resolution.</b> <c>navigator.userAgent</c> is now the engine's
+    /// own accessor, and an engine holds a string rather than a view of this object — so something has to
+    /// carry the new value across, and this is the one place that does. The resolution above stays the only
+    /// one there is, which is the property <see cref="EffectiveUserAgent"/>'s remarks are about.
+    /// </remarks>
+    internal Action<string>? UserAgentChanged { get; set; }
+
+    /// <summary>
+    /// <c>Emulation.setUserAgentOverride</c> and <c>Network.setUserAgentOverride</c>, which Chrome treats as
+    /// one setting and which are one write here.
+    /// <para>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setUserAgentOverride
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// All three reach the document that is <i>already loaded</i>: the user agent because the engine is told,
+    /// and the language and the platform because <c>NavigatorInstaller</c> reads this object per get. An
+    /// absent <c>acceptLanguage</c> or <c>platform</c> leaves the one already set, which is what a client
+    /// sending only a user agent expects.
+    /// </remarks>
+    internal void ApplyUserAgentOverride(string? userAgent, string? acceptLanguage, string? platform)
+    {
+        UserAgent = userAgent;
+
+        if (acceptLanguage is { Length: > 0 } language)
+        {
+            AcceptLanguage = language;
+        }
+
+        if (platform is { Length: > 0 } named)
+        {
+            Platform = named;
+        }
+
+        UserAgentChanged?.Invoke(EffectiveUserAgent);
+    }
+
     /// <summary>What <c>navigator.language</c> answers when a user agent override named one.</summary>
     internal string? AcceptLanguage { get; set; }
 

--- a/Jint.Browser/Runtime/NavigatorInstaller.cs
+++ b/Jint.Browser/Runtime/NavigatorInstaller.cs
@@ -31,9 +31,14 @@ namespace Jint.Browser.Runtime;
 /// members are inherited, and an own enumerable accessor would put every one of them in an object spread.
 /// </para>
 /// <para>
-/// <b><c>userAgent</c> is shadowed rather than left to the prototype</b>, because the page's user agent is
-/// <see cref="BrowserOptions.UserAgent"/> and a client's override, not <c>Jint/&lt;version&gt;</c> — and
-/// because it has to be the same string every request the page makes carries.
+/// <b><c>userAgent</c> is the exception, and it is left to the prototype.</b> The page's user agent is
+/// <see cref="BrowserOptions.UserAgent"/> and a client's override rather than <c>Jint/&lt;version&gt;</c>, and
+/// it used to be shadowed here to say so — which meant two answers to one IDL attribute, since the accessor
+/// the standard declares on <c>Navigator.prototype</c> went on answering the engine's own token
+/// (<see href="https://github.com/sebastienros/jint/issues/3655">#3655</see>). The engine now names its own:
+/// <c>Options.WebApi.Navigator.UserAgent</c> is what a page's engine is built with and
+/// <c>Engine.WebApi.UserAgent</c> is what an override moves, so one accessor answers and there is nothing
+/// here to shadow it with.
 /// </para>
 /// <para>
 /// The whole object is installed as a lazy global, so a page that never mentions <c>navigator</c> builds
@@ -69,9 +74,6 @@ internal static class NavigatorInstaller
             PropertyFlag.ConfigurableEnumerableWritable);
     }
 
-    /// <summary>What <c>navigator.userAgent</c> answers and what every request the page makes carries.</summary>
-    internal static string UserAgentOf(PageRuntime runtime) => runtime.Emulation.EffectiveUserAgent;
-
     /// <summary>
     /// What <c>navigator.language</c> answers: the first tag of the <c>Accept-Language</c> a user-agent
     /// override named, and otherwise the engine's own culture.
@@ -95,7 +97,8 @@ internal static class NavigatorInstaller
 
     private static void Attach(Engine engine, ObjectInstance navigator)
     {
-        Accessor(engine, navigator, "userAgent", static runtime => JsString.Create(UserAgentOf(runtime)));
+        // userAgent is deliberately absent: it is the one member the engine's own Navigator already declares,
+        // and Engine.WebApi.UserAgent is what carries the page's string to it.
         Accessor(engine, navigator, "language", static runtime => JsString.Create(LanguageOf(runtime)));
         Accessor(engine, navigator, "languages", static runtime => Languages(runtime));
         Accessor(engine, navigator, "platform", static runtime => JsString.Create(runtime.Emulation.Platform ?? ""));

--- a/Jint.Browser/Runtime/PageRuntime.cs
+++ b/Jint.Browser/Runtime/PageRuntime.cs
@@ -62,6 +62,12 @@ internal sealed class PageRuntime
         MutationObservers = new Observers.MutationObserverLane(this);
         Layout = new Layout.PageLayout(this);
         _started = System.Diagnostics.Stopwatch.GetTimestamp();
+
+        // The engine was built with this page's user agent already on it; what this adds is the *later*
+        // half. `navigator.userAgent` is the engine's own accessor now, so an override a client sets on a
+        // document that is already loaded has to be carried across rather than read through - and it is
+        // re-pointed here per navigation, because the engine it names is the one showing the document.
+        emulation.UserAgentChanged = userAgent => engine.WebApi.UserAgent = userAgent;
     }
 
     /// <summary>The engine this page runs in.</summary>

--- a/Jint.Tests.Browser/Runtime/NavigatorTests.cs
+++ b/Jint.Tests.Browser/Runtime/NavigatorTests.cs
@@ -1,0 +1,85 @@
+using Jint.Browser;
+using Jint.Tests.Browser.Navigation;
+
+namespace Jint.Tests.Browser.Runtime;
+
+/// <summary>
+/// A page's <c>navigator</c>: the members an embedded interpreter has no business publishing, and the one
+/// member the engine already had.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine's <c>Navigator</c> carries <c>userAgent</c> alone, because WinterTC's Minimum Common API
+/// requires it and everything else on HTML's interface describes a user agent with a user, a document and a
+/// network stack. A page <i>is</i> that, so the rest arrive here — and the one they share has to answer the
+/// page's string rather than the engine's, whichever way a script reads it.
+/// </para>
+/// <para>
+/// <c>Emulation.setUserAgentOverride</c> reading back through the same member is
+/// <c>DevTools/EmulationDomainTests</c>; this file is what a page sees with no client attached.
+/// </para>
+/// </remarks>
+public sealed class NavigatorTests
+{
+    private const string Ua = "Mozilla/5.0 (compatible; Probe/1.0)";
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent, read the two ways a
+    /// page can read it. Before <see href="https://github.com/sebastienros/jint/issues/3655">#3655</see> the
+    /// page shadowed <c>userAgent</c> with an own property, so the accessor WebIDL puts on
+    /// <c>Navigator.prototype</c> still answered the engine's <c>Jint/&lt;version&gt;</c> — two answers to
+    /// one IDL attribute, and the second is the one a script that hardens against tampering reaches for.
+    /// </summary>
+    [Test]
+    public async Task OneUserAgentAnswersWhicheverWayAPageReadsIt()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(configureBrowser: options => options.UserAgent = Ua);
+
+        await fixture.Page.SetContentAsync("<p>ok</p>");
+
+        (await fixture.Page.EvaluateAsync<string>("navigator.userAgent")).Should().Be(Ua);
+        (await fixture.Page.EvaluateAsync<string>(
+                "Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get.call(navigator)"))
+            .Should().Be(Ua, "the accessor the standard declares is the one that has to answer");
+    }
+
+    /// <summary>
+    /// And it is the prototype's, so the instance has no own <c>userAgent</c> at all — which is what a
+    /// browser answers and what idlharness asserts.
+    /// </summary>
+    [Test]
+    public async Task TheUserAgentIsNotAnOwnPropertyOfTheNavigator()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(configureBrowser: options => options.UserAgent = Ua);
+
+        await fixture.Page.SetContentAsync("<p>ok</p>");
+
+        (await fixture.Page.EvaluateAsync<bool>("Object.getOwnPropertyNames(navigator).includes('userAgent')"))
+            .Should().BeFalse("WebIDL puts a readonly attribute on the interface prototype object");
+
+        // The members the engine's Navigator does not have are still the page's own, and still hidden from
+        // Object.keys the way an inherited member would be.
+        (await fixture.Page.EvaluateAsync<bool>("Object.getOwnPropertyNames(navigator).includes('platform')"))
+            .Should().BeTrue();
+        (await fixture.Page.EvaluateAsync<double>("Object.keys(navigator).length")).Should().Be(0);
+    }
+
+    /// <summary>
+    /// The brand check survives the move: the getter is the interface's, so extracting it and calling it on
+    /// something that is not a <c>Navigator</c> is a <c>TypeError</c> exactly as a browser answers.
+    /// </summary>
+    [Test]
+    public async Task TheUserAgentGetterStillBrandChecksItsReceiver()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(configureBrowser: options => options.UserAgent = Ua);
+
+        await fixture.Page.SetContentAsync("<p>ok</p>");
+
+        (await fixture.Page.EvaluateAsync<string>("""
+            (() => {
+              const get = Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get;
+              try { get.call({}); return 'no throw'; } catch (e) { return e.constructor.name; }
+            })()
+            """)).Should().Be("TypeError");
+    }
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -142,6 +142,7 @@ namespace Jint
         {
             public Jint.WebApiFeatures Features { get; }
             public bool HasFetchHandler { get; }
+            public string UserAgent { get; set; }
             public System.Threading.Tasks.Task<long> CopyReadableStreamAsync(Jint.Native.JsValue readableStream, System.IO.Stream destination, Jint.WebApi.HostStreamCopyOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { }
             public Jint.Native.JsValue CreateAbortSignal(System.Threading.CancellationToken cancellationToken) { }
             public Jint.WebApi.MessagePortPair CreateMessagePortPair(Jint.Engine other) { }
@@ -404,6 +405,11 @@ namespace Jint
             public Jint.Runtime.Modules.IModuleLoader ModuleLoader { get; set; }
             public bool RegisterRequire { get; set; }
         }
+        public sealed class NavigatorOptions
+        {
+            public NavigatorOptions() { }
+            public string? UserAgent { get; set; }
+        }
         public sealed class ParsingOptions
         {
             public ParsingOptions() { }
@@ -446,6 +452,7 @@ namespace Jint
             public Jint.WebApiFeatures Features { get; set; }
             public Jint.Options.FetchOptions Fetch { get; }
             public Jint.Options.MessagingOptions Messaging { get; }
+            public Jint.Options.NavigatorOptions Navigator { get; }
             public Jint.Options.StorageOptions Storage { get; }
             public Jint.Options.TimerOptions Timers { get; }
             public Jint.Options.WorkerOptions Workers { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -142,6 +142,7 @@ namespace Jint
         {
             public Jint.WebApiFeatures Features { get; }
             public bool HasFetchHandler { get; }
+            public string UserAgent { get; set; }
             public System.Threading.Tasks.Task<long> CopyReadableStreamAsync(Jint.Native.JsValue readableStream, System.IO.Stream destination, Jint.WebApi.HostStreamCopyOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { }
             public Jint.Native.JsValue CreateAbortSignal(System.Threading.CancellationToken cancellationToken) { }
             public Jint.WebApi.MessagePortPair CreateMessagePortPair(Jint.Engine other) { }
@@ -404,6 +405,11 @@ namespace Jint
             public Jint.Runtime.Modules.IModuleLoader ModuleLoader { get; set; }
             public bool RegisterRequire { get; set; }
         }
+        public sealed class NavigatorOptions
+        {
+            public NavigatorOptions() { }
+            public string? UserAgent { get; set; }
+        }
         public sealed class ParsingOptions
         {
             public ParsingOptions() { }
@@ -446,6 +452,7 @@ namespace Jint
             public Jint.WebApiFeatures Features { get; set; }
             public Jint.Options.FetchOptions Fetch { get; }
             public Jint.Options.MessagingOptions Messaging { get; }
+            public Jint.Options.NavigatorOptions Navigator { get; }
             public Jint.Options.StorageOptions Storage { get; }
             public Jint.Options.TimerOptions Timers { get; }
             public Jint.Options.WorkerOptions Workers { get; }

--- a/Jint.Tests/Runtime/WebApi/NavigatorTests.cs
+++ b/Jint.Tests/Runtime/WebApi/NavigatorTests.cs
@@ -32,6 +32,80 @@ public class NavigatorTests
         userAgent.Should().Be($"Jint/{version.Major}.{version.Minor}.{version.Build}");
     }
 
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent - the user agent is
+    /// the host's to name. A browser is the host for which the engine's own product token is wrong: a page's
+    /// scripts sniff it and CDP's <c>Emulation.setUserAgentOverride</c> exists to set it, so
+    /// <c>Options.WebApi.Navigator.UserAgent</c> is what names it and the default is unchanged.
+    /// </summary>
+    [Test]
+    public void TheHostCanNameTheUserAgent()
+    {
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Navigator);
+            options.WebApi.Navigator.UserAgent = "Pretend/1.0 (compatible)";
+        });
+
+        engine.Evaluate("navigator.userAgent").AsString().Should().Be("Pretend/1.0 (compatible)");
+
+        // Still the prototype accessor WebIDL asks for, not an own property of the instance.
+        engine.Evaluate("Object.getOwnPropertyNames(navigator).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get.call(navigator)")
+            .AsString().Should().Be("Pretend/1.0 (compatible)");
+    }
+
+    /// <summary>
+    /// The empty string and <see langword="null"/> both mean "the engine's own", so a host clearing the
+    /// option gets the default back rather than an empty user agent - which is a string a page branches on.
+    /// </summary>
+    [TestCase(null)]
+    [TestCase("")]
+    public void ClearingTheOptionRestoresTheProductToken(string? value)
+    {
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Navigator);
+            options.WebApi.Navigator.UserAgent = value;
+        });
+
+        Regex.IsMatch(engine.Evaluate("navigator.userAgent").AsString(), @"^Jint/\d+\.\d+\.\d+$").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// And it moves on a live engine, because a browser's does: an override a client sets reaches the
+    /// document that is already loaded rather than the next one.
+    /// </summary>
+    [Test]
+    public void ThePerEngineValueMovesAfterTheEngineIsBuilt()
+    {
+        var engine = NavigatorEngine();
+
+        engine.WebApi.UserAgent = "Moved/2.0";
+        engine.Evaluate("navigator.userAgent").AsString().Should().Be("Moved/2.0");
+        engine.WebApi.UserAgent.Should().Be("Moved/2.0");
+
+        engine.WebApi.UserAgent = null;
+        Regex.IsMatch(engine.Evaluate("navigator.userAgent").AsString(), @"^Jint/\d+\.\d+\.\d+$").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// One engine naming its user agent says nothing about another's: the value is the engine's, not the
+    /// shared <see cref="Options"/> group's.
+    /// </summary>
+    [Test]
+    public void ThePerEngineValueIsNotSharedBetweenEngines()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.Navigator);
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.WebApi.UserAgent = "First/1.0";
+
+        first.Evaluate("navigator.userAgent").AsString().Should().Be("First/1.0");
+        Regex.IsMatch(second.Evaluate("navigator.userAgent").AsString(), @"^Jint/\d+\.\d+\.\d+$").Should().BeTrue();
+    }
+
     [Test]
     public void IsOneStableObjectWithTheInterfacesToStringTag()
     {

--- a/Jint/Engine.WebApi.Operations.cs
+++ b/Jint/Engine.WebApi.Operations.cs
@@ -71,6 +71,35 @@ public partial class Engine
         public WebApiFeatures Features => _engine._webApiFeatures;
 
         /// <summary>
+        /// What <c>navigator.userAgent</c> answers on this engine. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Starts as <see cref="Options.NavigatorOptions.UserAgent"/> — and, when the host named none, as the
+        /// engine's own product token <c>Jint/&lt;version&gt;</c>. Setting it to <see langword="null"/> or the
+        /// empty string puts that default back.
+        /// </para>
+        /// <para>
+        /// <b>Unlike the option, it may be moved after the engine is built</b>, and that is the whole reason
+        /// it exists: a browser's user agent is what a client's <c>Emulation.setUserAgentOverride</c> sets, and
+        /// a page under a client is expected to report the new string without navigating first
+        /// (<see href="https://github.com/sebastienros/jint/issues/3655">#3655</see>). The value is the
+        /// engine's own, so two engines built from one <see cref="Options"/> object never share it.
+        /// </para>
+        /// <para>
+        /// It names what <i>script</i> reads. What a request carries is <see cref="Options.FetchOptions.UserAgent"/>,
+        /// fixed when the engine is built; a host that moves one usually wants to move the other, and a page
+        /// does exactly that through its own network policy.
+        /// </para>
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.AllowNull]
+        public string UserAgent
+        {
+            get => _engine.NavigatorUserAgent;
+            set => _engine.NavigatorUserAgent = value;
+        }
+
+        /// <summary>
         /// Turns on the web APIs a host normally wants — <see cref="WebApiFeatures.Default"/> — on an engine
         /// that already exists. The per-engine counterpart of
         /// <see cref="WebApiOptionsExtensions.UseWebApis(Options)"/>. Requires .NET 8 or higher.

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -109,6 +109,50 @@ public partial class Engine
     internal WebApiFeatures _webApiFeatures;
 
     /// <summary>
+    /// The string <c>navigator.userAgent</c> answers, and the <see cref="JsString"/> the getter hands out.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Engine state rather than an <c>Options</c> value read per get, because it moves after the engine is
+    /// built: a browser's user agent is whatever <c>Emulation.setUserAgentOverride</c> last said, and the
+    /// document already loaded is expected to report it. <see cref="WebApiOperations.UserAgent"/> is the
+    /// public door; <c>Options.WebApi.Navigator.UserAgent</c> is what it starts as.
+    /// </para>
+    /// <para>
+    /// Both fields are <see langword="null"/> until something asks, so an engine whose script never mentions
+    /// <c>navigator</c> allocates neither — and an engine on the default keeps handing out
+    /// <see cref="Jint.WebApi.ProductToken.UserAgentString"/>, the one instance built for the process.
+    /// </para>
+    /// </remarks>
+    private string? _navigatorUserAgent;
+    private JsString? _navigatorUserAgentValue;
+
+    /// <inheritdoc cref="WebApiOperations.UserAgent"/>
+    [System.Diagnostics.CodeAnalysis.AllowNull]
+    internal string NavigatorUserAgent
+    {
+        get => _navigatorUserAgent ??= NamedUserAgent() ?? Jint.WebApi.ProductToken.UserAgent;
+        set
+        {
+            _navigatorUserAgent = string.IsNullOrEmpty(value) ? Jint.WebApi.ProductToken.UserAgent : value;
+            _navigatorUserAgentValue = null;
+        }
+    }
+
+    /// <summary>The <see cref="JsString"/> form, built once per distinct value.</summary>
+    internal JsString NavigatorUserAgentValue
+        => _navigatorUserAgentValue ??= ReferenceEquals(NavigatorUserAgent, Jint.WebApi.ProductToken.UserAgent)
+            ? Jint.WebApi.ProductToken.UserAgentString
+            : JsString.Create(NavigatorUserAgent);
+
+    /// <summary>What the host named, or <see langword="null"/> for an engine that took the default.</summary>
+    private string? NamedUserAgent()
+    {
+        var named = Options.WebApi.Navigator.UserAgent;
+        return string.IsNullOrEmpty(named) ? null : named;
+    }
+
+    /// <summary>
     /// Whether <see cref="Options"/> is a copy this engine took for itself, whose web-API subtree therefore
     /// no other engine reads.
     /// </summary>

--- a/Jint/Options.ReadOnly.cs
+++ b/Jint/Options.ReadOnly.cs
@@ -349,7 +349,7 @@ public sealed partial class Options
 
         void IOptionsGroup.SetReadOnly(bool value)
         {
-            // Published with a barrier for the reason Options.SetReadOnly states: the eight accessors below
+            // Published with a barrier for the reason Options.SetReadOnly states: the nine accessors below
             // read this flag before they publish, and this cascade reads their fields after it.
             Volatile.Write(ref _readOnly, value);
             Thread.MemoryBarrier();
@@ -358,6 +358,7 @@ public sealed partial class Options
             Options.SetReadOnly(_timers, value);
             Options.SetReadOnly(_fetch, value);
             Options.SetReadOnly(_xhr, value);
+            Options.SetReadOnly(_navigator, value);
             Options.SetReadOnly(_diagnostics, value);
             Options.SetReadOnly(_storage, value);
             Options.SetReadOnly(_cache, value);
@@ -366,7 +367,7 @@ public sealed partial class Options
         }
 
         /// <summary>
-        /// Whether <paramref name="group"/> is this group or one of its eight sub-groups.
+        /// Whether <paramref name="group"/> is this group or one of its nine sub-groups.
         /// </summary>
         internal bool Owns(IOptionsGroup group)
             => ReferenceEquals(group, this)
@@ -374,6 +375,7 @@ public sealed partial class Options
                 || ReferenceEquals(group, _timers)
                 || ReferenceEquals(group, _fetch)
                 || ReferenceEquals(group, _xhr)
+                || ReferenceEquals(group, _navigator)
                 || ReferenceEquals(group, _diagnostics)
                 || ReferenceEquals(group, _storage)
                 || ReferenceEquals(group, _cache)
@@ -400,6 +402,21 @@ public sealed partial class Options
             if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Messaging." + setting);
+            }
+        }
+    }
+
+    public sealed partial class NavigatorOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive(this))
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Navigator." + setting);
             }
         }
     }

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -124,6 +124,14 @@ public sealed partial class Options
         private XhrOptions? _xhr;
 
         /// <summary>
+        /// Settings for the <c>navigator</c> object, installed when <see cref="Features"/> contains
+        /// <see cref="WebApiFeatures.Navigator"/>.
+        /// </summary>
+        public NavigatorOptions Navigator => Materialize(ref _navigator, ref _readOnly);
+
+        private NavigatorOptions? _navigator;
+
+        /// <summary>
         /// Where the engine reports script errors nobody caught. Unlike everything else in this group it is
         /// not tied to a feature flag: setting <see cref="DiagnosticsOptions.Sink"/> arms the channel by
         /// itself, and <see cref="WebApiFeatures.Reporting"/> additionally gives script the
@@ -176,6 +184,7 @@ public sealed partial class Options
             clone._timers = _timers?.Clone();
             clone._fetch = _fetch?.Clone();
             clone._xhr = _xhr?.Clone();
+            clone._navigator = _navigator?.Clone();
             clone._diagnostics = _diagnostics?.Clone();
             clone._storage = _storage?.Clone();
             clone._cache = _cache?.Clone();
@@ -218,6 +227,56 @@ public sealed partial class Options
         public BroadcastChannelBroker? Broker { get; set { ThrowIfReadOnly(); field = value; } }
 
         internal MessagingOptions Clone() => (MessagingOptions) MemberwiseClone();
+    }
+
+    /// <summary>
+    /// Settings for the <c>navigator</c> object. Requires .NET 8 or higher.
+    /// </summary>
+    /// <remarks>
+    /// Like every other option group this may be shared by any number of engines, including concurrent ones:
+    /// nothing on it is engine-affine.
+    /// </remarks>
+    public sealed partial class NavigatorOptions
+    {
+        /// <summary>
+        /// Creates the group with its defaults, which is what an engine that names none of them gets.
+        /// </summary>
+        /// <remarks>
+        /// Declared rather than left implicit because <c>Jint.Tests.PublicInterface</c>'s allowlist of
+        /// undocumented public declarations may only ever shrink, and every other option group's constructor
+        /// is already on it.
+        /// </remarks>
+        public NavigatorOptions()
+        {
+        }
+
+        /// <summary>
+        /// What <c>navigator.userAgent</c> answers. <see langword="null"/> or the empty string — the default —
+        /// is the engine's own product token, <c>Jint/&lt;version&gt;</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The default is deliberately the truth</b>, and README's WinterTC section says why: a script that
+        /// branches on the runtime it is on should get the runtime it is on, and an embedded interpreter
+        /// claiming to be a browser is a lie a page cannot check. The host that this is wrong for is a
+        /// <i>browser</i> — a page's scripts sniff <c>navigator.userAgent</c>, and CDP's
+        /// <c>Emulation.setUserAgentOverride</c> exists to set it — so naming one is the host's decision to
+        /// make explicitly rather than a default anybody inherits.
+        /// </para>
+        /// <para>
+        /// Read once, when the engine is built; <see cref="Engine.WebApiOperations.UserAgent"/> is the same
+        /// value afterwards and may be moved on a live engine, which is what an override a client sets
+        /// between navigations needs.
+        /// </para>
+        /// <para>
+        /// It names <i>script's</i> answer alone. What a request carries is
+        /// <see cref="FetchOptions.UserAgent"/>, which defaults to the same token — an engine that says one
+        /// thing to script and another on the wire is a defect, so a host naming one usually names both.
+        /// </para>
+        /// </remarks>
+        public string? UserAgent { get; set { ThrowIfReadOnly(); field = value; } }
+
+        internal NavigatorOptions Clone() => (NavigatorOptions) MemberwiseClone();
     }
 
     /// <summary>

--- a/Jint/WebApi/Navigator/NavigatorPrototype.cs
+++ b/Jint/WebApi/Navigator/NavigatorPrototype.cs
@@ -62,14 +62,6 @@ internal sealed partial class NavigatorPrototype : Prototype
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
     private static readonly JsString NavigatorToStringTag = new("Navigator");
 
-    /// <summary>
-    /// The user agent string, built once for the process: the assembly version cannot change while it is
-    /// loaded, so every engine and every realm hands out this one <see cref="JsString"/>. The token is
-    /// <see cref="ProductToken.UserAgent"/>, which is also the <c>User-Agent</c> a request carries when the
-    /// host named none of its own — what a script reads and what the wire carries are one string.
-    /// </summary>
-    private static readonly JsString UserAgent = new(ProductToken.UserAgent);
-
     internal NavigatorPrototype(
         Engine engine,
         Realm realm,
@@ -91,15 +83,24 @@ internal sealed partial class NavigatorPrototype : Prototype
     /// <c>NavigatorID</c> mixin's <c>userAgent</c> attribute, which is where WinterTC's
     /// <c>globalThis.navigator.userAgent</c> requirement lands.
     /// </summary>
+    /// <remarks>
+    /// The value is the engine's — <see cref="Engine.WebApiOperations.UserAgent"/>, which starts as
+    /// <c>Options.WebApi.Navigator.UserAgent</c> and defaults to <see cref="ProductToken.UserAgent"/>. It is
+    /// read here rather than captured, because a host may move it after the engine was built: a browser's is
+    /// whatever a client's <c>Emulation.setUserAgentOverride</c> last said, and the page reads this one
+    /// accessor rather than shadowing it with an own property of its own
+    /// (<see href="https://github.com/sebastienros/jint/issues/3655">#3655</see>).
+    /// </remarks>
     [JsAccessor("userAgent", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsString UserAgentGet(JsValue thisObject)
     {
-        if (thisObject is not JsNavigator)
+        if (thisObject is not JsNavigator navigator)
         {
             Throw.TypeError(_realm, "Failed to read the 'userAgent' property from 'Navigator': illegal invocation, receiver is not a Navigator object.");
+            return JsString.Empty;
         }
 
-        return UserAgent;
+        return navigator.Engine.NavigatorUserAgentValue;
     }
 }
 #endif

--- a/Jint/WebApi/ProductToken.cs
+++ b/Jint/WebApi/ProductToken.cs
@@ -24,6 +24,12 @@ internal static class ProductToken
     internal static string UserAgent { get; } = "Jint/" + ProductVersion();
 
     /// <summary>
+    /// The same token as a <see cref="Native.JsString"/>, for the engines that took the default: the version
+    /// cannot change while the assembly is loaded, so every realm of every such engine hands out this one.
+    /// </summary>
+    internal static Native.JsString UserAgentString { get; } = new(UserAgent);
+
+    /// <summary>
     /// The <c>product-version</c> half of the token: Jint's own assembly version, as
     /// <c>major.minor.patch</c>. The fourth component is dropped because Jint never sets one, and the whole
     /// thing degrades to <c>"0.0.0"</c> rather than throwing if the assembly somehow carries no version.

--- a/README.md
+++ b/README.md
@@ -697,11 +697,31 @@ new PerformanceObserver(list => {
 }).observe({ type: 'measure', buffered: true });
 ```
 
-`navigator` carries `userAgent` and nothing else. It reports `Jint/<version>` — a single RFC 7231 product
-token with no comment component, so nothing about your operating system or your application leaks into it —
-and it is there because [WinterTC's Minimum Common API](https://min-common-api.proposal.wintertc.org/)
+`navigator` carries `userAgent` and nothing else. It reports `Jint/<version>` by default — a single RFC 7231
+product token with no comment component, so nothing about your operating system or your application leaks into
+it — and it is there because [WinterTC's Minimum Common API](https://min-common-api.proposal.wintertc.org/)
 requires `globalThis.navigator.userAgent` of a conforming runtime. Everything else a browser's `Navigator`
 carries describes a user agent with a user, a document and a network stack, so it is absent rather than faked.
+
+**The default is deliberately the truth: a script that branches on the runtime it is on should get the runtime
+it is on.** The host that is wrong for is a browser, whose pages sniff `navigator.userAgent`, so naming one is
+explicit rather than inherited:
+
+```csharp
+var engine = new Engine(options =>
+{
+    options.UseWebApis();
+    options.WebApi.Navigator.UserAgent = "Mozilla/5.0 (compatible; MyHost/1.0)";  // what script reads
+    options.WebApi.Fetch.UserAgent = "Mozilla/5.0 (compatible; MyHost/1.0)";      // what the wire carries
+});
+
+engine.WebApi.UserAgent = "Mozilla/5.0 (compatible; MyHost/2.0)";  // and it moves on a live engine
+```
+
+Naming only one of the two is how an engine comes to say one thing to script and another on the wire, so name
+both. Setting either to `null` or `""` puts `Jint/<version>` back. `Jint.Browser` uses exactly this seam: a
+page's user agent is `BrowserOptions.UserAgent` and whatever a client's `Emulation.setUserAgentOverride` last
+said.
 
 `Navigator` is a real interface object, so `navigator instanceof Navigator` holds and `userAgent` lives on
 `Navigator.prototype` where a browser's and Node's do — which is why `Object.keys(navigator)` and

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5376,6 +5376,26 @@ lane it did not before — a long-lived stream at that, so an observer that buff
 its own is the one to look at. The enum's own documentation already said new members may appear and that a
 `switch` over it wants a default arm.
 
+### 4.127 `navigator.userAgent` is the host's to name ([#3655](https://github.com/sebastienros/jint/issues/3655))
+
+`navigator.userAgent` was a fixed `Jint/<version>` with no way to change it. It is now
+`Options.WebApi.Navigator.UserAgent`, read when the engine is built, and `Engine.WebApi.UserAgent`, which
+moves it on an engine that already exists. **The default is unchanged**, so an engine that names neither
+reports exactly what it reported before and nothing has to be done to migrate.
+
+What a host that wants its own string writes:
+
+```csharp
+var engine = new Engine(options =>
+{
+    options.UseWebApis();
+    options.WebApi.Navigator.UserAgent = "Mozilla/5.0 (compatible; MyHost/1.0)";
+});
+```
+
+`null` and `""` both mean the default. `Options.WebApi.Fetch.UserAgent` ([§4.125](#4125-every-request-the-engine-makes-carries-a-user-agent-3720))
+is the other half — what a request carries — and a host that names one usually wants to name both.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Closes #3655

## What #3747 left, and what it did not

#3747 gave the engine `Options.WebApi.Fetch.UserAgent` — what a *request* carries — and said in as many words that `navigator.userAgent` stays unconfigurable. So the issue is not closed by it, and its own status comment says what remains: "the WebIDL shape … the engine option this issue asks for is what would let the browser stop shadowing."

## What failed before

`navigator.userAgent` was a fixed `Jint/<version>` with nothing to change it, so `Jint.Browser` shadowed the member with an own property of the page's `navigator` instance. A page therefore had **two** answers to one IDL attribute, measured:

```
navigator.userAgent                                                Mozilla/5.0 (compatible; Jint.Browser/5.0.0; …)
Object.getOwnPropertyDescriptor(Navigator.prototype,'userAgent')
    .get.call(navigator)                                           Jint/5.0.0
Object.getOwnPropertyNames(navigator).includes('userAgent')        true      (a browser: false)
```

The second is the accessor the standard declares, and it is the one a script that hardens itself against tampering reaches for.

## What changed

**The engine names its own.** `Options.WebApi.Navigator.UserAgent` is read when the engine is built; `Engine.WebApi.UserAgent` moves it afterwards. `null` and `""` both mean the default, and **the default is unchanged** — an engine that names neither reports exactly what it reported before, so there is nothing to migrate.

**The per-engine half is not optional, and that is the one place the issue's plan needed correcting.** The issue judged "construction-time is enough given one engine per navigation". It is not: `Emulation.setUserAgentOverride` is expected to reach the document *already loaded*, and `EmulationDomainTests.TheUserAgentOverrideIsWhatTheNavigatorAnswers` and `EitherUserAgentCommandMovesBothTheNavigatorAndTheHeader` both pin that today. A construction-time-only option would have regressed it, so the value is engine state with the option as its starting point.

**`Jint.Browser` stops shadowing.** `BrowserEngineFactory` sets the navigator option beside the `Fetch` one it already set, so what script reads and what the wire carries start as one string. A later change is carried across by `EmulationState.ApplyUserAgentOverride` — one method where `EmulationDomain` and `NetworkDomain` had a copy each, so this removes a duplication rather than adding one. That is a **publish, not a second resolution**: `EffectiveUserAgent` stays the only place the precedence is decided, which is the property its own remarks are about.

`navigator`'s other eight members stay own properties of the instance, for the reason `NavigatorInstaller` already gives — the engine's `Navigator.prototype` is a shared shaped object and a property it did not declare would cost every realm its prototype-method inline cache. `userAgent` is the one the engine *does* declare, so it is the one that could move.

## What was verified

Three browser tests, all red against unfixed code:

```
Failed OneUserAgentAnswersWhicheverWayAPageReadsIt
  Expected … "Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get.call(navigator)"
  to be the same string because the accessor the standard declares is the one that has to answer,
  but they differ at index 0
Failed TheUserAgentIsNotAnOwnPropertyOfTheNavigator
  Expected … "Object.getOwnPropertyNames(navigator).includes('userAgent')" to be False
  because WebIDL puts a readonly attribute on the interface prototype object, but found True
```

Plus a third that pins the brand check surviving the move, and nine engine cases in `Jint.Tests` for the option, the per-engine value, clearing it, and two engines built from one `Options` object not sharing it.

- `Jint.Tests` — 12 290 passed on `net8.0` and `net10.0`, 8 492 on `net472`, 0 failed.
- `Jint.Tests.Browser` — 1 686 / 1 690, 0 failed (includes the `Emulation` and `Network` domain suites and `UserAgentTests`).
- `Jint.Tests.PublicInterface` — 3 597 / 3 607 / 2 879, 0 failed, with the `net8.0` and `net10.0` API baselines approved for the three new members.

`NavigatorOptions` declares its constructor rather than leaving it implicit, because the undocumented-public-API allowlist may only ever shrink and every other option group's constructor is already on it.

Docs: README's WinterTC note now says why the default is the truth and which host it is wrong for, with both halves named together; `docs/v5-migration.md` §4.127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
