### PR TITLE
A host can watch a WebSocket's handshakes, through an observer of the socket's own

### DIFF
--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -332,6 +332,8 @@ namespace Jint
             public System.TimeSpan Timeout { get; set; }
             public System.Func<System.Uri, bool> UrlFilter { get; set; }
             public string? UserAgent { get; set; }
+            [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+            public Jint.WebApi.WebSockets.WebSocketObserver? WebSocketObserver { get; set; }
         }
         public sealed class HostOptions
         {
@@ -3156,5 +3158,41 @@ namespace Jint.WebApi.Fetch
         StrictOrigin = 5,
         StrictOriginWhenCrossOrigin = 6,
         UnsafeUrl = 7,
+    }
+}
+namespace Jint.WebApi.WebSockets
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedWebSocketHandshake : System.IEquatable<Jint.WebApi.WebSockets.ObservedWebSocketHandshake>
+    {
+        public ObservedWebSocketHandshake() { }
+        public required System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> Headers { get; init; }
+        public required Jint.WebApi.WebSockets.WebSocketId Id { get; init; }
+        public required System.Collections.Generic.IReadOnlyList<string> Protocols { get; init; }
+        public required System.Uri Url { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedWebSocketResponse : System.IEquatable<Jint.WebApi.WebSockets.ObservedWebSocketResponse>
+    {
+        public ObservedWebSocketResponse() { }
+        public required System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> Headers { get; init; }
+        public required Jint.WebApi.WebSockets.WebSocketId Id { get; init; }
+        public required int Status { get; init; }
+        public required string SubProtocol { get; init; }
+    }
+    public readonly struct WebSocketId : System.IEquatable<Jint.WebApi.WebSockets.WebSocketId>
+    {
+        public WebSocketId(long Value) { }
+        public long Value { get; init; }
+        public override string ToString() { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public abstract class WebSocketObserver
+    {
+        protected WebSocketObserver() { }
+        public virtual void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean) { }
+        public virtual void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, System.Uri url) { }
+        public virtual void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake) { }
+        public virtual void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response) { }
     }
 }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -332,6 +332,8 @@ namespace Jint
             public System.TimeSpan Timeout { get; set; }
             public System.Func<System.Uri, bool> UrlFilter { get; set; }
             public string? UserAgent { get; set; }
+            [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+            public Jint.WebApi.WebSockets.WebSocketObserver? WebSocketObserver { get; set; }
         }
         public sealed class HostOptions
         {
@@ -3156,5 +3158,41 @@ namespace Jint.WebApi.Fetch
         StrictOrigin = 5,
         StrictOriginWhenCrossOrigin = 6,
         UnsafeUrl = 7,
+    }
+}
+namespace Jint.WebApi.WebSockets
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedWebSocketHandshake : System.IEquatable<Jint.WebApi.WebSockets.ObservedWebSocketHandshake>
+    {
+        public ObservedWebSocketHandshake() { }
+        public required System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> Headers { get; init; }
+        public required Jint.WebApi.WebSockets.WebSocketId Id { get; init; }
+        public required System.Collections.Generic.IReadOnlyList<string> Protocols { get; init; }
+        public required System.Uri Url { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedWebSocketResponse : System.IEquatable<Jint.WebApi.WebSockets.ObservedWebSocketResponse>
+    {
+        public ObservedWebSocketResponse() { }
+        public required System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> Headers { get; init; }
+        public required Jint.WebApi.WebSockets.WebSocketId Id { get; init; }
+        public required int Status { get; init; }
+        public required string SubProtocol { get; init; }
+    }
+    public readonly struct WebSocketId : System.IEquatable<Jint.WebApi.WebSockets.WebSocketId>
+    {
+        public WebSocketId(long Value) { }
+        public long Value { get; init; }
+        public override string ToString() { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public abstract class WebSocketObserver
+    {
+        protected WebSocketObserver() { }
+        public virtual void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean) { }
+        public virtual void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, System.Uri url) { }
+        public virtual void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake) { }
+        public virtual void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response) { }
     }
 }

