### PR TITLE
Network.setUserAgentOverride's platform reaches the document already loaded, which is what the code did and the opposite of what it said

### DIFF
--- a/Jint.Browser/DevTools/EmulationDomain.cs
+++ b/Jint.Browser/DevTools/EmulationDomain.cs
@@ -172,17 +172,7 @@ internal sealed class EmulationDomain : EmulationDomainBase
         // One override for two commands: Chrome treats Emulation.setUserAgentOverride and
         // Network.setUserAgentOverride as the same setting, and the page's EmulationState is the one place
         // both write — what navigator.userAgent answers and what PageNetworkPolicy puts on every request.
-        State.UserAgent = parameters.UserAgent;
-
-        if (parameters.AcceptLanguage is { Length: > 0 } language)
-        {
-            State.AcceptLanguage = language;
-        }
-
-        if (parameters.Platform is { Length: > 0 } platform)
-        {
-            State.Platform = platform;
-        }
+        State.ApplyUserAgentOverride(parameters.UserAgent, parameters.AcceptLanguage, parameters.Platform);
 
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }

--- a/Jint.Browser/DevTools/NetworkDomain.cs
+++ b/Jint.Browser/DevTools/NetworkDomain.cs
@@ -122,10 +122,15 @@ internal sealed partial class NetworkDomain : NetworkDomainBase, IDetachableDoma
     /// <c>Accept-Language</c> header on the same terms.
     /// </para>
     /// <para>
-    /// <b><c>platform</c> reaches the next document, not this one.</b> <c>navigator.platform</c> is installed
-    /// when a page engine is built, so a client that sets it after the document is parsed has set it for the
-    /// navigation that follows — which is what Chrome documents too. <c>userAgentMetadata</c> is accepted and
-    /// dropped: this browser publishes no client hints for it to fill in.
+    /// <b><c>platform</c> reaches the document that is already loaded</b>, like the other two.
+    /// <c>navigator.platform</c> is an accessor over the page's own <c>EmulationState</c> rather than a value
+    /// captured when the engine was built, so it answers the new string on the next read and a client needs no
+    /// navigation to see it. This paragraph used to say the opposite
+    /// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 5), which would have
+    /// cost a client a reload it never needed;
+    /// <c>NetworkDomainTests.TheNetworkCommandsPlatformReachesTheDocumentAlreadyLoaded</c> is what now holds
+    /// the claim to the code. <c>userAgentMetadata</c> is accepted and dropped: this browser publishes no
+    /// client hints for it to fill in.
     /// </para>
     /// </remarks>
     protected override ValueTask<EmptyResult> SetUserAgentOverrideAsync(SetUserAgentOverrideRequest parameters, CommandContext context)

--- a/Jint.Browser/DevTools/NetworkDomain.cs
+++ b/Jint.Browser/DevTools/NetworkDomain.cs
@@ -132,17 +132,7 @@ internal sealed partial class NetworkDomain : NetworkDomainBase, IDetachableDoma
     {
         // The page's EmulationState is the one place either command writes; PageNetworkPolicy reads it while
         // composing a request, and navigator reads it in script, so the two can never disagree.
-        _target.Emulation.UserAgent = parameters.UserAgent;
-
-        if (parameters.AcceptLanguage is { Length: > 0 } language)
-        {
-            _target.Emulation.AcceptLanguage = language;
-        }
-
-        if (parameters.Platform is { Length: > 0 } platform)
-        {
-            _target.Emulation.Platform = platform;
-        }
+        _target.Emulation.ApplyUserAgentOverride(parameters.UserAgent, parameters.AcceptLanguage, parameters.Platform);
 
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }

--- a/Jint.Browser/Runtime/BrowserEngineFactory.cs
+++ b/Jint.Browser/Runtime/BrowserEngineFactory.cs
@@ -180,8 +180,10 @@ internal static class BrowserEngineFactory
         // https://fetch.spec.whatwg.org/#default-user-agent-value: what this document's fetches, its
         // XMLHttpRequests and — through the worker provider — its workers put on the wire is the same string
         // navigator.userAgent answers. An override a client sets *after* the engine was built reaches the
-        // wire through PageNetworkState.Apply, which rewrites the header per hop.
+        // wire through PageNetworkState.Apply, which rewrites the header per hop, and reaches script through
+        // Engine.WebApi.UserAgent, which EmulationState publishes to the engine showing the document.
         fetch.UserAgent = request.Emulation.EffectiveUserAgent;
