### PR TITLE
A fetch observer can answer a response, not only watch one

### DIFF
--- a/Jint.Browser/DevTools/FetchDomain.cs
+++ b/Jint.Browser/DevTools/FetchDomain.cs
@@ -32,13 +32,20 @@ namespace Jint.Browser.DevTools;
 /// thread that read them, and what they release is the fetch the loop is blocked on.
 /// </para>
 /// <para>
-/// <b>The <c>Request</c> stage only, and that is an engine seam rather than an omission.</b> A pattern
-/// asking for <c>requestStage: "Response"</c> is accepted and matches nothing:
-/// <c>FetchObserver.OnResponse</c> is a notification an observer cannot answer, so a response-stage pause
-/// could only ever continue unchanged — a client that called <c>fulfillRequest</c> from one would be
-/// silently ignored, which is worse than not pausing. <c>Fetch.continueResponse</c>,
-/// <c>Fetch.getResponseBody</c> and <c>Fetch.takeResponseBodyAsStream</c> (and with them the whole <c>IO</c>
-/// domain) are absent for the same reason; <c>Network.getResponseBody</c> is what answers a body here.
+/// <b>The <c>Request</c> stage only, and the reason has changed.</b> A pattern asking for
+/// <c>requestStage: "Response"</c> is still accepted and still matches nothing, but no longer because the
+/// engine cannot answer one: <c>FetchObserver.OnResponseAsync</c> is asked about the response that ends the
+/// chain and its answer substitutes, rewrites or fails it
+/// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 1). What is left is the
+/// wiring — this domain, <c>PageNetworkRecorder</c> and <c>IPageNetworkListener</c> — which is why
+/// <c>Fetch.continueResponse</c> is still absent and a response-stage pattern still matches nothing rather
+/// than pausing at something a client could not answer.
+/// </para>
+/// <para>
+/// <b><c>Fetch.getResponseBody</c> and <c>Fetch.takeResponseBodyAsStream</c> (and with them the whole
+/// <c>IO</c> domain) need something further</b>: the seam hands the observer a response's headers while its
+/// body is still on the socket, so there are no bytes to give a paused client without buffering them first.
+/// <c>Network.getResponseBody</c> is what answers a body here.
 /// </para>
 /// <para>
 /// <b>No authentication challenge exists here.</b> <c>handleAuthRequests</c> is accepted and
@@ -232,7 +239,8 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
 
     /// <summary>Whether one pattern asks about one request.</summary>
     /// <remarks>
-    /// <c>requestStage: "Response"</c> matches nothing here; see the class remarks. A pattern with no
+    /// <c>requestStage: "Response"</c> matches nothing here until this domain is wired to the engine's
+    /// response stage; see the class remarks. A pattern with no
     /// <c>urlPattern</c> means every URL, which is the protocol's default.
     /// </remarks>
     private static bool Matches(RequestPattern pattern, PageNetworkRequest request)

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -3097,12 +3097,20 @@ namespace Jint.WebApi.Fetch
         public virtual void OnFailed(Jint.WebApi.Fetch.FetchRequestId id, string reason, System.Exception? exception) { }
         public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchInterception?> OnRequestAsync(Jint.WebApi.Fetch.ObservedFetchRequest request, System.Threading.CancellationToken cancellationToken) { }
         public virtual void OnResponse(Jint.WebApi.Fetch.ObservedFetchResponse response) { }
