### PR TITLE
A mouse event's page and offset coordinates are fixed for the length of one dispatch, so a listener cannot move them out from under itself

### DIFF
--- a/Jint.Browser/Events/BrowserEventInterfaces.cs
+++ b/Jint.Browser/Events/BrowserEventInterfaces.cs
@@ -639,13 +639,10 @@ internal static class BrowserEventInterfaces
     /// on <c>MouseEvent</c> and inherited below it, which is exactly what the prototype chain gives.
     /// </summary>
     /// <remarks>
-    /// <c>pageY</c> is <c>clientY</c> plus the page's scroll offset and <c>offsetY</c> is <c>clientY</c> minus
-    /// the target's own box origin, both read from the flat box model when the event is read rather than
-    /// captured when it was dispatched. That is a divergence a page can only observe by scrolling from inside
-    /// a listener and then reading the event it is handling; capturing them instead means two more members on
-    /// every <c>MouseEvent</c>, including the ones a script constructs from an init dictionary that has
-    /// neither. <c>pageX</c> and <c>offsetX</c> are <c>clientX</c> itself and that is the same two formulas
-    /// rather than a shortcut: the page never scrolls sideways and every box starts at <c>x = 0</c>.
+    /// The four CSSOM View adds — <c>pageX</c>, <c>pageY</c>, <c>offsetX</c>, <c>offsetY</c> — are two
+    /// algorithms each, chosen by the event's dispatch flag, and <see cref="JsMouseEvent"/> is where both
+    /// live: they are fixed for the length of one dispatch rather than recomputed per read, so a listener
+    /// cannot move them out from under itself by scrolling or by mutating the document.
     /// </remarks>
     private static void AddMouseMembers(JsObjectShape.Builder builder)
     {
@@ -656,10 +653,10 @@ internal static class BrowserEventInterfaces
             .Accessor("clientY", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.clientY").ClientY))
             .Accessor("x", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.x").ClientX))
             .Accessor("y", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.y").ClientY))
-            .Accessor("pageX", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.pageX").ClientX))
-            .Accessor("pageY", static (t, _) => PageY(Brand<JsMouseEvent>(t, "MouseEvent.pageY")))
-            .Accessor("offsetX", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.offsetX").ClientX))
-            .Accessor("offsetY", static (t, _) => OffsetY(Brand<JsMouseEvent>(t, "MouseEvent.offsetY")))
+            .Accessor("pageX", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.pageX").PageX))
+            .Accessor("pageY", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.pageY").PageY))
+            .Accessor("offsetX", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.offsetX").OffsetX))
+            .Accessor("offsetY", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.offsetY").OffsetY))
             .Accessor("movementX", static (t, _) => Zero<JsMouseEvent>(t, "MouseEvent.movementX"))
             .Accessor("movementY", static (t, _) => Zero<JsMouseEvent>(t, "MouseEvent.movementY"))
             .Accessor("button", static (t, _) => JsNumber.Create(Brand<JsMouseEvent>(t, "MouseEvent.button").Button))
@@ -712,27 +709,11 @@ internal static class BrowserEventInterfaces
     /// https://drafts.csswg.org/cssom-view/#dom-mouseevent-pagey — the client coordinate plus the page's own
     /// scroll offset, which is what makes a coordinate stay put as the page moves under it.
     /// </summary>
-    private static JsNumber PageY(JsMouseEvent ev)
-    {
-        var scroll = Runtime.PageRuntime.Find(ev.Engine)?.Layout.ScrollY ?? 0;
-        return JsNumber.Create(ev.ClientY + scroll);
-    }
 
     /// <summary>
     /// https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsety — the client coordinate relative to the
     /// top of the target's own box, or the client coordinate itself when the target has no box.
     /// </summary>
-    private static JsNumber OffsetY(JsMouseEvent ev)
-    {
-        if (ev.Target is not Dom.DomNodeObject { Node: AngleSharp.Dom.IElement element } wrapper ||
-            Runtime.PageRuntime.Find(wrapper.DomRealm.Engine) is not { } runtime ||
-            runtime.Layout.Current().ClientBoxOf(element) is not { } box)
-        {
-            return JsNumber.Create(ev.ClientY);
-        }
-
-        return JsNumber.Create(ev.ClientY - box.Y);
-    }
 
     private static JsBoolean KeyboardModifier(JsValue thisObject, string member, EventModifiers flag)
         => JsBoolean.Create((Brand<JsKeyboardEvent>(thisObject, member).Modifiers & flag) != EventModifiers.None);

--- a/Jint.Browser/Events/UiEventInstances.cs
+++ b/Jint.Browser/Events/UiEventInstances.cs
@@ -97,11 +97,31 @@ internal class JsUiEvent : JsEvent
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>The coordinates are inputs, not measurements.</b> There is no layout here, so <c>pageX</c> is
-/// <c>clientX</c> plus a scroll offset that is always zero, and <c>offsetX</c> is <c>clientX</c> minus the
-/// target's border-box origin, which the flat renderer (campaign item C4) will supply and which is zero until
-/// it does. A page reading them gets exactly what the dispatcher was given; a page computing with them gets an
-/// answer consistent with a document whose every box sits at the origin.
+/// <b>The coordinates are inputs, not measurements.</b> <c>screenX</c>, <c>clientX</c> and their siblings are
+/// exactly what the dispatcher was given.
+/// </para>
+/// <para>
+/// <b>The four CSSOM View adds are fixed for the length of one dispatch</b>, which is what
+/// https://drafts.csswg.org/cssom-view/#dom-mouseevent-pagex asks for: step 1 of each of <c>pageX</c>,
+/// <c>pageY</c>, <c>offsetX</c> and <c>offsetY</c> is conditioned on the event's <i>dispatch flag</i>, and
+/// while it is set each answers "the position where the event occurred" rather than a sum taken afresh. They
+/// were recomputed on every read, so a listener could move them out from under itself by scrolling — or by
+/// mutating the document, which in the flat box model moves every element after the mutation
+/// (<see href="https://github.com/sebastienros/jint/issues/3698">#3698</see> item 4).
+/// </para>
+/// <para>
+/// <b>The two pairs are captured at different moments, and the reason is cost.</b> The page pair needs only
+/// the scroll offset, so it is taken in <see cref="OnDispatchBegun"/> — one field read per dispatch. The
+/// offset pair needs the target's box, and the flat layout is recomputed per query by design, so taking it
+/// eagerly would walk the whole document on every mouse dispatch whether or not anything read it. It is
+/// taken on the first read of the dispatch instead and held for the rest, which is strictly cheaper than
+/// before (one walk per dispatch rather than one per read) and leaves one residue: a listener that moves the
+/// target <i>and</i> is the first to read <c>offsetX</c>/<c>offsetY</c> sees the box it made. Closing that
+/// needs the cheap layout-invalidation signal the same issue records as its first half.
+/// </para>
+/// <para>
+/// Outside a dispatch all four follow their step 2, which <i>is</i> live: <c>pageY</c> is <c>clientY</c> plus
+/// the window's current <c>scrollY</c>, and <c>offsetY</c> is <c>pageY</c>.
 /// </para>
 /// <para>
 /// It is the interface that carries <see cref="JsEvent.IsActivationEvent"/>: dispatch's step 6.4 is "true if
@@ -131,6 +151,102 @@ internal class JsMouseEvent : JsUiEvent
         Modifiers = state.Modifiers;
         RelatedTarget = state.RelatedTarget;
     }
+
+    /// <summary>
+    /// https://drafts.csswg.org/cssom-view/#dom-mouseevent-pagex step 1 — the document coordinate the event
+    /// occurred at, fixed while the dispatch flag is set. Outside a dispatch, steps 2 and 3: the sum of the
+    /// window's current scroll offset and <see cref="ClientX"/>.
+    /// </summary>
+    /// <remarks>
+    /// The horizontal half needs no scroll offset of its own: the flat box model is exactly as wide as the
+    /// viewport and never scrolls sideways, which is the same reason <c>window.scrollX</c> is a constant zero.
+    /// It is still written as the sum rather than as <see cref="ClientX"/>, so that the day the model grows a
+    /// horizontal axis this member does not have to be found again.
+    /// </remarks>
+    internal double PageX => DispatchFlag ? _pageX : ClientX + ScrollX;
+
+    /// <inheritdoc cref="PageX"/>
+    internal double PageY => DispatchFlag ? _pageY : ClientY + ScrollY;
+
+    /// <summary>
+    /// https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsetx step 1 — the coordinate relative to the
+    /// padding edge of the target node, as the event found it. Outside a dispatch, step 2: <see cref="PageX"/>.
+    /// </summary>
+    internal double OffsetX
+    {
+        get
+        {
+            if (!DispatchFlag)
+            {
+                return PageX;
+            }
+
+            CaptureOffsets();
+            return _offsetX;
+        }
+    }
+
+    /// <inheritdoc cref="OffsetX"/>
+    internal double OffsetY
+    {
+        get
+        {
+            if (!DispatchFlag)
+            {
+                return PageY;
+            }
+
+            CaptureOffsets();
+            return _offsetY;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDispatchBegun()
+    {
+        _pageX = ClientX + ScrollX;
+        _pageY = ClientY + ScrollY;
+        _offsetsCaptured = false;
+    }
+
+    /// <summary>The page's scroll offset, or zero for an engine that is not showing one.</summary>
+    private double ScrollY => Runtime.PageRuntime.Find(Engine)?.Layout.ScrollY ?? 0;
+
+    /// <summary>Zero, and the flat box model is what keeps it zero. See <see cref="PageX"/>.</summary>
+    private static double ScrollX => 0;
+
+    /// <summary>
+    /// The offset pair, taken once per dispatch on the first read. See the class remarks for why it is not
+    /// taken with the page pair.
+    /// </summary>
+    private void CaptureOffsets()
+    {
+        if (_offsetsCaptured)
+        {
+            return;
+        }
+
+        _offsetsCaptured = true;
+
+        // Step 1 needs a box; a target that is not an element of a page has none, so the coordinate is the
+        // viewport one — which is what a document whose every box sits at the origin would have answered.
+        _offsetX = ClientX;
+        _offsetY = ClientY;
+
+        if (Target is Dom.DomNodeObject { Node: AngleSharp.Dom.IElement element } wrapper &&
+            Runtime.PageRuntime.Find(wrapper.DomRealm.Engine) is { } runtime &&
+            runtime.Layout.Current().ClientBoxOf(element) is { } box)
+        {
+            _offsetX = ClientX - box.X;
+            _offsetY = ClientY - box.Y;
+        }
+    }
+
+    private double _pageX;
+    private double _pageY;
+    private double _offsetX;
+    private double _offsetY;
+    private bool _offsetsCaptured;
 
     /// <summary>
     /// https://w3c.github.io/uievents/#dom-mouseevent-initmouseevent — the legacy initializer.

--- a/Jint.Tests.Browser/Events/MouseEventCoordinateTests.cs
+++ b/Jint.Tests.Browser/Events/MouseEventCoordinateTests.cs
@@ -1,0 +1,183 @@
+namespace Jint.Tests.Browser.Events;
+
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// CSSOM View §10's <c>pageX</c>/<c>pageY</c> and <c>offsetX</c>/<c>offsetY</c>, which are the four
+/// <c>MouseEvent</c> members whose answer depends on something other than the event.
+/// <para>
+/// https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every one of the four is two algorithms, and the dispatch flag chooses.</b> While it is set — which is
+/// the whole of the time a listener can read the event — each returns "the position where the event
+/// occurred": <c>pageY</c> relative to the initial containing block, <c>offsetY</c> relative to the padding
+/// edge of the target node. Only once the dispatch is over does <c>pageY</c> become <c>clientY</c> plus the
+/// window's <i>current</i> <c>scrollY</c>, and <c>offsetY</c> become <c>pageY</c>.
+/// </para>
+/// <para>
+/// So the question these ask is whether a listener can move the answer out from under itself, which is what
+/// <see href="https://github.com/sebastienros/jint/issues/3698">#3698</see> item 4 records: the values were
+/// computed on every read, so scrolling — or moving the target — inside a listener changed the coordinates of
+/// the event that listener was handling.
+/// </para>
+/// </remarks>
+public sealed class MouseEventCoordinateTests
+{
+    /// <summary>
+    /// A document tall enough to scroll, with a target well down it.
+    /// </summary>
+    /// <remarks>
+    /// It is built out of <i>many</i> elements rather than one tall one, because the flat box model gives
+    /// every rendered element a 16-pixel row in tree order and reads no CSS height at all — a
+    /// <c>style="height: 400px"</c> block is 16 pixels here, and a document of three of them does not scroll.
+    /// </remarks>
+    private static string TallPage(int rows = 120)
+    {
+        var html = new System.Text.StringBuilder();
+        for (var i = 0; i < rows; i++)
+        {
+            html.Append(System.Globalization.CultureInfo.InvariantCulture, $"<div id=\"row{i}\">row {i}</div>");
+        }
+
+        html.Append("<div id=\"target\">click me</div>");
+        return html.ToString();
+    }
+
+    private static async Task<global::Jint.Browser.Page> PageAsync(Browser browser, string? html = null)
+    {
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(html ?? TallPage());
+        return page;
+    }
+
+    /// <summary>
+    /// <c>pageY</c> step 1: with the dispatch flag set it is the position the event occurred at, so a
+    /// listener that scrolls and reads again reads the same number.
+    /// </summary>
+    [Test]
+    public async Task ScrollingInsideAListenerDoesNotMoveThePageCoordinate()
+    {
+        await using var browser = new Browser();
+        var page = await PageAsync(browser);
+
+        (await page.EvaluateAsync<string>("""
+            (() => {
+              const seen = [];
+              const target = document.getElementById('target');
+              target.addEventListener('click', e => {
+                seen.push(e.pageY);
+                window.scrollTo(0, 120);
+                seen.push(e.pageY);
+              });
+
+              window.scrollTo(0, 0);
+              target.dispatchEvent(new MouseEvent('click', { clientY: 40, bubbles: true }));
+              return seen.join('|') + ' scrollY=' + window.scrollY;
+            })()
+            """)).Should().Be("40|40 scrollY=120", "the coordinate is the position the event occurred at");
+    }
+
+    /// <summary>
+    /// And the scroll that was in force when the dispatch began <i>is</i> part of it — a page already
+    /// scrolled reports the document coordinate rather than the viewport one.
+    /// </summary>
+    [Test]
+    public async Task ThePageCoordinateIsTheDocumentPositionTheEventOccurredAt()
+    {
+        await using var browser = new Browser();
+        var page = await PageAsync(browser);
+
+        (await page.EvaluateAsync<double>("""
+            (() => {
+              let seen = 0;
+              const target = document.getElementById('target');
+              target.addEventListener('click', e => { seen = e.pageY; });
+
+              window.scrollTo(0, 100);
+              target.dispatchEvent(new MouseEvent('click', { clientY: 40, bubbles: true }));
+              return seen;
+            })()
+            """)).Should().Be(140);
+    }
+
+    /// <summary>
+    /// <c>offsetY</c> step 1: it is relative to the target's padding edge as the event found it, so a
+    /// listener that moves the target and reads again reads the same number.
+    /// </summary>
+    /// <remarks>
+    /// The mutation here removes a block <i>above</i> the target, which in the flat box model moves every
+    /// element after it — the cheapest way for a listener to change its own box without touching itself.
+    /// </remarks>
+    [Test]
+    public async Task MovingTheTargetInsideAListenerDoesNotMoveTheOffsetCoordinate()
+    {
+        await using var browser = new Browser();
+        var page = await PageAsync(browser);
+
+        (await page.EvaluateAsync<string>("""
+            (() => {
+              const seen = [];
+              const target = document.getElementById('target');
+              target.addEventListener('click', e => {
+                seen.push(e.offsetY);
+                document.getElementById('row0').remove();
+                seen.push(e.offsetY);
+              });
+
+              window.scrollTo(0, 0);
+              target.dispatchEvent(new MouseEvent('click', { clientY: 40, bubbles: true }));
+              return seen[0] === seen[1] ? 'same:' + seen[0] : 'moved:' + seen[0] + '->' + seen[1];
+            })()
+            """)).Should().StartWith(
+            "same:",
+            "the coordinate is relative to the padding edge the event found, not to the one the listener made");
+    }
+
+    /// <summary>
+    /// Two listeners of one dispatch agree, which is the same rule seen from the other side: the second
+    /// reader is handed what the first was, however much the first moved the page.
+    /// </summary>
+    [Test]
+    public async Task TwoListenersOfOneDispatchReadTheSameCoordinates()
+    {
+        await using var browser = new Browser();
+        var page = await PageAsync(browser);
+
+        (await page.EvaluateAsync<bool>("""
+            (() => {
+              const seen = [];
+              const target = document.getElementById('target');
+              target.addEventListener('click', e => { seen.push(e.pageY); window.scrollTo(0, 200); });
+              target.addEventListener('click', e => { seen.push(e.pageY); });
+
+              window.scrollTo(0, 0);
+              target.dispatchEvent(new MouseEvent('click', { clientY: 40, bubbles: true }));
+              return seen.length === 2 && seen[0] === seen[1];
+            })()
+            """)).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Steps 2 and 3, the half that must stay live: an event nobody is dispatching answers <c>clientY</c>
+    /// plus the window's <i>current</i> scroll offset, so reading one after scrolling moves it.
+    /// </summary>
+    [Test]
+    public async Task OutsideADispatchThePageCoordinateFollowsTheWindowsScroll()
+    {
+        await using var browser = new Browser();
+        var page = await PageAsync(browser);
+
+        (await page.EvaluateAsync<string>("""
+            (() => {
+              const e = new MouseEvent('click', { clientY: 40 });
+              window.scrollTo(0, 0);
+              const before = e.pageY;
+              window.scrollTo(0, 150);
+              return before + '|' + e.pageY;
+            })()
+            """)).Should().Be("40|190", "with the dispatch flag unset the sum is taken afresh");
+    }
+}

--- a/Jint/WebApi/Events/JsEvent.cs
+++ b/Jint/WebApi/Events/JsEvent.cs
@@ -143,7 +143,35 @@ internal class JsEvent : ObjectInstance
     /// what makes a re-entrant dispatch of the same event an <c>InvalidStateError</c> and what
     /// <c>composedPath()</c> answers from.
     /// </summary>
-    internal bool DispatchFlag { get; set; }
+    internal bool DispatchFlag
+    {
+        get;
+        set
+        {
+            field = value;
+
+            if (value)
+            {
+                OnDispatchBegun();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Called as the dispatch flag is set, before the path is built and before <see cref="Target"/> is
+    /// assigned — the moment an interface whose members are defined as "the position where the event
+    /// occurred" has to fix them.
+    /// </summary>
+    /// <remarks>
+    /// It exists for CSSOM View's <c>pageX</c>/<c>pageY</c>, whose first step is conditioned on this very
+    /// flag, and there is nowhere else to put it: a script's own <c>target.dispatchEvent(e)</c> reaches
+    /// dispatch through the engine, so a host cannot bracket one from outside. The base implementation is
+    /// empty and no event this engine ships overrides it, so an ordinary dispatch costs one branch and one
+    /// virtual call — once per dispatch, not once per listener.
+    /// </remarks>
+    protected virtual void OnDispatchBegun()
+    {
+    }
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#event-relatedtarget — the event's related target, which


### PR DESCRIPTION
Refs #3698 — item 4's **second half** only. The first half (a cheap layout-invalidation signal) is an AngleSharp-side seam and is untouched.

## What the standard says

CSSOM View §10 gives `pageX`, `pageY`, `offsetX` and `offsetY` two algorithms each, and the event's **dispatch flag** chooses — https://drafts.csswg.org/cssom-view/#dom-mouseevent-pagex:

> The `pageY` attribute must follow these steps:
> 1. If the event's **dispatch flag is set**, return the vertical coordinate of the position where the event occurred relative to the origin of the initial containing block and terminate these steps.
> 2. Let *offset* be the value of the `scrollY` attribute of the event's associated Window object, if there is one, or zero otherwise.
> 3. Return the sum of *offset* and the value of the event's `clientY` attribute.

`offsetY` step 1 is the same shape, relative to the padding edge of the **target node**; its step 2 is "return `pageY`".

Step 1 is the whole of the time a listener can read the event, and it is a captured position. Jint recomputed all four on every read.

## What failed before

Three tests, red against unfixed code:

```
Failed ScrollingInsideAListenerDoesNotMoveThePageCoordinate
  e.pageY, then window.scrollTo(0, 120), then e.pageY  ->  "40|160", expected "40|40"
Failed MovingTheTargetInsideAListenerDoesNotMoveTheOffsetCoordinate
  e.offsetY, then a block above the target removed, then e.offsetY  ->  "moved:…", expected "same:…"
Failed TwoListenersOfOneDispatchReadTheSameCoordinates
  the first listener scrolls; the two readings disagreed
```

Two more pass before *and* after, and they are the halves that had to stay put: the page coordinate still includes the scroll in force when the dispatch began, and outside a dispatch it still follows the window's current offset (steps 2 and 3).

## What changed

`JsEvent` grows a `protected virtual OnDispatchBegun()`, called as the dispatch flag is set. That is the only place the moment can be caught: a script's own `target.dispatchEvent(e)` reaches dispatch inside the engine, so a host cannot bracket one from outside. It costs one branch and one virtual call **per dispatch, not per listener**, and no event the engine itself ships overrides it. `JsEvent` is `internal`, so this is not public surface and there is no migration row.

`JsMouseEvent` overrides it and captures the page pair there — one field read, since it needs only the scroll offset.

**The offset pair is captured on the first read of the dispatch instead, and that is the one decision worth arguing.** It needs the target's box; the flat layout is recomputed per query by design; and `Target` is not even assigned when the flag is set. Capturing eagerly would walk the whole document on every mouse dispatch whether or not anything read it. Taking it on first read is **strictly cheaper than before** — one walk per dispatch rather than one per read — and leaves exactly one residue, stated on the class: a listener that moves the target *and* is the first to read `offsetX`/`offsetY` sees the box it made. Closing that is what item 4's first half is for.

The horizontal pair is written as the same sum rather than as `clientX`, even though the flat model's `scrollX` is a constant zero and every box starts at `x = 0`, so the day the model grows a horizontal axis these members do not have to be found again.

One behaviour beyond the three tests moves, and it is the standard's: reading `offsetY` **after** a dispatch now answers `pageY` (step 2) rather than continuing to measure against the target's box.

## What was verified

- `Jint.Tests.Browser` — 1 688 passed on `net8.0`, 1 692 on `net10.0`, 0 failed.
- `Jint.Tests` — 12 285 / 12 285 / 8 492, 0 failed (the `JsEvent` change is engine-wide).
- `Jint.Tests.PublicInterface` — 3 597 / 3 607 / 2 879, 0 failed.

One note on the test fixture, because it caught me first: the flat box model gives every rendered element a 16-pixel row and reads no CSS height at all, so a document of three `style="height: 400px"` blocks does not scroll. The fixture is 120 small elements instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