+        options.WebApi.Navigator.UserAgent = request.Emulation.EffectiveUserAgent;
 
         if (request.Network.Client is { } client)
         {

--- a/Jint.Browser/Runtime/EmulationState.cs
+++ b/Jint.Browser/Runtime/EmulationState.cs
@@ -99,6 +99,48 @@ internal sealed class EmulationState
     /// </remarks>
     internal string EffectiveUserAgent => UserAgent is { Length: > 0 } overridden ? overridden : DefaultUserAgent;
 
+    /// <summary>
+    /// Called on the page loop whenever <see cref="EffectiveUserAgent"/> may have changed, so the engine
+    /// showing the document can be told. Set by the page runtime for the engine it currently owns.
+    /// </summary>
+    /// <remarks>
+    /// <b>It is a publish rather than a second resolution.</b> <c>navigator.userAgent</c> is now the engine's
+    /// own accessor, and an engine holds a string rather than a view of this object — so something has to
+    /// carry the new value across, and this is the one place that does. The resolution above stays the only
+    /// one there is, which is the property <see cref="EffectiveUserAgent"/>'s remarks are about.
+    /// </remarks>
+    internal Action<string>? UserAgentChanged { get; set; }
+
+    /// <summary>
+    /// <c>Emulation.setUserAgentOverride</c> and <c>Network.setUserAgentOverride</c>, which Chrome treats as
+    /// one setting and which are one write here.
+    /// <para>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setUserAgentOverride
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// All three reach the document that is <i>already loaded</i>: the user agent because the engine is told,
+    /// and the language and the platform because <c>NavigatorInstaller</c> reads this object per get. An
+    /// absent <c>acceptLanguage</c> or <c>platform</c> leaves the one already set, which is what a client
+    /// sending only a user agent expects.
+    /// </remarks>
+    internal void ApplyUserAgentOverride(string? userAgent, string? acceptLanguage, string? platform)
+    {
+        UserAgent = userAgent;
+
+        if (acceptLanguage is { Length: > 0 } language)
+        {
+            AcceptLanguage = language;
+        }
+
+        if (platform is { Length: > 0 } named)
+        {
+            Platform = named;
+        }
+
+        UserAgentChanged?.Invoke(EffectiveUserAgent);
+    }
+
     /// <summary>What <c>navigator.language</c> answers when a user agent override named one.</summary>
     internal string? AcceptLanguage { get; set; }
 

--- a/Jint.Browser/Runtime/EmulationState.cs
+++ b/Jint.Browser/Runtime/EmulationState.cs
@@ -16,8 +16,10 @@ namespace Jint.Browser.Runtime;
 /// </para>
 /// <para>
 /// <b>Three groups, and what separates them is when they become effective.</b> The viewport, the media
-/// features, touch, focus, geolocation, the user agent and the hardware concurrency are read on every
-/// access, so setting one moves the document that is already loaded. The time zone and the locale are
+/// features, touch, focus, geolocation, the user agent, the platform, the language and the hardware
+/// concurrency are read on every access, so setting one moves the document that is already loaded - the user
+/// agent by being published to the engine showing it, and the rest because <c>NavigatorInstaller</c> and the
+/// media environment read this object per get. The time zone and the locale are
 /// <c>Options</c> the engine is <i>constructed</i> from, so they reach the next document and the command
 /// says so. Script execution is the document's, decided when its parse starts.
 /// </para>
@@ -145,6 +147,11 @@ internal sealed class EmulationState
     internal string? AcceptLanguage { get; set; }
 
     /// <summary>What <c>navigator.platform</c> answers, or <see langword="null"/> for the empty string.</summary>
+    /// <remarks>
+    /// Read per get by <c>NavigatorInstaller</c>, so it moves the document that is already loaded rather than
+    /// the next one. Unlike the user agent it needs no publish, because it is one of the page's own members
+    /// and not one the engine's <c>Navigator</c> declares.
+    /// </remarks>
     internal string? Platform { get; set; }
 
     /// <summary>Whether the client asked for the cache to be bypassed. There is no cache to bypass.</summary>

--- a/Jint.Browser/Runtime/NavigatorInstaller.cs
+++ b/Jint.Browser/Runtime/NavigatorInstaller.cs
@@ -31,9 +31,14 @@ namespace Jint.Browser.Runtime;
 /// members are inherited, and an own enumerable accessor would put every one of them in an object spread.
 /// </para>
 /// <para>
-/// <b><c>userAgent</c> is shadowed rather than left to the prototype</b>, because the page's user agent is
-/// <see cref="BrowserOptions.UserAgent"/> and a client's override, not <c>Jint/&lt;version&gt;</c> — and
-/// because it has to be the same string every request the page makes carries.
+/// <b><c>userAgent</c> is the exception, and it is left to the prototype.</b> The page's user agent is
+/// <see cref="BrowserOptions.UserAgent"/> and a client's override rather than <c>Jint/&lt;version&gt;</c>, and
+/// it used to be shadowed here to say so — which meant two answers to one IDL attribute, since the accessor
+/// the standard declares on <c>Navigator.prototype</c> went on answering the engine's own token
+/// (<see href="https://github.com/sebastienros/jint/issues/3655">#3655</see>). The engine now names its own:
+/// <c>Options.WebApi.Navigator.UserAgent</c> is what a page's engine is built with and
+/// <c>Engine.WebApi.UserAgent</c> is what an override moves, so one accessor answers and there is nothing
+/// here to shadow it with.
 /// </para>
 /// <para>
 /// The whole object is installed as a lazy global, so a page that never mentions <c>navigator</c> builds
@@ -69,9 +74,6 @@ internal static class NavigatorInstaller
             PropertyFlag.ConfigurableEnumerableWritable);
     }
 
-    /// <summary>What <c>navigator.userAgent</c> answers and what every request the page makes carries.</summary>
-    internal static string UserAgentOf(PageRuntime runtime) => runtime.Emulation.EffectiveUserAgent;
-
     /// <summary>
     /// What <c>navigator.language</c> answers: the first tag of the <c>Accept-Language</c> a user-agent
     /// override named, and otherwise the engine's own culture.