+        public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchResponseInterception?> OnResponseAsync(Jint.WebApi.Fetch.ObservedFetchResponse response, System.Threading.CancellationToken cancellationToken) { }
     }
     public readonly struct FetchRequestId : System.IEquatable<Jint.WebApi.Fetch.FetchRequestId>
     {
         public FetchRequestId(long Value) { }
         public long Value { get; init; }
         public override string ToString() { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class FetchResponseInterception
+    {
+        public static Jint.WebApi.Fetch.FetchResponseInterception Continue(int? status = default, string? statusText = null, System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader>? headers = null) { }
+        public static Jint.WebApi.Fetch.FetchResponseInterception Fail(string reason) { }
+        public static Jint.WebApi.Fetch.FetchResponseInterception Fulfill(int status, System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader>? headers = null, System.ReadOnlyMemory<byte> body = default, string? statusText = null) { }
     }
     public readonly struct FetchTiming : System.IEquatable<Jint.WebApi.Fetch.FetchTiming>
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -3097,12 +3097,20 @@ namespace Jint.WebApi.Fetch
         public virtual void OnFailed(Jint.WebApi.Fetch.FetchRequestId id, string reason, System.Exception? exception) { }
         public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchInterception?> OnRequestAsync(Jint.WebApi.Fetch.ObservedFetchRequest request, System.Threading.CancellationToken cancellationToken) { }
         public virtual void OnResponse(Jint.WebApi.Fetch.ObservedFetchResponse response) { }
+        public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchResponseInterception?> OnResponseAsync(Jint.WebApi.Fetch.ObservedFetchResponse response, System.Threading.CancellationToken cancellationToken) { }
     }
     public readonly struct FetchRequestId : System.IEquatable<Jint.WebApi.Fetch.FetchRequestId>
     {
         public FetchRequestId(long Value) { }
         public long Value { get; init; }
         public override string ToString() { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class FetchResponseInterception
+    {
+        public static Jint.WebApi.Fetch.FetchResponseInterception Continue(int? status = default, string? statusText = null, System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader>? headers = null) { }
+        public static Jint.WebApi.Fetch.FetchResponseInterception Fail(string reason) { }
+        public static Jint.WebApi.Fetch.FetchResponseInterception Fulfill(int status, System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader>? headers = null, System.ReadOnlyMemory<byte> body = default, string? statusText = null) { }
     }
     public readonly struct FetchTiming : System.IEquatable<Jint.WebApi.Fetch.FetchTiming>
     {

--- a/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
@@ -504,6 +504,8 @@ public class WebApiFetchDocumentTests
 
         internal Func<ObservedFetchRequest, FetchInterception?>? OnRequestHandler { get; init; }
 
+        internal Func<ObservedFetchResponse, FetchResponseInterception?>? OnResponseHandler { get; init; }
+
         public override int RequestBodyPreviewBytes => 16;
 
         public override ValueTask<FetchInterception?> OnRequestAsync(ObservedFetchRequest request, CancellationToken cancellationToken)
@@ -514,6 +516,16 @@ public class WebApiFetchDocumentTests
             }
 
             return new ValueTask<FetchInterception?>(OnRequestHandler?.Invoke(request));
+        }
+
+        public override ValueTask<FetchResponseInterception?> OnResponseAsync(ObservedFetchResponse response, CancellationToken cancellationToken)
+        {
+            lock (Events)
+            {
+                Events.Add($"asked {response.Id} {response.Status} redirect={response.IsRedirect}");
+            }
+
+            return new ValueTask<FetchResponseInterception?>(OnResponseHandler?.Invoke(response));
         }
 
         public override void OnResponse(ObservedFetchResponse response)
@@ -572,6 +584,10 @@ public class WebApiFetchDocumentTests
             $"request {id} GET https://a.test/start redirects=0 after=- initiator=Script",
             $"response {id} 302 redirect=True intercepted=False",
             $"request {id} GET https://a.test/landing redirects=1 after=302 initiator=Script",
+
+            // The response stage: the final response is asked about before it is reported, and a redirect
+            // above is reported without being asked about.
+            $"asked {id} 200 redirect=False",
             $"response {id} 200 redirect=False intercepted=False",
             $"data {id} 5",
             $"completed {id} 5");
@@ -740,12 +756,140 @@ public class WebApiFetchDocumentTests
             "nothing went on the wire, and a zero-length timing would report a socket that was never opened as an instant round trip");
     });
 
