### PR TITLE
A frame served XML gets an XML document, so the wpt XML half of createElementNS reports what it means

### DIFF
--- a/Jint.Browser/Runtime/Parsing/AGENTS.md
+++ b/Jint.Browser/Runtime/Parsing/AGENTS.md
@@ -84,6 +84,15 @@ script runs before a module script that precedes it in the document, because the
 HTML's one; and the first import map found anywhere applies to every module, because none of them could have
 resolved before the parse ended anyway.
 
+**A frame served XML gets an XML document, and only a frame can.** `Configuration` carries AngleSharp.Xml's
+document factory, so a response whose content type is an XML MIME type is parsed by the XML parser rather
+than wrapped in an HTML skeleton — without it `<foo>x</foo>` served as `text/xml` came back with
+`documentElement.tagName === "HTML"` and every XML rule a page then asked about was the wrong document's.
+The page's own document cannot reach it: `Parse` states `text/html` for what a navigation produces, and a
+navigation to an XML content type is refused by `DocumentFetch` before a parser sees it. `application/xhtml+xml`
+is **still** routed to the HTML parser — that is AngleSharp's own content-type mapping, not this file's, and
+it is what `NeedsXmlDocuments` covers in the browser lane.
+
 **`document.readyState` is the page's shadow.** `PageRuntime.ReadyState` moves `loading` → `interactive` →
 `complete` and `ParserDriver.SetReadyState` fires the `readystatechange` that goes with each, because
 `Document.ReadyState`'s setter is protected and unreachable from outside AngleSharp's assembly. AngleSharp's

--- a/Jint.Browser/Runtime/Parsing/ParserDriver.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserDriver.cs
@@ -99,6 +99,15 @@ internal sealed class ParserDriver : IDisposable
         // service rather than replacing one, so AngleSharp's own observer keeps working.
         var configuration = Configuration.Default
             .WithCss()
+            // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-xml — a document whose
+            // content type is an XML MIME type is parsed by the XML parser, and without the factory
+            // AngleSharp.Xml supplies there is no XML document for it to produce: `<foo>Dummy</foo>` served
+            // as `text/xml` came back as an *HTML* document with the text inside an `<html><body>` skeleton,
+            // so `documentElement.tagName` was `HTML` and every XML rule a page then asked about was the
+            // wrong document's. Only a *frame* can reach this: `Parse` states `text/html` for the page's own
+            // document, which is what the navigate rules already decided. AngleSharp.Xml is referenced for
+            // `DOMParser` either way, so this costs a service registration and no dependency.
+            .WithXml()
             .With(new PageResourceLoader(this))
             .With<AngleSharp.Css.IRenderDevice>(_ => new PageRenderDevice(_runtime))
             .With<AngleSharp.Dom.IAttributeObserver>(_ => new CustomElements.CustomElementAttributeObserver(_runtime));

--- a/Jint.Tests.Browser/Parsing/ChildFrameTests.cs
+++ b/Jint.Tests.Browser/Parsing/ChildFrameTests.cs
@@ -173,6 +173,47 @@ public class ChildFrameTests
     }
 
     [Test]