@@ -95,7 +97,8 @@ internal static class NavigatorInstaller
 
     private static void Attach(Engine engine, ObjectInstance navigator)
     {
-        Accessor(engine, navigator, "userAgent", static runtime => JsString.Create(UserAgentOf(runtime)));
+        // userAgent is deliberately absent: it is the one member the engine's own Navigator already declares,
+        // and Engine.WebApi.UserAgent is what carries the page's string to it.
         Accessor(engine, navigator, "language", static runtime => JsString.Create(LanguageOf(runtime)));
         Accessor(engine, navigator, "languages", static runtime => Languages(runtime));
         Accessor(engine, navigator, "platform", static runtime => JsString.Create(runtime.Emulation.Platform ?? ""));

--- a/Jint.Browser/Runtime/PageRuntime.cs
+++ b/Jint.Browser/Runtime/PageRuntime.cs
@@ -62,6 +62,12 @@ internal sealed class PageRuntime
         MutationObservers = new Observers.MutationObserverLane(this);
         Layout = new Layout.PageLayout(this);
         _started = System.Diagnostics.Stopwatch.GetTimestamp();
+
+        // The engine was built with this page's user agent already on it; what this adds is the *later*
+        // half. `navigator.userAgent` is the engine's own accessor now, so an override a client sets on a
+        // document that is already loaded has to be carried across rather than read through - and it is
+        // re-pointed here per navigation, because the engine it names is the one showing the document.
+        emulation.UserAgentChanged = userAgent => engine.WebApi.UserAgent = userAgent;
     }
 
     /// <summary>The engine this page runs in.</summary>

--- a/Jint.Tests.Browser/DevTools/NetworkDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/NetworkDomainTests.cs
@@ -279,6 +279,53 @@ public class NetworkDomainTests
         server.Received.Should().BeEmpty("offline means no socket is opened at all");
     }
 