+    /// <summary>
+    /// The response stage answers <c>Fulfill</c>: the bytes the server sent are discarded unread and the
+    /// observer's own response is what the script gets.
+    /// </summary>
+    /// <remarks>
+    /// This is what a protocol client's <c>Fetch.fulfillRequest</c> from a response-stage pause needs, and
+    /// what made the whole stage absent while <c>OnResponse</c> was a notification
+    /// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 1).
+    /// </remarks>
+    [Test]
+    public Task AnObserverCanReplaceTheResponseAtTheResponseStage() => DedicatedThread.RunAsync(() =>
+    {
+        var handler = new RecordingHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("from the server") },
+        };
+
+        var observer = new RecordingObserver
+        {
+            OnResponseHandler = _ => FetchResponseInterception.Fulfill(
+                203,
+                [new FetchHeader("x-source", "observer")],
+                new ReadOnlyMemory<byte>("from the observer"u8.ToArray()),
+                "Substituted"),
+        };
+
+        var engine = WebEngine(handler, f => f.Observer = observer);
+
+        engine.Evaluate("""
+            fetch('https://a.test/thing').then(r => r.status + '|' + r.statusText + '|' + r.headers.get('x-source') + '|' + r.text())
+            """)
+            .UnwrapIfPromise(TransportSignalCeiling);
+
+        engine.Evaluate("""
+            fetch('https://a.test/thing').then(r => r.text().then(t => r.status + '|' + r.statusText + '|' + r.headers.get('x-source') + '|' + t))
+            """)
+            .UnwrapIfPromise(TransportSignalCeiling).AsString()
+            .Should().Be("203|Substituted|observer|from the observer");
+
+        // The notification that follows the ask reports what the answer produced, not what the socket said.
+        observer.Events.Should().Contain(entry => entry.Contains("response ", StringComparison.Ordinal) && entry.Contains(" 203 ", StringComparison.Ordinal));
+        observer.Events.Should().Contain(entry => entry.Contains("intercepted=True", StringComparison.Ordinal));
+    });
+
+    /// <summary>
+    /// It answers <c>Continue</c>: the status line and the headers are rewritten and the server's own body
+    /// still arrives, which is <c>Fetch.continueResponse</c>.
+    /// </summary>
+    [Test]
+    public Task AnObserverCanRewriteAResponsesStatusAndHeadersAndKeepItsBody() => DedicatedThread.RunAsync(() =>
+    {
+        var handler = new RecordingHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("the real body") },
+        };
+
+        var observer = new RecordingObserver
+        {
+            OnResponseHandler = _ => FetchResponseInterception.Continue(
+                status: 200,
+                statusText: "Fine now",
+                headers: [new FetchHeader("content-type", "text/plain"), new FetchHeader("x-rewritten", "yes")]),
+        };
+
+        var engine = WebEngine(handler, f => f.Observer = observer);
+
+        engine.Evaluate("""
+            fetch('https://a.test/thing').then(r => r.text().then(t => r.ok + '|' + r.status + '|' + r.statusText + '|' + r.headers.get('x-rewritten') + '|' + t))
+            """)
+            .UnwrapIfPromise(TransportSignalCeiling).AsString()
+            .Should().Be("true|200|Fine now|yes|the real body");
+    });
+
+    /// <summary>
+    /// And <c>Fail</c>, which the script sees as the <c>TypeError</c> every network failure produces, with
+    /// the observer's own reason reaching only the host.
+    /// </summary>
+    [Test]
+    public Task AnObserverCanFailARequestAtTheResponseStage() => DedicatedThread.RunAsync(() =>
+    {
+        var handler = new RecordingHandler
+        {
+            Responder = _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("never seen") },
+        };
+
+        var observer = new RecordingObserver
+        {
+            OnResponseHandler = _ => FetchResponseInterception.Fail("the observer refused it"),
+        };
+
+        var engine = WebEngine(handler, f => f.Observer = observer);
+
+        engine.Evaluate("fetch('https://a.test/thing').then(() => 'resolved', e => e.constructor.name)")
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("TypeError");
+
+        observer.Events.Should().Contain(entry => entry.StartsWith("failed ", StringComparison.Ordinal) && entry.Contains("the observer refused it", StringComparison.Ordinal));
+    });
+
+    /// <summary>
+    /// The ask is for the response that <b>ends</b> the chain, once: a redirect the loop follows is reported
+    /// and not answerable, because what it produces is a hop <c>OnRequestAsync</c> is already asked about.
+    /// </summary>
+    [Test]
+    public Task TheResponseStageIsAskedOnceAndOnlyForTheFinalResponse() => DedicatedThread.RunAsync(() =>
+    {
+        var handler = new RecordingHandler
+        {
+            Responder = url => url.EndsWith("/start", StringComparison.Ordinal)
+                ? Redirect("https://a.test/landing")
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("hello") },
+        };
+
+        var observer = new RecordingObserver();
+        var engine = WebEngine(handler, f => f.Observer = observer);
+
+        engine.Evaluate("fetch('https://a.test/start').then(r => r.text())")
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("hello");
+
+        observer.Events.Count(entry => entry.StartsWith("asked ", StringComparison.Ordinal))
+            .Should().Be(1, "the redirect is reported, not asked about");
+        observer.Events.Should().Contain(entry => entry.StartsWith("asked ", StringComparison.Ordinal) && entry.Contains(" 200 ", StringComparison.Ordinal));
+
+        // And the ask comes before the notification of the same response.
+        var asked = observer.Events.FindIndex(entry => entry.StartsWith("asked ", StringComparison.Ordinal));
+        var reported = observer.Events.FindIndex(entry => entry.StartsWith("response ", StringComparison.Ordinal) && entry.Contains(" 200 ", StringComparison.Ordinal));
+        asked.Should().BeLessThan(reported);
+    });
+
     [Test]
     public void TheObserverSurfaceMentionsNoEngineType()
     {
         // The whole point of the seam: a protocol layer runs it from a transport thread, so nothing it is
         // handed may be a value only the engine thread may touch.
-        var types = new[] { typeof(FetchObserver), typeof(ObservedFetchRequest), typeof(ObservedFetchResponse), typeof(FetchInterception), typeof(FetchRequestId), typeof(FetchHeader), typeof(FetchTiming) };
+        var types = new[] { typeof(FetchObserver), typeof(ObservedFetchRequest), typeof(ObservedFetchResponse), typeof(FetchInterception), typeof(FetchResponseInterception), typeof(FetchRequestId), typeof(FetchHeader), typeof(FetchTiming) };
 
         foreach (var type in types)
         {

--- a/Jint/WebApi/Fetch/AGENTS.md
+++ b/Jint/WebApi/Fetch/AGENTS.md
@@ -58,8 +58,18 @@ reason. Nothing it is handed is a `JsValue`, an `Engine` or a realm, and
 Terminality is enforced in `FetchObservation` rather than trusted to the call sites, because a request can
 fail in the redirect loop, in the body stream *and* in `FetchOperation`'s own classification; the
 compare-and-swap is what makes `OnCompleted`/`OnFailed` fire exactly once between them. A notification that
-throws is ignored — there is no engine thread to report it to — while a throw from `OnRequestAsync` fails the
-fetch, because that is the callback that was asked to decide. Two ordering facts matter before mapping it
+throws is ignored — there is no engine thread to report it to — while a throw from `OnRequestAsync` or
+`OnResponseAsync` fails the fetch, because those are the callbacks that were asked to decide.
+
+**Two callbacks answer, and each is asked in the one place every lane passes.** `OnRequestAsync` is asked per
+hop, inside the redirect loop. `OnResponseAsync` is asked once, for the response that *ends* the chain, in
+`SendForStreamAsync` — deliberately not in `SendAsync`, because a document fetch, a subresource, an
+`XMLHttpRequest` and an `EventSource` all take the stream lane and only `fetch()` takes the other, so an ask
+placed there would have served the one caller that needed it least. **The ask is not the notification**: who
+tells the observer about the final response is still per lane (`BeginResponseAsync` for `SendAsync`,
+`FetchObservation.FinalResponse` for everyone else), so both report what the answer produced rather than what
+the socket said. What `Continue` may not rewrite is the body — it has not been read and is still coming — and
+that is the whole difference from `Fulfill`, which discards the socket's bytes unread. Two ordering facts matter before mapping it
 onto a protocol: **a refusal before the transport** (a `UrlFilter` denial, the concurrency cap, an
 already-aborted signal) reports `OnFailed` with no `OnRequest` before it, because `fetch`'s synchronous half
 cannot await one; and **a body nobody reads never completes**, because it is only pulled when script consumes

--- a/Jint/WebApi/Fetch/FetchObservation.cs
+++ b/Jint/WebApi/Fetch/FetchObservation.cs
@@ -72,6 +72,13 @@ internal sealed class FetchObservation
     }
 
     /// <summary>
+    /// Asks the observer what to do with the response that ends the chain. Like <see cref="RequestAsync"/>
+    /// and unlike every notification here, a throw is <b>not</b> swallowed.
+    /// </summary>
+    internal async Task<FetchResponseInterception?> ResponseAsync(ObservedFetchResponse response, CancellationToken cancellationToken)
+        => await _observer.OnResponseAsync(response, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
     /// Reports the final response of an exchange whose body the caller reads itself, then — once those bytes
     /// are counted — <see cref="Completed"/>.
     /// </summary>

--- a/Jint/WebApi/Fetch/FetchObserver.cs
+++ b/Jint/WebApi/Fetch/FetchObserver.cs
@@ -315,6 +315,98 @@ internal enum FetchInterceptionKind
 }
 
 /// <summary>
+/// What an observer answers a <i>response</i> with when it does not want the response delivered as it came
+/// off the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Build one with <see cref="Fulfill"/>, <see cref="Fail"/> or <see cref="Continue"/>; answering
+/// <see langword="null"/> instead delivers the response as it is.
+/// </para>
+/// <para>
+/// <b>It is asked once, for the response that ends the chain.</b> A redirect the loop is about to follow is
+/// reported to <see cref="FetchObserver.OnResponse"/> and is not answerable: what it produces is the next
+/// hop, and the hop is answerable through <see cref="FetchObserver.OnRequestAsync"/> already.
+/// </para>
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public sealed class FetchResponseInterception
+{
+    private FetchResponseInterception()
+    {
+    }
+
+    internal FetchInterceptionKind Kind { get; private init; }
+
+    internal int Status { get; private init; }
+
+    internal string? StatusText { get; private init; }
+
+    internal IReadOnlyList<FetchHeader>? Headers { get; private init; }
+
+    internal ReadOnlyMemory<byte> Body { get; private init; }
+
+    internal string? Reason { get; private init; }
+
+    /// <summary>
+    /// Replaces the response with one of the observer's own; the bytes the server sent are discarded unread.
+    /// </summary>
+    /// <param name="status">The HTTP status code the caller will see.</param>
+    /// <param name="headers">The response headers, or <see langword="null"/> for none.</param>
+    /// <param name="body">The response body.</param>
+    /// <param name="statusText">The reason phrase, or <see langword="null"/> for the empty string.</param>
+    /// <remarks>
+    /// The substitute is not a redirect however it is numbered: the chain has already ended, and the loop
+    /// only follows what the network answered.
+    /// </remarks>
+    public static FetchResponseInterception Fulfill(
+        int status,
+        IReadOnlyList<FetchHeader>? headers = null,
+        ReadOnlyMemory<byte> body = default,
+        string? statusText = null)
+        => new()
+        {
+            Kind = FetchInterceptionKind.Fulfill,
+            Status = status,
+            StatusText = statusText,
+            Headers = headers,
+            Body = body,
+        };
+
+    /// <summary>
+    /// Fails the request, which the caller sees as the same failure a network error produces.
+    /// </summary>
+    /// <param name="reason">Why it failed, for the host's own logs; script never sees it.</param>
+    public static FetchResponseInterception Fail(string reason)
+        => new() { Kind = FetchInterceptionKind.Fail, Reason = reason ?? string.Empty };
+
+    /// <summary>
+    /// Delivers the response the server sent, with its status line or headers rewritten; every argument left
+    /// <see langword="null"/> keeps what the response already had.
+    /// </summary>
+    /// <param name="status">A status code to report instead.</param>
+    /// <param name="statusText">A reason phrase to report instead.</param>
+    /// <param name="headers">The complete header list to report instead of the response's own.</param>
+    /// <remarks>
+    /// <b>The body is the one thing this cannot rewrite</b>, and that is the difference from
+    /// <see cref="Fulfill"/>: the bytes have not been read yet and are still coming off the socket, so a
+    /// rewritten header list describes a body the observer has not seen. Rewriting
+    /// <c>Content-Length</c> here therefore describes the transfer rather than changing it.
+    /// </remarks>
+    public static FetchResponseInterception Continue(
+        int? status = null,
+        string? statusText = null,
+        IReadOnlyList<FetchHeader>? headers = null)
+        => new()
+        {
+            Kind = FetchInterceptionKind.Continue,
+            Status = status ?? 0,
+            StatusText = statusText,
+            Headers = headers,
+        };
+}
+
+/// <summary>
 /// Watches every hop, response and body chunk of the requests one engine makes, and may answer a request
 /// itself.
 /// </summary>
@@ -326,14 +418,16 @@ internal enum FetchInterceptionKind
 /// </para>
 /// <para>
 /// <b>The order is fixed</b>: <c>OnRequest</c> for the first hop, then for a redirect chain
-/// <c>OnResponse</c>(the redirect) and <c>OnRequest</c>(the next hop) in turn, then <c>OnResponse</c> for
-/// the final response, then <c>OnData</c> per body chunk, then exactly one of <c>OnCompleted</c> and
-/// <c>OnFailed</c>.
+/// <c>OnResponse</c>(the redirect) and <c>OnRequest</c>(the next hop) in turn, then <c>OnResponseAsync</c>
+/// for the final response, then <c>OnData</c> per body chunk, then exactly one of <c>OnCompleted</c> and
+/// <c>OnFailed</c>. Two of those may answer rather than merely watch — <c>OnRequestAsync</c> decides a hop
+/// and <c>OnResponseAsync</c> decides the response that ends the chain.
 /// </para>
 /// <para>
 /// <b>A notification that throws is ignored</b> — there is no engine thread to report it to and a transfer
-/// must not depend on an observer. Only <see cref="OnRequestAsync"/> is different: a throw there fails the
-/// fetch, because it is the callback that was asked to decide.
+/// must not depend on an observer. The two that <i>decide</i> are different: a throw from
+/// <see cref="OnRequestAsync"/> or <see cref="OnResponseAsync"/> fails the fetch, because a decision that
+/// failed must not silently become "continue".
 /// </para>
 /// <para>
 /// The shape of this class is a preview and is declared to the compiler as <c>JINT0002</c>; see
@@ -376,9 +470,45 @@ public abstract class FetchObserver
     /// Called once per hop, as soon as that hop's response headers are in and before its body is read.
     /// </summary>
     /// <param name="response">The response headers.</param>
+    /// <remarks>
+    /// A notification: it cannot change what the caller receives, and for the final response it arrives
+    /// <i>after</i> <see cref="OnResponseAsync"/> has been asked — so what it carries is what the answer
+    /// produced. <see cref="OnResponseAsync"/> is the one that can change it.
+    /// </remarks>
     public virtual void OnResponse(ObservedFetchResponse response)
     {
     }
+
+    /// <summary>
+    /// Called once, for the response that ends the chain, before its body is read; answer
+    /// <see langword="null"/> to deliver it unchanged.
+    /// </summary>
+    /// <param name="response">The response headers.</param>
+    /// <param name="cancellationToken">Cancelled when the fetch is aborted or times out.</param>
+    /// <returns>What to do with the response, or <see langword="null"/> to leave it alone.</returns>
+    /// <remarks>
+    /// <para>
+    /// <b>This asks; <see cref="OnResponse"/> reports.</b> They are separate calls and both happen: the ask
+    /// comes first, with the headers as the socket gave them, and the notification follows with whatever the
+    /// answer produced. So an observer that only watches overrides <see cref="OnResponse"/> and is unaffected
+    /// by this existing, and one that rewrote a status sees its own value in the notification afterwards.
+    /// </para>
+    /// <para>
+    /// <b>It is asked for the final response only.</b> A redirect the loop is about to follow reaches
+    /// <see cref="OnResponse"/> and is not answerable: what it produces is the next hop, and that hop is
+    /// offered to <see cref="OnRequestAsync"/> already.
+    /// </para>
+    /// <para>
+    /// <b>The whole fetch is still bounded</b> by <c>Options.WebApi.Fetch.Timeout</c>, so time spent here
+    /// comes out of the request's own deadline — and the socket is open and the body unread while it is
+    /// spent. Like <see cref="OnRequestAsync"/>, a throw here fails the fetch rather than becoming
+    /// "continue": this is the call that was asked to decide.
+    /// </para>
+    /// </remarks>
+    public virtual ValueTask<FetchResponseInterception?> OnResponseAsync(
+        ObservedFetchResponse response,
+        CancellationToken cancellationToken)
+        => new((FetchResponseInterception?) null);
 
     /// <summary>
     /// Called for each chunk of the final response's body as it is read off the wire.

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -391,6 +391,184 @@ internal static class FetchTransport
         CancellationToken cancellationToken,
         FetchObservation? observation = null)
     {
+        var exchange = await SendForStreamCoreAsync(client, request, policy, cancellationToken, observation).ConfigureAwait(false);
+
+        if (observation is null)
+        {
+            return exchange;
+        }
+
+        try
+        {
+            return await AnswerResponseAsync(exchange, observation, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            exchange.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// The response stage: the one place every lane passes through with the headers in hand and the body
+    /// still on the socket, so the observer's answer reaches a document fetch, a subresource, an
+    /// <c>XMLHttpRequest</c> and an <c>EventSource</c> and not only <c>fetch()</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>It asks, it does not report.</b> Who tells the observer about the final response is unchanged and
+    /// deliberately per lane: <see cref="BeginResponseAsync"/> does it for <see cref="SendAsync"/>, because
+    /// the list it reports is the merged one the <c>Response</c> object will carry, and every caller of this
+    /// method owes <c>FetchObservation.FinalResponse</c> for the same reason. Both therefore report what the
+    /// answer here produced rather than what the socket said, which is what a client that rewrote a status
+    /// expects to see afterwards.
+    /// </para>
+    /// <para>
+    /// <b>A substitution disposes the exchange it replaces</b>, which closes the connection with the body
+    /// unread — the same thing a caller that drops a <c>Response</c> does.
+    /// </para>
+    /// </remarks>
+    private static async Task<FetchExchange> AnswerResponseAsync(
+        FetchExchange exchange,
+        FetchObservation observation,
+        CancellationToken cancellationToken)
+    {
+        var response = exchange.Response;
+
+        var snapshot = new ObservedFetchResponse
+        {
+            Id = observation.Id,
+            Url = exchange.RequestUri,
+            Status = (int) response.StatusCode,
+            StatusText = response.ReasonPhrase ?? string.Empty,
+            Headers = ObservedHeaders(response),
+            FromInterception = exchange.FromInterception,
+            IsRedirect = false,
+            Timing = exchange.Timing,
+        };
+
+        var interception = await observation.ResponseAsync(snapshot, cancellationToken).ConfigureAwait(false);
+        if (interception is null)
+        {
+            return exchange;
+        }
+
+        if (interception.Kind == FetchInterceptionKind.Fail)
+        {
+            throw new FetchFailureException(FetchFailureKind.PolicyDenied, interception.Reason ?? "A fetch observer failed the response.");
+        }
+
+        if (interception.Kind == FetchInterceptionKind.Fulfill)
+        {
+            var substitute = new FetchExchange
+            {
+                Response = BuildResponse(interception.Status, interception.StatusText, interception.Headers, interception.Body),
+                Method = exchange.Method,
+                Url = exchange.Url,
+                RequestUri = exchange.RequestUri,
+                Redirected = exchange.Redirected,
+                FromInterception = true,
+
+                // The hop that produced the response being replaced really was sent, so its timing is kept:
+                // what the observer substituted is the answer, not the round trip.
+                Timing = exchange.Timing,
+            };
+
+            exchange.Dispose();
+            return substitute;
+        }
+
+        // Continue: the status line and the header list may be rewritten, the body may not — it has not been
+        // read yet. Rewriting in place keeps the content, and with it the connection the body is coming on.
+        if (interception.Status != 0)
+        {
+            response.StatusCode = (System.Net.HttpStatusCode) interception.Status;
+        }
+
+        if (interception.StatusText is { } statusText)
+        {
+            response.ReasonPhrase = statusText;
+        }
+
+        if (interception.Headers is { } headers)
+        {
+            response.Headers.Clear();
+            response.Content.Headers.Clear();
+
+            foreach (var header in headers)
+            {
+                if (!response.Headers.TryAddWithoutValidation(header.Name, header.Value))
+                {
+                    response.Content.Headers.TryAddWithoutValidation(header.Name, header.Value);
+                }
+            }
+        }
+
+        return exchange;
+    }
+
+    /// <summary>Every value of every header of one response, as the observer surface spells them.</summary>
+    private static List<FetchHeader> ObservedHeaders(HttpResponseMessage response)
+    {
+        var headers = new List<FetchHeader>();
+        Collect(response.Headers);
+        Collect(response.Content.Headers);
+        return headers;
+
+        void Collect(System.Net.Http.Headers.HttpHeaders source)
+        {
+            foreach (var header in source.NonValidated)
+            {
+                foreach (var value in header.Value)
+                {
+                    headers.Add(new FetchHeader(HeaderList.Lowercase(header.Key), value));
+                }
+            }
+        }
+    }
+
+    /// <summary>The <see cref="HttpResponseMessage"/> an interception's status, headers and body make.</summary>
+    private static HttpResponseMessage BuildResponse(
+        int status,
+        string? statusText,
+        IReadOnlyList<FetchHeader>? headers,
+        ReadOnlyMemory<byte> body)
+    {
+        var response = new HttpResponseMessage((System.Net.HttpStatusCode) status)
+        {
+            Content = new ReadOnlyMemoryContent(body),
+        };
+
+        if (statusText is not null)
+        {
+            response.ReasonPhrase = statusText;
+        }
+
+        // ReadOnlyMemoryContent supplies one of its own, and an interception that named none must not be
+        // given a type it did not choose.
+        response.Content.Headers.ContentType = null;
+
+        if (headers is not null)
+        {
+            foreach (var header in headers)
+            {
+                if (!response.Headers.TryAddWithoutValidation(header.Name, header.Value))
+                {
+                    response.Content.Headers.TryAddWithoutValidation(header.Name, header.Value);
+                }
+            }
+        }
+
+        return response;
+    }
+
+    private static async Task<FetchExchange> SendForStreamCoreAsync(
+        HttpClient client,
+        FetchRequestSnapshot request,
+        FetchPolicy policy,
+        CancellationToken cancellationToken,
+        FetchObservation? observation = null)
+    {
         var url = request.Url;
         var method = request.Method;
         var body = request.Body;
@@ -791,32 +969,9 @@ internal static class FetchTransport
     /// </remarks>
     private static FetchExchange Fulfil(FetchInterception interception, string method, UrlRecord url, Uri uri, int redirectCount)
     {
-        var response = new HttpResponseMessage((System.Net.HttpStatusCode) interception.Status)
-        {
-            Content = new ReadOnlyMemoryContent(interception.Body),
-        };
-
-        if (interception.StatusText is { } statusText)
-        {
-            response.ReasonPhrase = statusText;
-        }
-
-        response.Content.Headers.ContentType = null;
-
-        if (interception.Headers is { } headers)
-        {
-            foreach (var header in headers)
-            {
-                if (!response.Headers.TryAddWithoutValidation(header.Name, header.Value))
-                {
-                    response.Content.Headers.TryAddWithoutValidation(header.Name, header.Value);
-                }
-            }
-        }
-
         return new FetchExchange
         {
-            Response = response,
+            Response = BuildResponse(interception.Status, interception.StatusText, interception.Headers, interception.Body),
             Method = method,
             Url = url,
             RequestUri = uri,

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5396,6 +5396,31 @@ var engine = new Engine(options =>
 `null` and `""` both mean the default. `Options.WebApi.Fetch.UserAgent` ([§4.125](#4125-every-request-the-engine-makes-carries-a-user-agent-3720))
 is the other half — what a request carries — and a host that names one usually wants to name both.
 
+### 4.128 A `FetchObserver` can answer a response, not only watch one ([#3701](https://github.com/sebastienros/jint/issues/3701))
+
+`FetchObserver.OnResponse` was a notification. It still is, and it still fires exactly where it did — what is
+new beside it is `OnResponseAsync`, which is *asked* about the response that ends the chain and may
+substitute it, rewrite its status line and headers, or fail the request:
+
+```csharp
+public override ValueTask<FetchResponseInterception?> OnResponseAsync(
+    ObservedFetchResponse response,
+    CancellationToken cancellationToken)
+{
+    // null - deliver it as it came off the wire, which is what the default does.
+    return new(response.Status == 500
+        ? FetchResponseInterception.Fulfill(200, body: new ReadOnlyMemory<byte>("ok"u8.ToArray()))
+        : null);
+}
+```
+
+Nothing has to be done to migrate: the default answers `null`, so an observer that only overrode
+`OnResponse` behaves exactly as before. **One ordering detail is new** for an observer that asserts on the
+callback sequence: the ask arrives before the notification of the same response, so a recorder that logs
+both now sees two entries for the final response where it saw one.
+
+`FetchObserver` remains a preview surface (`JINT0002`).
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Refs #3701 — item 1. **The seam, not the protocol wiring**; what is left is named below.

## What was wrong

`FetchObserver.OnResponse` was a `void` notification, so an observer could see a response and never change it. That is why the `Fetch` domain's whole **response stage** is absent, and `FetchDomain`'s own class remarks said so:

> A pattern asking for `requestStage: "Response"` is accepted and matches nothing: `FetchObserver.OnResponse` is a notification an observer cannot answer, so a response-stage pause could only ever continue unchanged — a client that called `fulfillRequest` from one would be silently ignored, which is worse than not pausing.

## What changed

`OnResponseAsync` is the answerable half. It is asked **once, for the response that ends the chain**, before its body is read, and answers one of the same three shapes `OnRequestAsync` already had — `null` still means "leave it alone":

| Answer | Effect |
| --- | --- |
| `FetchResponseInterception.Fulfill(status, headers, body, statusText)` | The observer's response is delivered; the socket's bytes are discarded unread |
| `.Continue(status, statusText, headers)` | The status line and header list are rewritten; the server's own body still arrives |
| `.Fail(reason)` | The caller sees the failure a network error produces; the reason reaches only the host |

**It is asked in `SendForStreamAsync`, and that is the decision worth reviewing.** Putting it in `SendAsync` would have served `fetch()` and nothing else — a document fetch, a subresource, an `XMLHttpRequest` and an `EventSource` all take the stream lane. `SendForStreamAsync` is the one place every lane passes with the headers in hand and the body still on the socket.

**The ask is not the notification.** Who tells the observer about the final response is unchanged and still per lane (`BeginResponseAsync` for `SendAsync`, `FetchObservation.FinalResponse` for everyone else), so both now report what the answer produced rather than what the socket said — a client that rewrote a status sees its own value afterwards. The default `OnResponseAsync` answers `null` and calls nothing, so an observer that only overrode `OnResponse` is unaffected.

`Continue` deliberately cannot rewrite the body: it has not been read and is still coming. That is the whole difference from `Fulfill`.

The seam stays engine-free, which `Jint/WebApi/Fetch/AGENTS.md` names as its whole point: `FetchResponseInterception` carries a status, a header list and bytes, and it is in the type list `TheObserverSurfaceMentionsNoEngineType` walks.

## What this unlocks, and what is left

Unlocked by this seam, and **not wired here**: the `Fetch` response stage (`requestStage: "Response"` matching, `requestPaused` carrying `responseStatusCode`/`responseHeaders`), `Fetch.continueResponse`, and `fulfillRequest`/`failRequest` answered from a response-stage pause. That wiring is three layers — `PageNetworkRecorder`, `IPageNetworkListener` (whose `ResponseReceived` is `void` and needs an answerable sibling) and `FetchDomain` — and is a PR of its own rather than a half-implemented command in this one.

**Still needs something further**, and it is not this seam: `Fetch.getResponseBody`, `Fetch.takeResponseBodyAsStream` and the `IO` domain. The seam hands the observer a response's **headers** while its body is still on the socket, so there are no bytes to give a paused client without buffering them first — a decision about a buffer budget, not a hook. `Network.getResponseBody` is what answers a body today.

## Fixed in passing

`FetchDomain`'s class remarks and its `Matches` remark both explained the missing response stage by saying the observer *cannot* answer one. It can now, so both were false the moment this landed; they say what is actually left instead. Small, and in the file the change makes wrong.

## What was verified

Four new tests — the three answers, and that the ask is for the final response alone (a redirect is reported and not asked about). `TheObserverSeesEveryHopInOrder` now spells the ask out in its event sequence, which is the file's statement of the fixed callback order.

- `Jint.Tests.PublicInterface` — 3 603 / 3 613 / 2 879, 0 failed, with the `net8.0` and `net10.0` API baselines approved for the new type and method.
- `Jint.Tests` — 12 296 / 12 296 / 8 492, 0 failed.
- `Jint.Tests.Browser` — 1 708 / 1 712, 0 failed.

`docs/v5-migration.md` §4.128, including the one ordering detail an observer that asserts on the callback sequence will notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