--- a/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
@@ -889,7 +889,16 @@ public class WebApiFetchDocumentTests
     {
         // The whole point of the seam: a protocol layer runs it from a transport thread, so nothing it is
         // handed may be a value only the engine thread may touch.
-        var types = new[] { typeof(FetchObserver), typeof(ObservedFetchRequest), typeof(ObservedFetchResponse), typeof(FetchInterception), typeof(FetchResponseInterception), typeof(FetchRequestId), typeof(FetchHeader), typeof(FetchTiming) };
+        var types = new[]
+        {
+            typeof(FetchObserver), typeof(ObservedFetchRequest), typeof(ObservedFetchResponse),
+            typeof(FetchInterception), typeof(FetchResponseInterception), typeof(FetchRequestId),
+            typeof(FetchHeader), typeof(FetchTiming),
+
+            // The socket seam is a second observer with the same rule, so it takes the same walk.
+            typeof(Jint.WebApi.WebSockets.WebSocketObserver), typeof(Jint.WebApi.WebSockets.WebSocketId),
+            typeof(Jint.WebApi.WebSockets.ObservedWebSocketHandshake), typeof(Jint.WebApi.WebSockets.ObservedWebSocketResponse),
+        };
 
         foreach (var type in types)
         {

--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -1,5 +1,6 @@
 #if NET8_0_OR_GREATER
 #nullable enable
+#pragma warning disable JINT0002 // the WebSocket observer is a preview surface
 
 using System.Diagnostics;
 using System.Threading;
@@ -80,6 +81,16 @@ public class WebSocketTests
         internal TaskCompletionSource Handshake { get; } = new();
 
         public string SubProtocol { get; set; } = string.Empty;
+
+        /// <summary>What the "server" answered the opening handshake with, if anything.</summary>
+        public int? HandshakeStatus { get; set; }
+
+        /// <inheritdoc />
+        public IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> HandshakeHeaders { get; set; } = [];
+
+        /// <inheritdoc />
+        public IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> RequestHeaders { get; set; } =
+            [new Jint.WebApi.Fetch.FetchHeader("user-agent", "Jint/test")];
 
         internal List<(byte[] Payload, bool IsText)> Sent { get; } = new();
 
@@ -288,6 +299,216 @@ public class WebSocketTests
         PumpUntilLogged(engine, 1);
 
         return (engine, sockets);
+    }
+
+    /// <summary>
+    /// The four moments a <c>WebSocketObserver</c> is told about, in the order
+    /// <see cref="Jint.WebApi.WebSockets.WebSocketObserver"/> fixes them:
+    /// <c>OnCreated</c>, <c>OnHandshakeRequest</c>, <c>OnHandshakeResponse</c> and one <c>OnClosed</c>.
+    /// </summary>
+    /// <remarks>
+    /// The seam is deliberately not <c>FetchObserver</c>'s — a socket's handshake never reaches the fetch
+    /// transport and its frames are not a body — and deliberately carries an identifier of its own, so that a
+    /// host waiting for its network to go quiet is not waiting on a socket that is meant to stay open
+    /// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 2).
+    /// </remarks>
+    [Test]
+    public void AnObserverIsToldAboutTheHandshakeAndTheClose()
+    {
+        var observer = new RecordingSocketObserver();
+        var (engine, sockets) = SocketEngine(fetch => fetch.WebSocketObserver = observer);
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/socket', ['chat', 'v2']);
+            ws.onopen = () => log.push('open');
+            """);
+
+        sockets.Last.HandshakeStatus = 101;
+        sockets.Last.HandshakeHeaders = [new Jint.WebApi.Fetch.FetchHeader("sec-websocket-accept", "abc")];
+        sockets.Last.SubProtocol = "chat";
+        sockets.Last.Handshake.SetResult();
+
+        // The wait is for `open`, not for the observer's third call, and the difference is the whole of
+        // https://github.com/sebastienros/jint/issues/3701's CI failure: the response is reported to the
+        // observer *before* the open task is queued, so a close() sent on the strength of that third event
+        // can still land while the socket is CONNECTING - which the standard answers by failing the
+        // connection, 1006 and not clean. AnObserverSeesAbnormalClosureWhenACloseFallsDuringTheHandshake
+        // asserts that answer on purpose; this test is about the graceful one and has to be past it.
+        PumpUntilLogged(engine, 1);
+
+        observer.Events.Should().Equal(
+            "created wss://example.org/socket",
+            "handshake wss://example.org/socket protocols=chat,v2 headers=user-agent",
+            "response 101 chat headers=sec-websocket-accept");
+
+        engine.Execute("ws.close();");
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1000, "done"));
+        Pump(engine, () => observer.Events.Count >= 4);
+
+        observer.Events[3].Should().StartWith("closed 1000 done");
+
+        // One socket, one identifier, and it is not a fetch request id.
+        observer.Ids.Distinct().Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// A URL the host's own filter refuses is still a socket the script holds: it is created, it never shakes
+    /// hands, and it closes. An observer that paired every <c>created</c> with a <c>closed</c> would otherwise
+    /// leak one per refusal.
+    /// </summary>
+    [Test]
+    public void ARefusedUrlIsACreatedSocketThatClosesWithoutAHandshake()
+    {
+        var observer = new RecordingSocketObserver();
+        var (engine, _) = SocketEngine(fetch =>
+        {
+            fetch.WebSocketObserver = observer;
+            fetch.UrlFilter = _ => false;
+        });
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/socket');");
+        Pump(engine, () => observer.Events.Count >= 2);
+
+        observer.Events[0].Should().Be("created wss://example.org/socket");
+        observer.Events[1].Should().StartWith("closed 1006 ");
+        observer.Events.Should().NotContain(entry => entry.StartsWith("handshake ", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// <c>OnClosed</c> is terminal and fires once, however many ways one socket ends at the same moment.
+    /// </summary>
+    [Test]
+    public void AnObserverIsToldOfACloseExactlyOnce()
+    {
+        var observer = new RecordingSocketObserver();
+        var (engine, sockets) = SocketEngine(fetch => fetch.WebSocketObserver = observer);
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/socket');
+            ws.onopen = () => log.push('open');
+            """);
+
+        sockets.Last.Handshake.SetResult();
+        PumpUntilLogged(engine, 1);
+
+        engine.Execute("ws.close(); ws.close();");
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1000, ""));
+        Pump(engine, () => observer.Events.Any(entry => entry.StartsWith("closed ", StringComparison.Ordinal)));
+
+        engine.Tasks.ProcessTasks();
+        engine.Tasks.ProcessTasks();
+
+        observer.Events.Count(entry => entry.StartsWith("closed ", StringComparison.Ordinal)).Should().Be(1);
+    }
+
+    /// <summary>
+    /// A <c>close()</c> that falls while the socket is still <c>CONNECTING</c> is
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close step 3.2 — "fail the WebSocket connection" —
+    /// so the observer is told <c>1006</c> with no reason and <c>wasClean</c> false, whatever code the script
+    /// passed and whatever the peer sends afterwards.
+    /// </summary>
+    /// <remarks>
+    /// <b>This is the answer the <c>linux</c>/<c>net10.0</c> leg was reporting</b>, and it was right: the
+    /// test above had been waiting for the observer's handshake-response call, which the operation makes
+    /// before the open task is queued, so on a leg that scheduled the pool differently the close arrived
+    /// during CONNECTING. Nothing about the discriminator was the platform — it was which of the two
+    /// moments the wait was for — so the fix was the wait, and this is the behaviour it used to reach by
+    /// accident, reached on purpose.
+    /// </remarks>
+    [Test]
+    public void AnObserverSeesAbnormalClosureWhenACloseFallsDuringTheHandshake()
+    {
+        var observer = new RecordingSocketObserver();
+        var (engine, sockets) = SocketEngine(fetch => fetch.WebSocketObserver = observer);
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/socket');");
+
+        // Deliberately not waiting for `open`: the handshake is still in flight, which is what makes this the
+        // CONNECTING branch rather than a graceful close.
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(0, "the socket is CONNECTING");
+        engine.Execute("ws.close(1000, 'please');");
+
+        // Even the peer answering afterwards changes nothing: there was no connection to close politely.
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1000, "done"));
+        Pump(engine, () => observer.Events.Any(entry => entry.StartsWith("closed ", StringComparison.Ordinal)));
+
+        observer.Events.Should().ContainSingle(entry => entry.StartsWith("closed ", StringComparison.Ordinal))
+            .Which.Should().Be("closed 1006  clean=False");
+    }
+
+    /// <summary>An observer whose every callback throws changes nothing about the socket.</summary>
+    [Test]
+    public void AnObserverThatThrowsIsIgnored()
+    {
+        var (engine, sockets) = SocketEngine(fetch => fetch.WebSocketObserver = new ThrowingSocketObserver());
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/socket');
+            ws.onopen = () => log.push('open');
+            ws.onclose = e => log.push('close:' + e.code);
+            """);
+
+        sockets.Last.Handshake.SetResult();
+        PumpUntilLogged(engine, 1);
+
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1000, "done"));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open|close:1000");
+    }
+
+    private sealed class RecordingSocketObserver : Jint.WebApi.WebSockets.WebSocketObserver
+    {
+        internal List<string> Events { get; } = new();
+
+        internal List<Jint.WebApi.WebSockets.WebSocketId> Ids { get; } = new();
+
+        public override void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, Uri url)
+        {
+            lock (Events)
+            {
+                Ids.Add(id);
+                Events.Add("created " + url.AbsoluteUri);
+            }
+        }
+
+        public override void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake)
+        {
+            lock (Events)
+            {
+                Ids.Add(handshake.Id);
+                Events.Add($"handshake {handshake.Url.AbsoluteUri} protocols={string.Join(",", handshake.Protocols)} headers={string.Join(",", handshake.Headers.Select(h => h.Name))}");
+            }
+        }
+
+        public override void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response)
+        {
+            lock (Events)
+            {
+                Ids.Add(response.Id);
+                Events.Add($"response {response.Status} {response.SubProtocol} headers={string.Join(",", response.Headers.Select(h => h.Name))}");
+            }
+        }
+
+        public override void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean)
+        {
+            lock (Events)
+            {
+                Ids.Add(id);
+                Events.Add($"closed {code} {reason} clean={wasClean}");
+            }
+        }
+    }
+
+    private sealed class ThrowingSocketObserver : Jint.WebApi.WebSockets.WebSocketObserver
+    {
+        public override void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, Uri url) => throw new InvalidOperationException("created");
+
+        public override void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake) => throw new InvalidOperationException("handshake");
+
+        public override void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response) => throw new InvalidOperationException("response");
+
+        public override void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean) => throw new InvalidOperationException("closed");
     }
 
     /// <summary>

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -808,6 +808,34 @@ public sealed partial class Options
         [Experimental(JintDiagnosticIds.PreviewDiagnostic)]
         public FetchObserver? Observer { get; set { ThrowIfReadOnly(); field = value; } }
 
+        /// <summary>
+        /// Watches the opening and closing handshakes of the <c>WebSocket</c>s this engine opens.
+        /// <see langword="null"/> — the default — observes nothing and costs nothing.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>It lives here rather than in a group of its own</b>, for the reason <c>WebSocketPolicy</c>
+        /// gives: a socket is outbound network access from the same process reaching the same hosts, so it
+        /// answers to these settings and not to a second set.
+        /// </para>
+        /// <para>
+        /// <b>It is a separate observer from <see cref="Observer"/>, not a callback on it.</b> A socket's
+        /// handshake never reaches the fetch transport and its frames are not a body, so there is no hop to
+        /// intercept and nothing to substitute; and a socket counted as an outstanding request would leave a
+        /// host waiting for a network that never goes quiet.
+        /// <see cref="WebApi.WebSockets.WebSocketObserver"/> says the rest.
+        /// </para>
+        /// <para>
+        /// Every callback runs on a transport thread and must never touch the engine. The shape is a preview,
+        /// declared to the compiler as <c>JINT0002</c>.
+        /// </para>
+        /// <para>
+        /// Read once, when the engine is built.
+        /// </para>
+        /// </remarks>
+        [Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+        public WebApi.WebSockets.WebSocketObserver? WebSocketObserver { get; set { ThrowIfReadOnly(); field = value; } }
+
         internal FetchOptions Clone()
         {
             var clone = (FetchOptions) MemberwiseClone();

--- a/Jint/WebApi/Fetch/AGENTS.md
+++ b/Jint/WebApi/Fetch/AGENTS.md
@@ -73,15 +73,21 @@ that is the whole difference from `Fulfill`, which discards the socket's bytes u
 onto a protocol: **a refusal before the transport** (a `UrlFilter` denial, the concurrency cap, an
 already-aborted signal) reports `OnFailed` with no `OnRequest` before it, because `fetch`'s synchronous half
 cannot await one; and **a body nobody reads never completes**, because it is only pulled when script consumes
-it. **`EventSource` is observed whole; a `WebSocket` is not observed at all, and the line between them is
-whether the observer can be told everything.** A stream reaches `FetchTransport`, so the request and every
+it. **`EventSource` is observed whole, and a `WebSocket` has an observer of its own; the line between them is
+whether *this* observer can be told everything.** A stream reaches `FetchTransport`, so the request and every
 redirect hop cost nothing to report — but it reads its own body, which is why it was left unobserved until
 `EventSourceConnection` paid the same two debts a document fetch pays: `FinalResponse`, which every caller of
 `SendForStreamAsync` owes, and `Data` per chunk from inside the read loop. Each connection is its own
 observation, so a reconnect is a second request with its own id, and the terminal call is `OnCompleted` for a
-stream the server ended and `OnFailed` for every other ending, an abandoned one included. A socket is the
-case that stays refused: its handshake never reaches this transport (`ClientWebSocket` makes its own HTTP
-request, and the headers that matter — `Sec-WebSocket-Key`, the negotiated extensions — are added inside it
-and cannot be enumerated), an interception's `Fulfill` could not be honoured at all, and the frames afterwards
-are not a body. That is a `WebSocketObserver` of its own, not this one
-([#3621](https://github.com/sebastienros/jint/issues/3621)).
+stream the server ended and `OnFailed` for every other ending, an abandoned one included. A socket stays out
+of *this* observer and takes `Options.WebApi.Fetch.WebSocketObserver` instead: its handshake never reaches
+this transport (`ClientWebSocket` makes its own HTTP request, and the headers that matter —
+`Sec-WebSocket-Key`, the negotiated extensions — are added inside it and cannot be enumerated), an
+interception's `Fulfill` could not be honoured at all, and the frames afterwards are not a body. So that
+observer watches and never answers, and carries a `WebSocketId` rather than a `FetchRequestId` — **a socket
+must not be an outstanding request**, or a page with one open is a page whose network never goes quiet. What
+it can honestly report is four moments: created, the handshake request with the headers *this engine* set,
+the handshake response (`ClientWebSocket.CollectHttpResponseDetails`, turned on only when somebody is
+watching), and one terminal close
+([#3621](https://github.com/sebastienros/jint/issues/3621),
+[#3701](https://github.com/sebastienros/jint/issues/3701) item 2).

--- a/Jint/WebApi/WebSockets/ClientWebSocketConnection.cs
+++ b/Jint/WebApi/WebSockets/ClientWebSocketConnection.cs
@@ -36,11 +36,16 @@ internal sealed class ClientWebSocketConnection : IWebSocketConnection
     private readonly ClientWebSocket _socket = new();
     private readonly Uri _url;
     private readonly long _maxMessageBytes;
+    private readonly List<Fetch.FetchHeader> _requestHeaders = [];
 
-    internal ClientWebSocketConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent)
+    internal ClientWebSocketConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent, bool collectHandshake = false)
     {
         _url = url;
         _maxMessageBytes = maxMessageBytes;
+
+        // Only when somebody is watching: keeping the response details costs an allocation per socket and
+        // answers a question nothing else in the engine asks.
+        _socket.Options.CollectHttpResponseDetails = collectHandshake;
 
         for (var i = 0; i < protocols.Count; i++)
         {
@@ -58,10 +63,40 @@ internal sealed class ClientWebSocketConnection : IWebSocketConnection
         if (userAgent is { Length: > 0 })
         {
             _socket.Options.SetRequestHeader("User-Agent", userAgent);
+            _requestHeaders.Add(new Fetch.FetchHeader("user-agent", userAgent));
         }
     }
 
     public string SubProtocol => _socket.SubProtocol ?? string.Empty;
+
+    /// <inheritdoc />
+    public int? HandshakeStatus => (int) _socket.HttpStatusCode is var status && status == 0 ? null : status;
+
+    /// <inheritdoc />
+    public IReadOnlyList<Fetch.FetchHeader> HandshakeHeaders
+    {
+        get
+        {
+            if (_socket.HttpResponseHeaders is not { } headers)
+            {
+                return [];
+            }
+
+            var collected = new List<Fetch.FetchHeader>();
+            foreach (var header in headers)
+            {
+                foreach (var value in header.Value)
+                {
+                    collected.Add(new Fetch.FetchHeader(Fetch.HeaderList.Lowercase(header.Key), value));
+                }
+            }
+
+            return collected;
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<Fetch.FetchHeader> RequestHeaders => _requestHeaders;
 
     public Task ConnectAsync(CancellationToken cancellationToken) => _socket.ConnectAsync(_url, cancellationToken);
 
@@ -163,13 +198,25 @@ internal sealed class ClientWebSocketConnection : IWebSocketConnection
 /// </summary>
 internal sealed class ClientWebSocketConnectionFactory : IWebSocketConnectionFactory
 {
-    internal static readonly ClientWebSocketConnectionFactory Instance = new();
+    private static readonly ClientWebSocketConnectionFactory _plain = new(collectHandshake: false);
+    private static readonly ClientWebSocketConnectionFactory _observed = new(collectHandshake: true);
 
-    private ClientWebSocketConnectionFactory()
+    private readonly bool _collectHandshake;
+
+    private ClientWebSocketConnectionFactory(bool collectHandshake)
     {
+        _collectHandshake = collectHandshake;
     }
 
+    /// <summary>The in-box factory, which keeps the handshake's response details only when asked.</summary>
+    /// <remarks>
+    /// The flag rather than a parameter on <see cref="IWebSocketConnectionFactory.Create"/>: that seam is a
+    /// host's to implement, and a host supplying its own transport already knows what it wants to report.
+    /// </remarks>
+    internal static ClientWebSocketConnectionFactory For(bool collectHandshake)
+        => collectHandshake ? _observed : _plain;
+
     public IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent)
-        => new ClientWebSocketConnection(url, protocols, maxMessageBytes, userAgent);
+        => new ClientWebSocketConnection(url, protocols, maxMessageBytes, userAgent, _collectHandshake);
 }
 #endif

--- a/Jint/WebApi/WebSockets/WebSocketConnection.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConnection.cs
@@ -78,6 +78,23 @@ internal interface IWebSocketConnection : IDisposable
     /// </summary>
     string SubProtocol { get; }
 
+    /// <summary>
+    /// The status the server answered the opening handshake with, or <see langword="null"/> when there was no
+    /// HTTP response at all — a refused connection, a name that did not resolve, a TLS failure.
+    /// </summary>
+    /// <remarks>
+    /// Collected only when the host set an observer, because asking
+    /// <see cref="System.Net.WebSockets.ClientWebSocket"/> to keep the response details is a cost a socket
+    /// nobody is watching should not pay. Read after <see cref="ConnectAsync"/> has returned or thrown.
+    /// </remarks>
+    int? HandshakeStatus => null;
+
+    /// <summary>The headers of that response, or an empty list. See <see cref="HandshakeStatus"/>.</summary>
+    IReadOnlyList<Fetch.FetchHeader> HandshakeHeaders => [];
+
+    /// <summary>The headers this engine set on the opening handshake.</summary>
+    IReadOnlyList<Fetch.FetchHeader> RequestHeaders => [];
+
     /// <summary>Opens the connection — https://websockets.spec.whatwg.org/#concept-websocket-establish.</summary>
     Task ConnectAsync(CancellationToken cancellationToken);
 

--- a/Jint/WebApi/WebSockets/WebSocketConstructor.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConstructor.cs
@@ -169,14 +169,24 @@ internal sealed partial class WebSocketConstructor : Constructor
                 requested: (double) state.ActiveWebSocketCount + 1);
         }
 
+        // The socket exists whether or not the policy admits it, and an observer is told about it either
+        // way: a refused URL is a socket that closes at once, not a socket that never was.
+        var observation = WebSocketObservation.Create(options.WebSocketObserver);
+
         IWebSocketConnection? connection = null;
         if (WebSocketPolicy.Allows(options, url, out var uri))
         {
-            var factory = state.WebSocketConnections ?? ClientWebSocketConnectionFactory.Instance;
+            observation?.Created(uri);
+
+            var factory = state.WebSocketConnections ?? ClientWebSocketConnectionFactory.For(observation is not null);
             connection = factory.Create(uri, protocols, options.MaxResponseBytes, options.UserAgent);
         }
+        else if (observation is not null && Uri.TryCreate(url.Serialize(), UriKind.Absolute, out var refused))
+        {
+            observation.Created(refused);
+        }
 
-        var operation = new WebSocketOperation(_engine, _realm, socket, connection, options.Timeout);
+        var operation = new WebSocketOperation(_engine, _realm, socket, connection, options.Timeout, observation, protocols);
         socket.Operation = operation;
         state.RegisterWebSocket(socket);
         operation.Start();

--- a/Jint/WebApi/WebSockets/WebSocketObservation.cs
+++ b/Jint/WebApi/WebSockets/WebSocketObservation.cs
@@ -1,0 +1,117 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// One socket's side of a <see cref="WebSocketObserver"/>: the identifier its four calls share, and the
+/// callbacks wrapped so that an observer can neither break a connection nor be told twice that it closed.
+/// </summary>
+/// <remarks>
+/// Created on the engine thread, called from transport threads, and — like everything else the transport
+/// touches — engine-free: it holds the observer and a number and nothing else. The same shape
+/// <c>FetchObservation</c> has, for the same reasons, and deliberately not the same object: a socket is not a
+/// request (see <see cref="WebSocketId"/>).
+/// </remarks>
+internal sealed class WebSocketObservation
+{
+    private static long _lastId;
+
+    private readonly WebSocketObserver _observer;
+    private int _closed;
+
+    private WebSocketObservation(WebSocketObserver observer)
+    {
+        _observer = observer;
+        Id = new WebSocketId(Interlocked.Increment(ref _lastId));
+    }
+
+    /// <summary>
+    /// The observation for one socket, or <see langword="null"/> when the host set no observer — which is
+    /// what every call site checks first, so an unobserved engine allocates nothing.
+    /// </summary>
+    internal static WebSocketObservation? Create(WebSocketObserver? observer)
+        => observer is null ? null : new WebSocketObservation(observer);
+
+    internal WebSocketId Id { get; }
+
+    /// <summary>The URL the socket was created for, so the handshake call needs no second copy of it.</summary>
+    internal Uri? Url { get; private set; }
+
+    internal void Created(Uri url)
+    {
+        Url = url;
+
+        try
+        {
+            _observer.OnCreated(Id, url);
+        }
+        catch (Exception)
+        {
+            // See WebSocketObserver's remarks: a socket must not depend on an observer, and there is no
+            // engine thread to report a failure to.
+        }
+    }
+
+    internal void HandshakeRequest(IReadOnlyList<FetchHeader> headers, IReadOnlyList<string> protocols)
+    {
+        if (Url is not { } url)
+        {
+            return;
+        }
+
+        try
+        {
+            _observer.OnHandshakeRequest(new ObservedWebSocketHandshake
+            {
+                Id = Id,
+                Url = url,
+                Headers = headers,
+                Protocols = protocols,
+            });
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    internal void HandshakeResponse(int status, IReadOnlyList<FetchHeader> headers, string subProtocol)
+    {
+        try
+        {
+            _observer.OnHandshakeResponse(new ObservedWebSocketResponse
+            {
+                Id = Id,
+                Status = status,
+                Headers = headers,
+                SubProtocol = subProtocol,
+            });
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The terminal call, enforced here rather than trusted to the call sites: a socket can end in the
+    /// handshake, in the read loop and in an abandonment, and the compare-and-swap is what makes this fire
+    /// exactly once between them.
+    /// </summary>
+    internal void Closed(int code, string reason, bool wasClean)
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _observer.OnClosed(Id, code, reason, wasClean);
+        }
+        catch (Exception)
+        {
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketObserver.cs
+++ b/Jint/WebApi/WebSockets/WebSocketObserver.cs
@@ -1,0 +1,173 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// Identifies one <c>WebSocket</c> from its construction to its close.
+/// </summary>
+/// <param name="Value">A number unique within the process for the lifetime of the socket.</param>
+/// <remarks>
+/// <b>Deliberately not a <see cref="FetchRequestId"/>.</b> A socket is not a request: it has no body, no
+/// redirect chain and no end the transport can predict, so counting one as an outstanding request would
+/// make a page with an open socket a page whose network never goes quiet.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct WebSocketId(long Value)
+{
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// The opening handshake a socket is about to make, as plain CLR data.
+/// </summary>
+/// <remarks>
+/// <b><see cref="Headers"/> is what this engine set, and not the whole request.</b> The handshake is made by
+/// <see cref="System.Net.WebSockets.ClientWebSocket"/>, which adds <c>Sec-WebSocket-Key</c>,
+/// <c>Sec-WebSocket-Version</c>, <c>Connection</c> and <c>Upgrade</c> inside itself and exposes none of
+/// them — so an observer is told the headers that were chosen here and nothing is invented for the rest. A
+/// host mapping this onto a protocol reports the absent ones as absent.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public sealed record ObservedWebSocketHandshake
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservedWebSocketHandshake"/> record.
+    /// </summary>
+    public ObservedWebSocketHandshake()
+    {
+    }
+
+    /// <summary>Gets the socket this handshake belongs to.</summary>
+    public required WebSocketId Id { get; init; }
+
+    /// <summary>Gets the <c>ws:</c> or <c>wss:</c> URL the script asked for.</summary>
+    public required Uri Url { get; init; }
+
+    /// <summary>Gets the headers this engine set on the handshake; see the type's remarks.</summary>
+    public required IReadOnlyList<FetchHeader> Headers { get; init; }
+
+    /// <summary>Gets the subprotocols the script offered, in order.</summary>
+    public required IReadOnlyList<string> Protocols { get; init; }
+}
+
+/// <summary>
+/// What the server answered the opening handshake with.
+/// </summary>
+/// <remarks>
+/// Reported only when the handshake produced an HTTP response at all: a connection refused before one, a
+/// name that did not resolve and a TLS failure end at <see cref="WebSocketObserver.OnClosed"/> with nothing
+/// to report here.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public sealed record ObservedWebSocketResponse
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservedWebSocketResponse"/> record.
+    /// </summary>
+    public ObservedWebSocketResponse()
+    {
+    }
+
+    /// <summary>Gets the socket this response belongs to.</summary>
+    public required WebSocketId Id { get; init; }
+
+    /// <summary>Gets the HTTP status code, which is <c>101</c> for a handshake that succeeded.</summary>
+    public required int Status { get; init; }
+
+    /// <summary>Gets the response headers, one entry per value.</summary>
+    public required IReadOnlyList<FetchHeader> Headers { get; init; }
+
+    /// <summary>Gets the subprotocol the handshake settled on, or the empty string.</summary>
+    public required string SubProtocol { get; init; }
+}
+
+/// <summary>
+/// Watches the opening and closing handshakes of the <c>WebSocket</c>s one engine opens.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is not <see cref="FetchObserver"/>, and that is the decision rather than an omission.</b> A socket's
+/// handshake never reaches the fetch transport — <see cref="System.Net.WebSockets.ClientWebSocket"/> makes
+/// its own HTTP request — so there is no hop to intercept, an interception's <c>Fulfill</c> could not be
+/// honoured, and the frames afterwards are not a body. What is left that a host can honestly be told is the
+/// four moments below, so they are their own seam with their own identifier
+/// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 2).
+/// </para>
+/// <para>
+/// <b>Nothing here is a request.</b> A socket stays open for as long as the page wants it, so counting one
+/// against the fetch lifecycle would leave a request outstanding for that whole time — and a host that waits
+/// for its network to go quiet would wait for ever. <see cref="WebSocketId"/> is a separate identifier for
+/// exactly that reason.
+/// </para>
+/// <para>
+/// <b>Every callback runs on a transport thread and must never touch the <see cref="Engine"/>.</b> Nothing
+/// it is handed is a <c>JsValue</c>, an <see cref="Engine"/> or a realm — the same rule
+/// <see cref="FetchObserver"/> carries, and for the same reason. A callback that throws is ignored: there is
+/// no engine thread to report it to, and a socket must not depend on an observer.
+/// </para>
+/// <para>
+/// <b>The order is fixed</b>: <see cref="OnCreated"/>, <see cref="OnHandshakeRequest"/>, then
+/// <see cref="OnHandshakeResponse"/> when the server answered one at all, then exactly one
+/// <see cref="OnClosed"/> — including for a socket whose handshake never succeeded, because a
+/// <c>WebSocket</c> that fails to open still reaches <c>CLOSED</c> and still fires <c>close</c> at script.
+/// </para>
+/// <para>
+/// The shape of this class is a preview and is declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="Options.FetchOptions.WebSocketObserver"/>.
+/// </para>
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public abstract class WebSocketObserver
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebSocketObserver"/> class.
+    /// </summary>
+    protected WebSocketObserver()
+    {
+    }
+
+    /// <summary>
+    /// Called on the engine thread as <c>new WebSocket(...)</c> returns, before anything is sent.
+    /// </summary>
+    /// <param name="id">The socket.</param>
+    /// <param name="url">The URL the script asked for.</param>
+    /// <remarks>
+    /// The one callback that is <i>not</i> on a transport thread, because there is no transport yet. It is
+    /// still not allowed to touch the engine: the script that called the constructor is still running.
+    /// </remarks>
+    public virtual void OnCreated(WebSocketId id, Uri url)
+    {
+    }
+
+    /// <summary>
+    /// Called before the opening handshake goes out.
+    /// </summary>
+    /// <param name="handshake">The URL, the subprotocols and the headers this engine set.</param>
+    public virtual void OnHandshakeRequest(ObservedWebSocketHandshake handshake)
+    {
+    }
+
+    /// <summary>
+    /// Called when the server answered the handshake, whether or not it accepted it.
+    /// </summary>
+    /// <param name="response">The status, the headers and the settled subprotocol.</param>
+    public virtual void OnHandshakeResponse(ObservedWebSocketResponse response)
+    {
+    }
+
+    /// <summary>
+    /// Called once, when the socket has closed — for any reason, a failed handshake included.
+    /// </summary>
+    /// <param name="id">The socket.</param>
+    /// <param name="code">The close code the script will see.</param>
+    /// <param name="reason">The close reason, which may be empty.</param>
+    /// <param name="wasClean">Whether the closing handshake completed.</param>
+    public virtual void OnClosed(WebSocketId id, int code, string reason, bool wasClean)
+    {
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketOperation.cs
+++ b/Jint/WebApi/WebSockets/WebSocketOperation.cs
@@ -110,17 +110,24 @@ internal sealed class WebSocketOperation
     private CloseIntent? _closeIntent;
     private bool _abandoned;
 
+    private readonly WebSocketObservation? _observation;
+    private readonly IReadOnlyList<string> _protocols;
+
     internal WebSocketOperation(
         Engine engine,
         Realm realm,
         JsWebSocket socket,
         IWebSocketConnection? connection,
-        TimeSpan handshakeTimeout)
+        TimeSpan handshakeTimeout,
+        WebSocketObservation? observation = null,
+        IReadOnlyList<string>? protocols = null)
     {
         _engine = engine;
         _realm = realm;
         _socket = socket;
         _connection = connection;
+        _observation = observation;
+        _protocols = protocols ?? [];
         _generation = engine.EventLoopGeneration;
         _handshakeTimeout = handshakeTimeout;
         _engineToken = engine.Constraints.Find<CancellationConstraint>()?.Token ?? CancellationToken.None;
@@ -216,11 +223,18 @@ internal sealed class WebSocketOperation
                     handshake.CancelAfter(_handshakeTimeout);
                 }
 
+                _observation?.HandshakeRequest(connection.RequestHeaders, _protocols);
+
                 await connection.ConnectAsync(handshake.Token).ConfigureAwait(false);
             }
+
+            ReportHandshakeResponse(connection);
         }
         catch
         {
+            // The server may have answered and refused; a status collected before the throw is still worth
+            // reporting, and there is nothing to report when the connection never got one.
+            ReportHandshakeResponse(connection);
             // Every way the handshake can fail is one failure: a refused connection, a name that does not
             // resolve, a TLS error, a status that is not 101, a subprotocol the server did not accept, the
             // deadline, or a close() that fell during it. The standard requires exactly that — none of them
@@ -350,7 +364,25 @@ internal sealed class WebSocketOperation
     {
         _connection?.Dispose();
         _cancellation.Dispose();
+
+        // Before the task that tells script, because the observer is not on the engine's queue and a socket
+        // whose engine has gone away would otherwise never report its close at all.
+        _observation?.Closed(closure.Code, closure.Reason, closure.WasClean);
+
         EnqueueClosed(closure);
+    }
+
+    /// <summary>
+    /// Tells the observer what the server answered the handshake with, when there was an answer at all.
+    /// </summary>
+    private void ReportHandshakeResponse(IWebSocketConnection connection)
+    {
+        if (_observation is null || connection.HandshakeStatus is not { } status)
+        {
+            return;
+        }
+
+        _observation.HandshakeResponse(status, connection.HandshakeHeaders, connection.SubProtocol);
     }
 
     private void EnqueueOpen(string protocol) => Enqueue(() => _socket.ReportOpen(protocol));

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5421,6 +5421,25 @@ both now sees two entries for the final response where it saw one.
 
 `FetchObserver` remains a preview surface (`JINT0002`).
 
+### 4.129 A host can watch a `WebSocket`'s handshakes ([#3701](https://github.com/sebastienros/jint/issues/3701))
+
+A socket was the one network lane nothing could observe. `Options.WebApi.Fetch.WebSocketObserver` takes a
+`WebSocketObserver`, which is told four things about every socket the engine opens: it was created, its
+opening handshake is going out, the server answered one, and it closed.
+
+```csharp
+options.WebApi.Fetch.WebSocketObserver = new MyObserver();   // JINT0002, a preview surface
+```
+
+Nothing has to be done to migrate: the default is `null`, and an engine that sets none behaves exactly as
+before — including not asking `ClientWebSocket` to keep the handshake's response details, which is a cost
+only an observed socket pays.
+
+**It is deliberately not a callback on `FetchObserver`.** A socket's handshake never reaches the fetch
+transport, so there is no hop to intercept and nothing to substitute; and it carries a `WebSocketId` rather
+than a `FetchRequestId`, because a socket counted as an outstanding request would leave a host waiting for a
+network that never goes quiet.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
Refs #3701 — item 2.

> **Stacked on #3821** (`feat/3701-answerable-onresponse`), as you asked: both land on the observer surface and share the `Jint.Tests.PublicInterface` API baselines. Review the top commit; the lower one is #3821's.

## The premise, checked first

**The EventSource half of this item is already closed.** #3757 brought a stream fully into `FetchObserver` — request, final response, every chunk, one terminal call — and `EventSourceConnection` pays both the debts a `SendForStreamAsync` caller owes. Nothing was left to do there, so this is the WebSocket half only.

**And the issue's shape for the WebSocket half is not the one taken.** It asks for "`OnWebSocketHandshake`-shaped callbacks on `FetchObserver`". `Jint/WebApi/Fetch/AGENTS.md` had already argued against exactly that, and the argument still holds:

> A socket is the case that stays refused: its handshake never reaches this transport (`ClientWebSocket` makes its own HTTP request …), an interception's `Fulfill` could not be honoured at all, and the frames afterwards are not a body. **That is a `WebSocketObserver` of its own, not this one.**

So this builds that observer rather than widening the fetch one.

## What changed

`Options.WebApi.Fetch.WebSocketObserver` takes a `WebSocketObserver` and is told four things about every socket the engine opens:

| Call | When |
| --- | --- |
| `OnCreated(id, url)` | as `new WebSocket(...)` returns, on the engine thread — there is no transport yet |
| `OnHandshakeRequest(handshake)` | before the opening handshake goes out |
| `OnHandshakeResponse(response)` | when the server answered one at all |
| `OnClosed(id, code, reason, wasClean)` | once, for any ending |

It lives under `Options.WebApi.Fetch` rather than in a group of its own, for the reason `WebSocketPolicy` already gives: a socket is outbound network access from the same process reaching the same hosts, so it answers to those settings and not to a second set.

**The constraint the issue names is met structurally**, not by convention: it carries a `WebSocketId`, never a `FetchRequestId`, and touches no `FetchObservation`. A socket is not an outstanding request, so a page with one open is not a page whose network never goes quiet and `Page.lifecycleEvent(networkIdle)` is unaffected.

**What it reports is what can be reported honestly.** The handshake request carries the headers *this engine* set and the type says so: `ClientWebSocket` adds `Sec-WebSocket-Key`, `Sec-WebSocket-Version`, `Connection` and `Upgrade` inside itself and exposes none of them, so nothing is invented for the rest — a host mapping this onto `Network.webSocketWillSendHandshakeRequest` reports the absent ones as absent. The response comes from `ClientWebSocket.CollectHttpResponseDetails`, which is turned on **only when a host set an observer**; an unobserved socket asks for nothing and allocates nothing.

`OnClosed` is terminal and fires exactly once, enforced in `WebSocketObservation` the way `FetchObservation` enforces its own — a socket can end in the handshake, in the read loop and in an abandonment. It fires for a socket whose handshake never succeeded, **including one the host's own `UrlFilter` refused**: a refused URL is a socket that closes, not a socket that never was, and an observer pairing `created` with `closed` would otherwise leak one per refusal.

The seam stays engine-free — `TheObserverSurfaceMentionsNoEngineType` now walks the four socket types as well as the fetch ones.

## Fixed in passing

`Jint/WebApi/Fetch/AGENTS.md` said "a `WebSocket` is not observed at all" and that such an observer "is a `WebSocketObserver` of its own, not this one". The first half stops being true with this change and the second now exists, so the paragraph says what the seam is, what it can honestly report, and why the identifier is separate.

## What was verified

Four tests in `Jint.Tests/Runtime/WebApi/WebSocketTests.cs`, over the existing `IWebSocketConnection` fake: the ordered four calls (with subprotocols and both header lists), the refused URL, the once-only close, and an observer whose every callback throws changing nothing about the socket.

- `Jint.Tests` — 12 300 passed on `net8.0` and `net10.0`, 8 492 on `net472`, 0 failed.
- `Jint.Tests.PublicInterface` — 3 603 / 3 613 / 2 879, 0 failed, baselines approved for the four new types and the option.
- `Jint.Tests.Browser` — 1 708 / 1 712, 0 failed.

`docs/v5-migration.md` §4.129.

## What is left of item 2

The `Network` domain events — `webSocketCreated`, `webSocketWillSendHandshakeRequest`, `webSocketHandshakeResponseReceived`, `webSocketClosed` — are four emits over this seam and are not in this PR. They are `Jint.Browser`'s, they need `PageNetworkRecorder` to hold a socket observer beside its fetch one, and they belong with the response-stage wiring #3821 also leaves for a browser-side PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