+    /// <summary>
+    /// <c>Network.setUserAgentOverride</c>'s three parameters all reach the document that is <b>already
+    /// loaded</b>, with no navigation in between —
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setUserAgentOverride.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This is the claim that was wrong rather than the code</b>
+    /// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 5). The command's own
+    /// documentation said <c>platform</c> reached the <i>next</i> document because "navigator.platform is
+    /// installed when a page engine is built" — but it is not installed as a value, it is an accessor over
+    /// the page's own <c>EmulationState</c>, so it has always answered on the next read. A client that
+    /// believed the comment would have reloaded a page for nothing.
+    /// </para>
+    /// <para>
+    /// <c>EmulationDomainTests.TheUserAgentOverrideIsWhatTheNavigatorAnswers</c> is the same assertion for
+    /// the <c>Emulation</c> spelling of the command; the two write one field, and only that one was covered.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task TheNetworkCommandsPlatformReachesTheDocumentAlreadyLoaded()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await NetworkFixture.OpenAsync(server);
+        await fixture.NavigateAsync("/page");
+
+        (await fixture.Page.EvaluateAsync<string>("navigator.platform")).Should().BeEmpty();
+
+        await fixture.Session.ResultAsync(
+            "Network.setUserAgentOverride",
+            """{"userAgent":"ViaNetwork/1.0","acceptLanguage":"sv-SE","platform":"Win32"}""",
+            fixture.Attachment);
+
+        // No navigation between the command and the read: this is the document the command arrived on.
+        (await fixture.Page.EvaluateAsync<string>("navigator.platform")).Should().Be("Win32");
+        (await fixture.Page.EvaluateAsync<string>("navigator.userAgent")).Should().Be("ViaNetwork/1.0");
+        (await fixture.Page.EvaluateAsync<string>("navigator.language")).Should().Be("sv-SE");
+
+        // And it outlives the document, because the override is the page's rather than the engine's.
+        await fixture.NavigateAsync("/page");
+
+        (await fixture.Page.EvaluateAsync<string>("navigator.platform")).Should().Be("Win32");
+        (await fixture.Page.EvaluateAsync<string>("navigator.userAgent")).Should().Be("ViaNetwork/1.0");
+    }
+
     [Test]
     public async Task CookiesRoundTripThroughTheContextsJar()
     {

--- a/Jint.Tests.Browser/Runtime/NavigatorTests.cs
+++ b/Jint.Tests.Browser/Runtime/NavigatorTests.cs
@@ -1,0 +1,85 @@
+using Jint.Browser;
+using Jint.Tests.Browser.Navigation;
+
+namespace Jint.Tests.Browser.Runtime;
+
+/// <summary>
+/// A page's <c>navigator</c>: the members an embedded interpreter has no business publishing, and the one
+/// member the engine already had.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine's <c>Navigator</c> carries <c>userAgent</c> alone, because WinterTC's Minimum Common API
+/// requires it and everything else on HTML's interface describes a user agent with a user, a document and a
+/// network stack. A page <i>is</i> that, so the rest arrive here — and the one they share has to answer the
+/// page's string rather than the engine's, whichever way a script reads it.
+/// </para>
+/// <para>
+/// <c>Emulation.setUserAgentOverride</c> reading back through the same member is
+/// <c>DevTools/EmulationDomainTests</c>; this file is what a page sees with no client attached.
+/// </para>
+/// </remarks>
+public sealed class NavigatorTests
+{
+    private const string Ua = "Mozilla/5.0 (compatible; Probe/1.0)";
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent, read the two ways a
+    /// page can read it. Before <see href="https://github.com/sebastienros/jint/issues/3655">#3655</see> the
+    /// page shadowed <c>userAgent</c> with an own property, so the accessor WebIDL puts on
+    /// <c>Navigator.prototype</c> still answered the engine's <c>Jint/&lt;version&gt;</c> — two answers to
+    /// one IDL attribute, and the second is the one a script that hardens against tampering reaches for.
+    /// </summary>
+    [Test]
+    public async Task OneUserAgentAnswersWhicheverWayAPageReadsIt()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(configureBrowser: options => options.UserAgent = Ua);
+
+        await fixture.Page.SetContentAsync("<p>ok</p>");
+
+        (await fixture.Page.EvaluateAsync<string>("navigator.userAgent")).Should().Be(Ua);
+        (await fixture.Page.EvaluateAsync<string>(
+                "Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get.call(navigator)"))
+            .Should().Be(Ua, "the accessor the standard declares is the one that has to answer");
+    }
+
+    /// <summary>
+    /// And it is the prototype's, so the instance has no own <c>userAgent</c> at all — which is what a
+    /// browser answers and what idlharness asserts.
+    /// </summary>
+    [Test]
+    public async Task TheUserAgentIsNotAnOwnPropertyOfTheNavigator()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(configureBrowser: options => options.UserAgent = Ua);
+
+        await fixture.Page.SetContentAsync("<p>ok</p>");
+
+        (await fixture.Page.EvaluateAsync<bool>("Object.getOwnPropertyNames(navigator).includes('userAgent')"))
+            .Should().BeFalse("WebIDL puts a readonly attribute on the interface prototype object");
+
+        // The members the engine's Navigator does not have are still the page's own, and still hidden from
+        // Object.keys the way an inherited member would be.
+        (await fixture.Page.EvaluateAsync<bool>("Object.getOwnPropertyNames(navigator).includes('platform')"))
+            .Should().BeTrue();
+        (await fixture.Page.EvaluateAsync<double>("Object.keys(navigator).length")).Should().Be(0);
+    }
+
+    /// <summary>
+    /// The brand check survives the move: the getter is the interface's, so extracting it and calling it on
+    /// something that is not a <c>Navigator</c> is a <c>TypeError</c> exactly as a browser answers.
+    /// </summary>
+    [Test]
+    public async Task TheUserAgentGetterStillBrandChecksItsReceiver()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(configureBrowser: options => options.UserAgent = Ua);
+
+        await fixture.Page.SetContentAsync("<p>ok</p>");
+
+        (await fixture.Page.EvaluateAsync<string>("""
+            (() => {
+              const get = Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get;
+              try { get.call({}); return 'no throw'; } catch (e) { return e.constructor.name; }
+            })()
+            """)).Should().Be("TypeError");
+    }
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -142,6 +142,7 @@ namespace Jint
         {
             public Jint.WebApiFeatures Features { get; }
             public bool HasFetchHandler { get; }
+            public string UserAgent { get; set; }
             public System.Threading.Tasks.Task<long> CopyReadableStreamAsync(Jint.Native.JsValue readableStream, System.IO.Stream destination, Jint.WebApi.HostStreamCopyOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { }
             public Jint.Native.JsValue CreateAbortSignal(System.Threading.CancellationToken cancellationToken) { }
             public Jint.WebApi.MessagePortPair CreateMessagePortPair(Jint.Engine other) { }
@@ -404,6 +405,11 @@ namespace Jint
             public Jint.Runtime.Modules.IModuleLoader ModuleLoader { get; set; }
             public bool RegisterRequire { get; set; }
         }
+        public sealed class NavigatorOptions
+        {
+            public NavigatorOptions() { }
+            public string? UserAgent { get; set; }
+        }
         public sealed class ParsingOptions
         {
             public ParsingOptions() { }
@@ -446,6 +452,7 @@ namespace Jint
             public Jint.WebApiFeatures Features { get; set; }
             public Jint.Options.FetchOptions Fetch { get; }
             public Jint.Options.MessagingOptions Messaging { get; }
+            public Jint.Options.NavigatorOptions Navigator { get; }
             public Jint.Options.StorageOptions Storage { get; }
             public Jint.Options.TimerOptions Timers { get; }
             public Jint.Options.WorkerOptions Workers { get; }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -142,6 +142,7 @@ namespace Jint
         {
             public Jint.WebApiFeatures Features { get; }
             public bool HasFetchHandler { get; }
+            public string UserAgent { get; set; }
             public System.Threading.Tasks.Task<long> CopyReadableStreamAsync(Jint.Native.JsValue readableStream, System.IO.Stream destination, Jint.WebApi.HostStreamCopyOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { }
             public Jint.Native.JsValue CreateAbortSignal(System.Threading.CancellationToken cancellationToken) { }
             public Jint.WebApi.MessagePortPair CreateMessagePortPair(Jint.Engine other) { }
@@ -404,6 +405,11 @@ namespace Jint
             public Jint.Runtime.Modules.IModuleLoader ModuleLoader { get; set; }
             public bool RegisterRequire { get; set; }
         }
+        public sealed class NavigatorOptions
+        {
+            public NavigatorOptions() { }
+            public string? UserAgent { get; set; }
+        }
         public sealed class ParsingOptions
         {
             public ParsingOptions() { }
@@ -446,6 +452,7 @@ namespace Jint
             public Jint.WebApiFeatures Features { get; set; }
             public Jint.Options.FetchOptions Fetch { get; }
             public Jint.Options.MessagingOptions Messaging { get; }
+            public Jint.Options.NavigatorOptions Navigator { get; }
             public Jint.Options.StorageOptions Storage { get; }
             public Jint.Options.TimerOptions Timers { get; }
             public Jint.Options.WorkerOptions Workers { get; }

--- a/Jint.Tests/Runtime/WebApi/NavigatorTests.cs
+++ b/Jint.Tests/Runtime/WebApi/NavigatorTests.cs
@@ -32,6 +32,80 @@ public class NavigatorTests
         userAgent.Should().Be($"Jint/{version.Major}.{version.Minor}.{version.Build}");
     }
 
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent - the user agent is
+    /// the host's to name. A browser is the host for which the engine's own product token is wrong: a page's
+    /// scripts sniff it and CDP's <c>Emulation.setUserAgentOverride</c> exists to set it, so
+    /// <c>Options.WebApi.Navigator.UserAgent</c> is what names it and the default is unchanged.
+    /// </summary>
+    [Test]
+    public void TheHostCanNameTheUserAgent()
+    {
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Navigator);
+            options.WebApi.Navigator.UserAgent = "Pretend/1.0 (compatible)";
+        });
+
+        engine.Evaluate("navigator.userAgent").AsString().Should().Be("Pretend/1.0 (compatible)");
+
+        // Still the prototype accessor WebIDL asks for, not an own property of the instance.
+        engine.Evaluate("Object.getOwnPropertyNames(navigator).length").AsNumber().Should().Be(0);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(Navigator.prototype, 'userAgent').get.call(navigator)")
+            .AsString().Should().Be("Pretend/1.0 (compatible)");
+    }
+
+    /// <summary>
+    /// The empty string and <see langword="null"/> both mean "the engine's own", so a host clearing the
+    /// option gets the default back rather than an empty user agent - which is a string a page branches on.
+    /// </summary>
+    [TestCase(null)]
+    [TestCase("")]
+    public void ClearingTheOptionRestoresTheProductToken(string? value)
+    {
+        var engine = new Engine(options =>
+        {
+            options.UseWebApis(WebApiFeatures.Navigator);
+            options.WebApi.Navigator.UserAgent = value;
+        });
+
+        Regex.IsMatch(engine.Evaluate("navigator.userAgent").AsString(), @"^Jint/\d+\.\d+\.\d+$").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// And it moves on a live engine, because a browser's does: an override a client sets reaches the
+    /// document that is already loaded rather than the next one.
+    /// </summary>
+    [Test]
+    public void ThePerEngineValueMovesAfterTheEngineIsBuilt()
+    {
+        var engine = NavigatorEngine();
+
+        engine.WebApi.UserAgent = "Moved/2.0";
+        engine.Evaluate("navigator.userAgent").AsString().Should().Be("Moved/2.0");
+        engine.WebApi.UserAgent.Should().Be("Moved/2.0");
+
+        engine.WebApi.UserAgent = null;
+        Regex.IsMatch(engine.Evaluate("navigator.userAgent").AsString(), @"^Jint/\d+\.\d+\.\d+$").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// One engine naming its user agent says nothing about another's: the value is the engine's, not the
+    /// shared <see cref="Options"/> group's.
+    /// </summary>
+    [Test]
+    public void ThePerEngineValueIsNotSharedBetweenEngines()
+    {
+        var options = new Options().UseWebApis(WebApiFeatures.Navigator);
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        first.WebApi.UserAgent = "First/1.0";
+
+        first.Evaluate("navigator.userAgent").AsString().Should().Be("First/1.0");
+        Regex.IsMatch(second.Evaluate("navigator.userAgent").AsString(), @"^Jint/\d+\.\d+\.\d+$").Should().BeTrue();
+    }
+
     [Test]
     public void IsOneStableObjectWithTheInterfacesToStringTag()
     {

--- a/Jint/Engine.WebApi.Operations.cs
+++ b/Jint/Engine.WebApi.Operations.cs
@@ -71,6 +71,35 @@ public partial class Engine
         public WebApiFeatures Features => _engine._webApiFeatures;
 
         /// <summary>
+        /// What <c>navigator.userAgent</c> answers on this engine. Requires .NET 8 or higher.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Starts as <see cref="Options.NavigatorOptions.UserAgent"/> — and, when the host named none, as the
+        /// engine's own product token <c>Jint/&lt;version&gt;</c>. Setting it to <see langword="null"/> or the
+        /// empty string puts that default back.
+        /// </para>
+        /// <para>
+        /// <b>Unlike the option, it may be moved after the engine is built</b>, and that is the whole reason
+        /// it exists: a browser's user agent is what a client's <c>Emulation.setUserAgentOverride</c> sets, and
+        /// a page under a client is expected to report the new string without navigating first
+        /// (<see href="https://github.com/sebastienros/jint/issues/3655">#3655</see>). The value is the
+        /// engine's own, so two engines built from one <see cref="Options"/> object never share it.
+        /// </para>
+        /// <para>
+        /// It names what <i>script</i> reads. What a request carries is <see cref="Options.FetchOptions.UserAgent"/>,
+        /// fixed when the engine is built; a host that moves one usually wants to move the other, and a page
+        /// does exactly that through its own network policy.
+        /// </para>
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.AllowNull]
+        public string UserAgent
+        {
+            get => _engine.NavigatorUserAgent;
+            set => _engine.NavigatorUserAgent = value;
+        }
+
+        /// <summary>
         /// Turns on the web APIs a host normally wants — <see cref="WebApiFeatures.Default"/> — on an engine
         /// that already exists. The per-engine counterpart of
         /// <see cref="WebApiOptionsExtensions.UseWebApis(Options)"/>. Requires .NET 8 or higher.

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -109,6 +109,50 @@ public partial class Engine
     internal WebApiFeatures _webApiFeatures;
 
     /// <summary>
+    /// The string <c>navigator.userAgent</c> answers, and the <see cref="JsString"/> the getter hands out.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Engine state rather than an <c>Options</c> value read per get, because it moves after the engine is
+    /// built: a browser's user agent is whatever <c>Emulation.setUserAgentOverride</c> last said, and the
+    /// document already loaded is expected to report it. <see cref="WebApiOperations.UserAgent"/> is the
+    /// public door; <c>Options.WebApi.Navigator.UserAgent</c> is what it starts as.
+    /// </para>
+    /// <para>
+    /// Both fields are <see langword="null"/> until something asks, so an engine whose script never mentions
+    /// <c>navigator</c> allocates neither — and an engine on the default keeps handing out
+    /// <see cref="Jint.WebApi.ProductToken.UserAgentString"/>, the one instance built for the process.
+    /// </para>
+    /// </remarks>
+    private string? _navigatorUserAgent;
+    private JsString? _navigatorUserAgentValue;
+
+    /// <inheritdoc cref="WebApiOperations.UserAgent"/>
+    [System.Diagnostics.CodeAnalysis.AllowNull]
+    internal string NavigatorUserAgent
+    {
+        get => _navigatorUserAgent ??= NamedUserAgent() ?? Jint.WebApi.ProductToken.UserAgent;
+        set
+        {
+            _navigatorUserAgent = string.IsNullOrEmpty(value) ? Jint.WebApi.ProductToken.UserAgent : value;
+            _navigatorUserAgentValue = null;
+        }
+    }
+
+    /// <summary>The <see cref="JsString"/> form, built once per distinct value.</summary>
+    internal JsString NavigatorUserAgentValue
+        => _navigatorUserAgentValue ??= ReferenceEquals(NavigatorUserAgent, Jint.WebApi.ProductToken.UserAgent)
+            ? Jint.WebApi.ProductToken.UserAgentString
+            : JsString.Create(NavigatorUserAgent);
+
+    /// <summary>What the host named, or <see langword="null"/> for an engine that took the default.</summary>
+    private string? NamedUserAgent()
+    {
+        var named = Options.WebApi.Navigator.UserAgent;
+        return string.IsNullOrEmpty(named) ? null : named;
+    }
+
+    /// <summary>
     /// Whether <see cref="Options"/> is a copy this engine took for itself, whose web-API subtree therefore
     /// no other engine reads.
     /// </summary>

--- a/Jint/Options.ReadOnly.cs
+++ b/Jint/Options.ReadOnly.cs
@@ -349,7 +349,7 @@ public sealed partial class Options
 
         void IOptionsGroup.SetReadOnly(bool value)
         {
-            // Published with a barrier for the reason Options.SetReadOnly states: the eight accessors below
+            // Published with a barrier for the reason Options.SetReadOnly states: the nine accessors below
             // read this flag before they publish, and this cascade reads their fields after it.
             Volatile.Write(ref _readOnly, value);
             Thread.MemoryBarrier();
@@ -358,6 +358,7 @@ public sealed partial class Options
             Options.SetReadOnly(_timers, value);
             Options.SetReadOnly(_fetch, value);
             Options.SetReadOnly(_xhr, value);
+            Options.SetReadOnly(_navigator, value);
             Options.SetReadOnly(_diagnostics, value);
             Options.SetReadOnly(_storage, value);
             Options.SetReadOnly(_cache, value);
@@ -366,7 +367,7 @@ public sealed partial class Options
         }
 
         /// <summary>
-        /// Whether <paramref name="group"/> is this group or one of its eight sub-groups.
+        /// Whether <paramref name="group"/> is this group or one of its nine sub-groups.
         /// </summary>
         internal bool Owns(IOptionsGroup group)
             => ReferenceEquals(group, this)
@@ -374,6 +375,7 @@ public sealed partial class Options
                 || ReferenceEquals(group, _timers)
                 || ReferenceEquals(group, _fetch)
                 || ReferenceEquals(group, _xhr)
+                || ReferenceEquals(group, _navigator)
                 || ReferenceEquals(group, _diagnostics)
                 || ReferenceEquals(group, _storage)
                 || ReferenceEquals(group, _cache)
@@ -400,6 +402,21 @@ public sealed partial class Options
             if (_readOnly && !IsConfiguringWebApisLive(this))
             {
                 Throw.OptionsReadOnly("Options.WebApi.Messaging." + setting);
+            }
+        }
+    }
+
+    public sealed partial class NavigatorOptions : IOptionsGroup
+    {
+        private bool _readOnly;
+
+        void IOptionsGroup.SetReadOnly(bool value) => _readOnly = value;
+
+        private void ThrowIfReadOnly([CallerMemberName] string? setting = null)
+        {
+            if (_readOnly && !IsConfiguringWebApisLive(this))
+            {
+                Throw.OptionsReadOnly("Options.WebApi.Navigator." + setting);
             }
         }
     }

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -124,6 +124,14 @@ public sealed partial class Options
         private XhrOptions? _xhr;
 
         /// <summary>
+        /// Settings for the <c>navigator</c> object, installed when <see cref="Features"/> contains
+        /// <see cref="WebApiFeatures.Navigator"/>.
+        /// </summary>
+        public NavigatorOptions Navigator => Materialize(ref _navigator, ref _readOnly);
+
+        private NavigatorOptions? _navigator;
+
+        /// <summary>
         /// Where the engine reports script errors nobody caught. Unlike everything else in this group it is
         /// not tied to a feature flag: setting <see cref="DiagnosticsOptions.Sink"/> arms the channel by
         /// itself, and <see cref="WebApiFeatures.Reporting"/> additionally gives script the
@@ -176,6 +184,7 @@ public sealed partial class Options
             clone._timers = _timers?.Clone();
             clone._fetch = _fetch?.Clone();
             clone._xhr = _xhr?.Clone();
+            clone._navigator = _navigator?.Clone();
             clone._diagnostics = _diagnostics?.Clone();
             clone._storage = _storage?.Clone();
             clone._cache = _cache?.Clone();
@@ -218,6 +227,56 @@ public sealed partial class Options
         public BroadcastChannelBroker? Broker { get; set { ThrowIfReadOnly(); field = value; } }
 
         internal MessagingOptions Clone() => (MessagingOptions) MemberwiseClone();