+    public async Task AFrameServedXmlGetsAnXmlDocument()
+    {
+        await using var loopback = await LoopbackPage.CreateAsync(server => server
+            .Map("/dummy.xml", _ => LoopbackResponse.Bytes("<foo>Dummy XML document</foo>", "text/xml"))
+            .MapHtml("/", "<!doctype html><html><body><iframe id=f src=\"/dummy.xml\"></iframe></body></html>"));
+
+        await loopback.Page.NavigateAsync(loopback.Url("/"));
+
+        // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-xml — a document whose content
+        // type is an XML MIME type is parsed by the XML parser. Without AngleSharp.Xml's factory registered
+        // the response came back as an *HTML* document with the text inside an <html><body> skeleton, so the
+        // root element was HTML and every XML rule a page then asked about was the wrong document's.
+        (await loopback.Page.EvaluateAsync<string>(
+            "document.getElementById('f').contentDocument.documentElement.tagName")).Should().Be("foo");
+
+        (await loopback.Page.EvaluateAsync<string>(
+            "document.getElementById('f').contentDocument.contentType")).Should().Be("text/xml");
+
+        (await loopback.Page.EvaluateAsync<string>(
+            "document.getElementById('f').contentDocument.documentElement.textContent"))
+            .Should().Be("Dummy XML document");
+
+        loopback.Page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task RegisteringTheXmlFactoryDoesNotMakeAPageNavigableToXml()
+    {
+        // The XML factory is registered on the whole browsing context, so this is the half that says only a
+        // *frame* can reach it. A top-level navigation to an XML content type is refused before any parser
+        // sees it — `DocumentFetch` decides that, and registering a document factory does not change it.
+        await using var loopback = await LoopbackPage.CreateAsync(server => server
+            .Map("/", _ => LoopbackResponse.Bytes("<foo>not a page</foo>", "text/xml")));
+
+        var navigate = async () => await loopback.Page.NavigateAsync(loopback.Url("/"));
+
+        (await navigate.Should().ThrowAsync<NavigationFailedException>())
+            .Which.Message.Should().Contain("text/xml");
+    }
+
+    [Test]
     public async Task ContentWindowIsNullBecauseAFrameHasNoRealm()
     {
         await using var loopback = await LoopbackPage.CreateAsync(server => server

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -26,7 +26,7 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | Suite | Documents | Synthesized | Tests | Not passing |
 | --- | --- | --- | --- | --- |
 | `dom/events/` | 56 | 9 | 544 | 20 |
-| `dom/nodes/` | 159 | 0 | 4,796 | 1,416 |
+| `dom/nodes/` | 159 | 0 | 4,796 | 1,345 |
 | `dom/collections/` | 8 | 0 | 43 | 18 |
 | `dom/lists/` | 5 | 0 | 189 | 5 |
 | `dom/traversal/` | 13 | 0 | 52 | 7 |
@@ -38,7 +38,7 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 68 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **340** | **9** | **6,664** | **1,855** |
+| **total** | **340** | **9** | **6,664** | **1,784** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -965,8 +965,15 @@ internal static class WptBrowserExclusions
         // a second global with a document in it
         new("dom/nodes/Document-createElement.html", "*XHTML document", WptDivergence.NeedsIframeScripting),
         new("dom/nodes/Document-createElement.html", "*XML document", WptDivergence.NeedsIframeScripting),
-        new("dom/nodes/Document-createElementNS.html", "createElementNS test in XHTML*", WptDivergence.NeedsIframeScripting),
-        new("dom/nodes/Document-createElementNS.html", "createElementNS test in XML*", WptDivergence.NeedsIframeScripting),
+        // Not the frame any more: the frame has its document. `application/xhtml+xml` is routed to the
+        // HTML parser even with the XML factory registered, so the XHTML fixture comes back as an HTML
+        // document and all 195 fail on its first assertion — the trailing newline an HTML skeleton adds.
+        new("dom/nodes/Document-createElementNS.html", "createElementNS test in XHTML*", WptDivergence.NeedsXmlDocuments),
+        // Narrowed by the run rather than by hand: the XML document is real now, so 56 of these pass.
+        // What is left of them is the 110 rows that reach `doc.defaultView.DOMException`, and a frame
+        // has a document here and no window — every one of those names ends in the exception it expects,
+        // which is what separates them from the 56 that do not throw at all.
+        new("dom/nodes/Document-createElementNS.html", "createElementNS test in XML document:*_ERR\"", WptDivergence.NeedsIframeScripting),
         new("dom/nodes/Document-createEvent.https.html", "*TextEvent.", WptDivergence.NeedsIframeScripting),
         new("dom/nodes/Node-appendChild.html", "*document", WptDivergence.NeedsIframeScripting),
         new("dom/nodes/Node-appendChild.html", "*orphan", WptDivergence.NeedsIframeScripting),
@@ -1180,6 +1187,20 @@ internal static class WptBrowserExclusions
         new("dom/nodes/Node-replaceChild.html", "*a doctype should throw a HierarchyRequestError.", WptDivergence.NeedsTriage),
         new("dom/nodes/Node-replaceChild.html", "*node should throw a HierarchyRequestError.", WptDivergence.NeedsTriage),
         new("dom/nodes/attributes.html", "Basic*.", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: \"http://example.com/\",\"0:a\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: \"http://example.com/\",\"a:̀\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: \"http://example.com/\",\"a:;\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: \"http://example.com/\",\"f:o:o\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: \"http://example.com/\",\"fo<o\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: \"http://example.com/\",\"̀:a\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: \"http://example.com/\",\";:a\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: null,\"\\ufffffoo\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: null,\"f<oo\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: null,\"f\\uffffoo\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: null,\"foo\\uffff\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: null,\"foo}\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: null,\"f}oo\",null", WptDivergence.NeedsTriage),
+        new("dom/nodes/Document-createElementNS.html", "* XML document: null,\";foo\",null", WptDivergence.NeedsTriage),
 
         // ---------------------------------------------------------------- a nullable DOMString answers the string "null"
         // a DOMString? parameter or attribute answers the string "null"


### PR DESCRIPTION
Phase 1 of the three that reach the [#3771](https://github.com/sebastienros/jint/issues/3771) rows without a
second realm. The survey that decided the phases is [a comment on the issue](https://github.com/sebastienros/jint/issues/3771#issuecomment-5537117352).

## What was wrong

`<foo>Dummy XML document</foo>` served to a frame as `text/xml` came back as an **HTML** document. The text
survived — wrapped in an `<html><body>` skeleton — so `documentElement.tagName` was `HTML`, and every XML
rule a page then asked about was answered by the wrong kind of document.

AngleSharp needs its XML document factory registered to produce one, and `ParserDriver` built its
configuration with `.WithCss()` and nothing else. **Registering it is the whole change.** AngleSharp.Xml is
already referenced for `DOMParser`'s four XML content types, so this costs a service registration and no
dependency.

## Only a frame can reach it, by construction

Not by a guard that could rot: `Parse` states `text/html` for the document a navigation produces — what the
navigate rules already decided — and a top-level navigation to an XML content type is refused by
`DocumentFetch` before any parser sees it. Both halves are pinned by a test, the second one asserting the
refusal rather than a parse.

## Measured

| | before | after |
| --- | ---: | ---: |
| `dom/nodes/` not passing | 1,439 | **1,383** |
| lane total not passing | 1,855 | **1,784** |
| `Document-createElementNS.html` tests registered | 596 | 596 |
| …passing | 173 | **229** |

**56 rows, for one line.** The document registers the same 596 tests either way — worth saying because an
earlier note of mine said 205, which came from dividing by the file's own advertised case count of 447
instead of by what it measurably registers. The run is the number; 56 is the run.

## The exclusion table is re-derived from that run, not narrowed by hand

* `"createElementNS test in XML*"` covered **56 tests that now pass**, so the runner refused it. It becomes
  `"createElementNS test in XML document:*_ERR\""` — the 110 rows that reach `doc.defaultView.DOMException`,
  which a frame with no realm has no window for. Every one of their names ends in the exception it expects,
  which is exactly what separates them from the 56 that do not throw at all. Verified: **110 failing matched,
  zero passing.** That one pattern replaces the 95 exact names a mechanical carve produced.
* `"createElementNS test in XHTML*"` is **no longer about frames** and moves `NeedsIframeScripting` →
  `NeedsXmlDocuments`. `application/xhtml+xml` is routed to the HTML parser *even with the XML factory
  registered*, so all 195 fail on the trailing newline an HTML skeleton adds. That is AngleSharp's own
  content-type mapping and it is phase 2's subject.
* **29 rows join the two groups their HTML twins already sit in** — fifteen where a nullable `DOMString`
  answers the string `"null"` ([#3712](https://github.com/sebastienros/jint/issues/3712)) and fourteen
  validate-and-extract refusals. Those were always the cause; the frame was simply in front of them.

Every new pattern was checked against the run to match at least one failing test and no passing one before it
was written down, which the runner then re-checks from both sides on every build.

## Fixed in passing

The README's `#3771` row said *"none of these 540 moved"*. True when it was written, and not now — it says 56
have, and which half of `Document-createElementNS.html` is left and why.

## What this does not do

- **XHTML is still parsed as HTML** — 195 rows of this document and 49 of `Document-createElement.html`.
  Phase 2.
- **A frame still has no window**, so `contentWindow` is `null` and a frame document's `defaultView` is
  undefined — the 110 rows above, plus `Document-createElement.html`'s 98. Phase 3.
- **No realm.** The `node-realm-*`, `node-creation-realm` and cross-realm `TreeWalker` documents — about 52
  rows — still need one, and #3771 stays open for exactly that.

## Verified

* `dotnet test Jint.Tests.Browser -c Release` — net8.0 1,711 passed, net10.0 1,715 passed, 0 failed, with
  `JINT_WPT_BROWSER_CENSUS=1` set so both the census and the exclusion table are enforced.
* The two new tests were run against the **unfixed** code first: `AFrameServedXmlGetsAnXmlDocument` failed
  with `"HTML"` where it wants `"foo"`.
* `Jint.Tests` corpus, census and agent-instruction checks — 0 failed.

No public API change and no migration section, so nothing to number against §5.30/§5.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz


