### PR TITLE
An HTMLCollection refuses the empty string as a name, because its own list of supported names had already declined to hold it

### DIFF
--- a/Jint.Browser/Dom/Collections/DomHtmlCollectionObject.cs
+++ b/Jint.Browser/Dom/Collections/DomHtmlCollectionObject.cs
@@ -47,9 +47,10 @@ internal sealed class DomHtmlCollectionObject<T> : DomCollectionBase where T : c
     protected override bool HasIndex(uint index) => index < (uint) _collection.Length;
 
     /// <summary>
-    /// https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmlcollection-nameditem — the
-    /// supported property names are every element's non-empty <c>id</c> plus every HTML element's non-empty
-    /// <c>name</c>, in tree order, without duplicates.
+    /// https://dom.spec.whatwg.org/#interface-htmlcollection — the supported property names are every
+    /// element's non-empty <c>id</c> plus every HTML element's non-empty <c>name</c>, in tree order, without
+    /// duplicates. The standard says "neither the empty string nor already in result" of both, which is the
+    /// half of the rule <see cref="TryGetNamedValue"/> carries the other half of.
     /// </summary>
     protected override int NameCount
     {
@@ -71,9 +72,29 @@ internal sealed class DomHtmlCollectionObject<T> : DomCollectionBase where T : c
     /// </summary>
     protected override bool IsNameEnumerable(string name) => false;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmlcollection-nameditem">HTML's
+    /// <c>namedItem</c></a>, whose first step is the empty string and whose second is the element lookup.
+    /// </summary>
+    /// <remarks>
+    /// <b>The empty string is refused before anything is searched, and it has to be here rather than left to
+    /// the search.</b> An element may carry <c>id=""</c> or <c>name=""</c> — the HTML parser builds both, and
+    /// AngleSharp's own named lookup matches them — so without step 1 a collection answered for a name
+    /// <see cref="NameCount"/> had already declined to list, which is the projection's three hooks
+    /// disagreeing at the same instant. It is one refusal for all three views, because <c>HasName</c> derives
+    /// from this and so does <c>NamedItem</c>: <c>'' in collection</c>, <c>collection['']</c> and
+    /// <c>collection.namedItem('')</c> are one answer.
+    /// </remarks>
     protected override bool TryGetNamedValue(string name, out JsValue value)
     {
+        // Step 1.
+        if (name.Length == 0)
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        // Step 2.
         var item = _collection[name];
         if (item is null)
         {

--- a/Jint.Tests.Browser/Dom/HtmlCollectionEmptyNameTests.cs
+++ b/Jint.Tests.Browser/Dom/HtmlCollectionEmptyNameTests.cs
@@ -1,0 +1,127 @@
+namespace Jint.Tests.Browser.Dom;
+
+/// <summary>
+/// <a href="https://dom.spec.whatwg.org/#interface-htmlcollection">DOM §4.2.10.2's supported property
+/// names</a> and
+/// <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmlcollection-nameditem">HTML's
+/// <c>namedItem</c></a>, in the one place the two used to disagree: the empty string.
+/// </summary>
+/// <remarks>
+/// An element may carry <c>id=""</c> or <c>name=""</c> — the HTML parser builds both — and DOM's supported
+/// property names skip it explicitly, "neither the empty string nor already in result". HTML's
+/// <c>namedItem</c> makes the same refusal as its own first step, before it looks at a single element. The
+/// two halves have to agree, because <c>'' in collection</c>, <c>collection['']</c> and
+/// <c>collection.namedItem('')</c> are three views of one answer.
+/// </remarks>
+public sealed class HtmlCollectionEmptyNameTests
+{
+    /// <summary>
+    /// The corpus's own markup: three elements whose <c>id</c> or <c>name</c> is present and empty, and one
+    /// of each carrying a real value so the positive case is pinned beside the negative one.
+    /// </summary>
+    private const string Page = """
+        <!doctype html>
+        <html><body>
+        <div id="test">
+        <div class="a" id></div>
+        <div class="a" name></div>
+        <a class="a" name></a>
+        <div class="a" id="real"></div>
+        <a class="a" name="named"></a>
+        </div>
+        </body></html>
+        """;
+
+    /// <summary>
+    /// Every collection an element or the document hands out. The empty string is not a supported property
+    /// name on any of them, so all three views of the answer agree.
+    /// </summary>
+    [TestCase("document.getElementsByTagName('*')", TestName = "Document.getElementsByTagName")]
+    [TestCase("document.getElementById('test').getElementsByTagName('*')", TestName = "Element.getElementsByTagName")]
+    [TestCase("document.getElementsByTagNameNS('http://www.w3.org/1999/xhtml', 'a')", TestName = "Document.getElementsByTagNameNS")]
+    [TestCase("document.getElementById('test').getElementsByTagNameNS('http://www.w3.org/1999/xhtml', 'a')", TestName = "Element.getElementsByTagNameNS")]
+    [TestCase("document.getElementsByClassName('a')", TestName = "Document.getElementsByClassName")]
+    [TestCase("document.getElementById('test').getElementsByClassName('a')", TestName = "Element.getElementsByClassName")]
+    [TestCase("document.getElementById('test').children", TestName = "Element.children")]
+    public void TheEmptyStringIsNeverASupportedPropertyName(string collection)
+    {
+        Answer($$"""
+            (function () {
+              var c = {{collection}};
+              return [
+                '' in c,
+                c[''] === undefined,
+                c.namedItem('') === null,
+              ].join('|');
+            })()
+            """).Should().Be("false|true|true");
+    }
+
+    /// <summary>
+    /// The other half of the same rule, so the refusal above cannot be satisfied by refusing every name: a
+    /// real <c>id</c> and a real <c>name</c> still answer, and still answer the same element three ways.
+    /// </summary>
+    [Test]
+    public void ARealIdOrNameStillAnswers()
+    {
+        Answer("""
+            (function () {
+              var c = document.getElementById('test').getElementsByClassName('a');
+              return [
+                'real' in c,
+                c['real'] === c.namedItem('real'),
+                c.namedItem('real').id,
+                'named' in c,
+                c.namedItem('named').localName,
+              ].join('|');
+            })()
+            """).Should().Be("true|true|real|true|a");
+    }
+
+    /// <summary>
+    /// The name list and the lookup are two halves of one projection, so the empty string is absent from
+    /// both: an own-property enumeration must not report a key the getter answers <c>undefined</c> for.
+    /// </summary>
+    [Test]
+    public void TheEmptyStringIsAbsentFromTheOwnPropertyNames()
+    {
+        Answer("""
+            (function () {
+              var c = document.getElementById('test').getElementsByClassName('a');
+              return Object.getOwnPropertyNames(c).indexOf('');
+            })()
+            """).Should().Be("-1");
+    }
+
+    /// <summary>
+    /// <c>namedItem</c> answers <c>null</c> and the named getter answers <c>undefined</c> — a distinction
+    /// HTML makes deliberately, and one the empty-string refusal must not flatten.
+    /// </summary>
+    [Test]
+    public void TheTwoMissAnswersStayDifferent()
+    {
+        Answer("""
+            (function () {
+              var c = document.getElementById('test').getElementsByClassName('a');
+              return [
+                String(c.namedItem('')),
+                String(c['']),
+                String(c.namedItem('nothing')),
+                String(c['nothing']),
+              ].join('|');
+            })()
+            """).Should().Be("null|undefined|null|undefined");
+    }
+
+    private static string? Answer(string source)
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        return fixture.Text($$"""
+            (function () {
+              try { return String({{source}}); }
+              catch (e) { return e.constructor.name + ': ' + e.message; }
+            })()
+            """);
+    }
+}

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -27,7 +27,7 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | --- | --- | --- | --- | --- |
 | `dom/events/` | 56 | 9 | 544 | 20 |
 | `dom/nodes/` | 159 | 0 | 4,796 | 1,439 |
-| `dom/collections/` | 8 | 0 | 43 | 25 |
+| `dom/collections/` | 8 | 0 | 43 | 18 |
 | `dom/lists/` | 5 | 0 | 189 | 5 |
 | `dom/traversal/` | 13 | 0 | 52 | 7 |
 | `dom/ranges/` | 17 | 0 | 82 | 10 |
@@ -38,7 +38,7 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 200 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **340** | **9** | **6,664** | **2,027** |
+| **total** | **340** | **9** | **6,664** | **2,020** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -1080,7 +1080,6 @@ internal static class WptBrowserExclusions
         // ---------------------------------------------------------------- a collection's named and indexed properties, and its liveness
         // a collection's named and indexed properties
         new("dom/collections/HTMLCollection-as-prototype.html", "*", WptDivergence.NeedsTriage),
-        new("dom/collections/HTMLCollection-empty-name.html", "*", WptDivergence.NeedsTriage),
         new("dom/collections/HTMLCollection-own-props.html", "*", WptDivergence.NeedsTriage),
         new("dom/collections/HTMLCollection-supported-property-names.html", "*later", WptDivergence.NeedsTriage),
         new("dom/collections/HTMLCollection-supported-property-names.html", "Object*", WptDivergence.NeedsTriage),


### PR DESCRIPTION
`dom/collections/HTMLCollection-empty-name.html` reported 0 of its 7 tests. It now reports 7.

## The two halves of one rule had drifted apart

An element may carry `id=""` or `name=""` — the HTML parser builds both, and the corpus's own markup does:

```html
<div class=a id></div>
<div class=a name></div>
<a class=a name></a>
```

[DOM §4.2.10.2](https://dom.spec.whatwg.org/#interface-htmlcollection)'s supported property names skip that case explicitly, saying "neither the empty string nor already in result" of the id and again of the name. `SupportedNames()` in `DomHtmlCollectionObject` already did exactly that.

**The lookup did not.** It went straight to AngleSharp's named indexer, which matches an empty `id` or `name`, so the collection answered for a name it had just declined to list — the projection's hooks disagreeing at the same instant, which is the incoherence host-contract verification exists to catch.

It showed up three ways at once, because all three are one answer:

```js
'' in collection            // true, should be false
collection['']              // an element, should be undefined
collection.namedItem('')    // an element, should be null
```

## The fix is HTML's own first step

[HTML's `namedItem`](https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmlcollection-nameditem) is two steps, and the first is *"If key is the empty string, return null"* — before it looks at a single element. So that is where it goes: `TryGetNamedValue` returns false for a zero-length name and the search runs only afterwards.

One place fixes all three views, which is why it belongs there rather than in the three callers: `HasName` derives from `TryGetNamedValue` and so does `NamedItem`.

The fix is confined to `DomHtmlCollectionObject`, the one hand-written collection wrapper. The generated `DomCollectionAccessor` scheme serves `dataset` and `NamedNodeMap` and neither reaches this path.

## Found and fixed in passing

`NameCount`'s summary cited HTML's `namedItem` anchor for the **supported property names**, which are DOM's algorithm and not HTML's. The citation now points at DOM §4.2.10.2, and the `namedItem` anchor sits on the member that actually implements `namedItem`. One line either side; flagging it so the diff is not a surprise.

## Tests

`Jint.Tests.Browser/Dom/HtmlCollectionEmptyNameTests.cs`, 10 cases, **verified red against the unfixed tree first**: 8 failed, 2 passed. That the two survivors were the positive-case guard and the own-property-names check is the whole diagnosis in one line — the name *list* already excluded `""`, so only the *lookup* was wrong.

They cover all seven collections the corpus drives (`getElementsByTagName`, `getElementsByTagNameNS`, `getElementsByClassName` on both `Document` and `Element`, plus `children`) and add three things the wpt document does not:

- a real `id` and a real `name` still answer, and answer the same element three ways — so the refusal cannot be satisfied by refusing every name;
- `Object.getOwnPropertyNames` does not report `""`, because a key an enumeration reports and the getter answers `undefined` for is the same incoherence in the other direction;
- `namedItem` answers `null` while the named getter answers `undefined`, a distinction HTML makes deliberately and one the new refusal must not flatten.

Whole `Jint.Tests.Browser` suite: 1,722 passed, 0 failed. Full `dotnet build -c Release`: 0 errors. `SpecCitationTests` passes over the changed anchor.

## Census

Re-derived from the run with `JINT_WPT_BROWSER_CENSUS=update`, not edited by hand: `dom/collections/` 25 not passing → **18**, total 2,027 → **2,020**. Those are the only two changed cells in `Jint.Tests.Browser/Wpt/README.md`, in the table at lines 27–41; they do not touch the committed conflict markers further down, which are a known defect owned elsewhere and are left byte-identical.

Rebased over #3814, which had landed its own census numbers into the same file. The two subtractions do compose to 2,020 — but that figure comes from re-running the lane, not from adding them: `JINT_WPT_BROWSER_CENSUS=1` then passes in check mode, which is the only thing that makes the table a measurement rather than a prediction.

Part of #3772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