+    }
+
+    /// <summary>
+    /// Settings for the <c>navigator</c> object. Requires .NET 8 or higher.
+    /// </summary>
+    /// <remarks>
+    /// Like every other option group this may be shared by any number of engines, including concurrent ones:
+    /// nothing on it is engine-affine.
+    /// </remarks>
+    public sealed partial class NavigatorOptions
+    {
+        /// <summary>
+        /// Creates the group with its defaults, which is what an engine that names none of them gets.
+        /// </summary>
+        /// <remarks>
+        /// Declared rather than left implicit because <c>Jint.Tests.PublicInterface</c>'s allowlist of
+        /// undocumented public declarations may only ever shrink, and every other option group's constructor
+        /// is already on it.
+        /// </remarks>
+        public NavigatorOptions()
+        {
+        }
+
+        /// <summary>
+        /// What <c>navigator.userAgent</c> answers. <see langword="null"/> or the empty string — the default —
+        /// is the engine's own product token, <c>Jint/&lt;version&gt;</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The default is deliberately the truth</b>, and README's WinterTC section says why: a script that
+        /// branches on the runtime it is on should get the runtime it is on, and an embedded interpreter
+        /// claiming to be a browser is a lie a page cannot check. The host that this is wrong for is a
+        /// <i>browser</i> — a page's scripts sniff <c>navigator.userAgent</c>, and CDP's
+        /// <c>Emulation.setUserAgentOverride</c> exists to set it — so naming one is the host's decision to
+        /// make explicitly rather than a default anybody inherits.
+        /// </para>
+        /// <para>
+        /// Read once, when the engine is built; <see cref="Engine.WebApiOperations.UserAgent"/> is the same
+        /// value afterwards and may be moved on a live engine, which is what an override a client sets
+        /// between navigations needs.
+        /// </para>
+        /// <para>
+        /// It names <i>script's</i> answer alone. What a request carries is
+        /// <see cref="FetchOptions.UserAgent"/>, which defaults to the same token — an engine that says one
+        /// thing to script and another on the wire is a defect, so a host naming one usually names both.
+        /// </para>
+        /// </remarks>
+        public string? UserAgent { get; set { ThrowIfReadOnly(); field = value; } }
+
+        internal NavigatorOptions Clone() => (NavigatorOptions) MemberwiseClone();
     }
 
     /// <summary>

--- a/Jint/WebApi/Navigator/NavigatorPrototype.cs
+++ b/Jint/WebApi/Navigator/NavigatorPrototype.cs
@@ -62,14 +62,6 @@ internal sealed partial class NavigatorPrototype : Prototype
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
     private static readonly JsString NavigatorToStringTag = new("Navigator");
 
-    /// <summary>
-    /// The user agent string, built once for the process: the assembly version cannot change while it is
-    /// loaded, so every engine and every realm hands out this one <see cref="JsString"/>. The token is
-    /// <see cref="ProductToken.UserAgent"/>, which is also the <c>User-Agent</c> a request carries when the
-    /// host named none of its own — what a script reads and what the wire carries are one string.
-    /// </summary>
-    private static readonly JsString UserAgent = new(ProductToken.UserAgent);
-
     internal NavigatorPrototype(
         Engine engine,
         Realm realm,
@@ -91,15 +83,24 @@ internal sealed partial class NavigatorPrototype : Prototype
     /// <c>NavigatorID</c> mixin's <c>userAgent</c> attribute, which is where WinterTC's
     /// <c>globalThis.navigator.userAgent</c> requirement lands.
     /// </summary>
+    /// <remarks>
+    /// The value is the engine's — <see cref="Engine.WebApiOperations.UserAgent"/>, which starts as
+    /// <c>Options.WebApi.Navigator.UserAgent</c> and defaults to <see cref="ProductToken.UserAgent"/>. It is
+    /// read here rather than captured, because a host may move it after the engine was built: a browser's is
+    /// whatever a client's <c>Emulation.setUserAgentOverride</c> last said, and the page reads this one
+    /// accessor rather than shadowing it with an own property of its own
+    /// (<see href="https://github.com/sebastienros/jint/issues/3655">#3655</see>).
+    /// </remarks>
     [JsAccessor("userAgent", Flags = PropertyFlag.Configurable | PropertyFlag.Enumerable)]
     private JsString UserAgentGet(JsValue thisObject)
     {
-        if (thisObject is not JsNavigator)
+        if (thisObject is not JsNavigator navigator)
         {
             Throw.TypeError(_realm, "Failed to read the 'userAgent' property from 'Navigator': illegal invocation, receiver is not a Navigator object.");
+            return JsString.Empty;
         }
 
-        return UserAgent;
+        return navigator.Engine.NavigatorUserAgentValue;
     }
 }
 #endif

--- a/Jint/WebApi/ProductToken.cs
+++ b/Jint/WebApi/ProductToken.cs
@@ -24,6 +24,12 @@ internal static class ProductToken
     internal static string UserAgent { get; } = "Jint/" + ProductVersion();
 
     /// <summary>
+    /// The same token as a <see cref="Native.JsString"/>, for the engines that took the default: the version
+    /// cannot change while the assembly is loaded, so every realm of every such engine hands out this one.
+    /// </summary>
+    internal static Native.JsString UserAgentString { get; } = new(UserAgent);
+
+    /// <summary>
     /// The <c>product-version</c> half of the token: Jint's own assembly version, as
     /// <c>major.minor.patch</c>. The fourth component is dropped because Jint never sets one, and the whole
     /// thing degrades to <c>"0.0.0"</c> rather than throwing if the assembly somehow carries no version.

--- a/README.md
+++ b/README.md
@@ -697,11 +697,31 @@ new PerformanceObserver(list => {
 }).observe({ type: 'measure', buffered: true });
 ```
 
-`navigator` carries `userAgent` and nothing else. It reports `Jint/<version>` — a single RFC 7231 product
-token with no comment component, so nothing about your operating system or your application leaks into it —
-and it is there because [WinterTC's Minimum Common API](https://min-common-api.proposal.wintertc.org/)
+`navigator` carries `userAgent` and nothing else. It reports `Jint/<version>` by default — a single RFC 7231
+product token with no comment component, so nothing about your operating system or your application leaks into
+it — and it is there because [WinterTC's Minimum Common API](https://min-common-api.proposal.wintertc.org/)
 requires `globalThis.navigator.userAgent` of a conforming runtime. Everything else a browser's `Navigator`
 carries describes a user agent with a user, a document and a network stack, so it is absent rather than faked.
+
+**The default is deliberately the truth: a script that branches on the runtime it is on should get the runtime
+it is on.** The host that is wrong for is a browser, whose pages sniff `navigator.userAgent`, so naming one is
+explicit rather than inherited:
+
+```csharp
+var engine = new Engine(options =>
+{
+    options.UseWebApis();
+    options.WebApi.Navigator.UserAgent = "Mozilla/5.0 (compatible; MyHost/1.0)";  // what script reads
+    options.WebApi.Fetch.UserAgent = "Mozilla/5.0 (compatible; MyHost/1.0)";      // what the wire carries
+});
+
+engine.WebApi.UserAgent = "Mozilla/5.0 (compatible; MyHost/2.0)";  // and it moves on a live engine
+```
+
+Naming only one of the two is how an engine comes to say one thing to script and another on the wire, so name
+both. Setting either to `null` or `""` puts `Jint/<version>` back. `Jint.Browser` uses exactly this seam: a
+page's user agent is `BrowserOptions.UserAgent` and whatever a client's `Emulation.setUserAgentOverride` last
+said.
 
 `Navigator` is a real interface object, so `navigator instanceof Navigator` holds and `userAgent` lives on
 `Navigator.prototype` where a browser's and Node's do — which is why `Object.keys(navigator)` and

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5376,6 +5376,26 @@ lane it did not before — a long-lived stream at that, so an observer that buff
 its own is the one to look at. The enum's own documentation already said new members may appear and that a
 `switch` over it wants a default arm.
 
+### 4.127 `navigator.userAgent` is the host's to name ([#3655](https://github.com/sebastienros/jint/issues/3655))
+
+`navigator.userAgent` was a fixed `Jint/<version>` with no way to change it. It is now
+`Options.WebApi.Navigator.UserAgent`, read when the engine is built, and `Engine.WebApi.UserAgent`, which
+moves it on an engine that already exists. **The default is unchanged**, so an engine that names neither
+reports exactly what it reported before and nothing has to be done to migrate.
+
+What a host that wants its own string writes:
+
+```csharp
+var engine = new Engine(options =>
+{
+    options.UseWebApis();
+    options.WebApi.Navigator.UserAgent = "Mozilla/5.0 (compatible; MyHost/1.0)";
+});
+```
+
+`null` and `""` both mean the default. `Options.WebApi.Fetch.UserAgent` ([§4.125](#4125-every-request-the-engine-makes-carries-a-user-agent-3720))
+is the other half — what a request carries — and a host that names one usually wants to name both.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Refs #3701 (item 5 only — items 1–4 are untouched).

> **Stacked on #3815** (`feat/3655-navigator-user-agent`), which rewrote the body of the very method this corrects the documentation of. Review the top commit; the lower one is #3815's. Merge #3815 first and this rebases to a three-file change.

## The premise did not hold

Item 5 reads: *"A `navigator.platform` option on the engine. `Network.setUserAgentOverride`'s `platform` reaches the next document only, because the navigator is built with the engine."*

**It does not.** `NavigatorInstaller` does not install `platform` as a value captured when the engine is built — it installs it as an accessor over the page's own `EmulationState`, which is read per get. Measured on a document that was already loaded, with no navigation in between:

```
navigator.platform before                                         ''
Network.setUserAgentOverride {"userAgent":"ViaNetwork/1.0","platform":"Win32"}
navigator.platform after                                          'Win32'
```

So there is no engine option to add, and adding one would be worse than nothing: the engine's `Navigator` publishes `userAgent` alone because WinterTC's Minimum Common API requires it and everything else on HTML's interface describes a user agent with a user, a document and a network stack. `NavigatorPrototype` argues that at length — those members are *absent rather than present-and-lying* — and `platform` is one of them. A page is the host that legitimately has one, and that is exactly where it already lives.

## What was actually wrong

The claim. `NetworkDomain.SetUserAgentOverrideAsync` documented, in bold:

> **`platform` reaches the next document, not this one.** `navigator.platform` is installed when a page engine is built, so a client that sets it after the document is parsed has set it for the navigation that follows — which is what Chrome documents too.

That is the opposite of what the code does, and it is a claim that costs something: a client author who believed it would reload a page for nothing. `EmulationState`'s own class remarks had the same gap the other way round — they list which settings are read per access and named neither the platform nor the language, both of which are.

## Why no test was red

Nothing behavioural is being fixed, so nothing can be. What was missing is the test that holds the sentence to the code: `EmulationDomainTests.TheUserAgentOverrideIsWhatTheNavigatorAnswers` covered the `Emulation` spelling of this command, and the `Network` spelling had none — which is how the two came to disagree in the first place. The new `NetworkDomainTests.TheNetworkCommandsPlatformReachesTheDocumentAlreadyLoaded` covers it, and it would fail if the comment had been right: the first assertion reads `navigator.platform` on the document the command arrived on and expects `Win32`, which a value captured at engine construction would answer as `""`.

It also pins the half that genuinely *is* about the next document — the override outlives the navigation, because it belongs to the page rather than to the engine.

## What was verified

`dotnet test -c Release Jint.Tests.Browser\Jint.Tests.Browser.csproj` — 1 687 passed on `net8.0`, 1 691 on `net10.0`, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
