### PR TITLE
The Fetch response stage and the four WebSocket events, over the two seams that now exist

### DIFF
--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -72,20 +72,32 @@ target/runtime split and the manifest are there and none of it is repeated here.
   [`Runtime/AGENTS.md`](../Runtime/AGENTS.md#the-request-log-is-the-protocols-seam-too) argues why moving them
   would deadlock the one fetch a page cannot pump through. **The three commands that release a pause run
   there too**, which is what makes "a pause never blocks the loop's answer" unconditional rather than true
-  with one exception: `PageTarget.RunsOffThread` names `Fetch.continueRequest`, `failRequest` and
-  `fulfillRequest` — they look one entry up and complete a promise, touching no engine, no `JsValue` and no
-  node, which is the bar [`Jint.DevTools/AGENTS.md`](../../Jint.DevTools/AGENTS.md#the-thread-rule) sets —
-  so a `<script src>` a running script inserted, fetched with the loop *blocked* rather than pumping, is
-  released while it blocks. `Fetch.enable` and `disable` are deliberately not named: they are the domain's
+  with one exception: `PageTarget.RunsOffThread` names `Fetch.continueRequest`, `failRequest`,
+  `fulfillRequest` and `continueResponse` — they look one entry up and complete a promise, touching no
+  engine, no `JsValue` and no node, which is the bar
+  [`Jint.DevTools/AGENTS.md`](../../Jint.DevTools/AGENTS.md#the-thread-rule) sets — so a `<script src>` a
+  running script inserted, fetched with the loop *blocked* rather than pumping, is released while it
+  blocks. **`continueResponse` is on that list for a reason no weaker than the other three's**: the loop is
+  blocked on the *whole* fetch (`ParserDriver`'s `fetch.GetAwaiter().GetResult()`), from the request stage
+  through the body read, so a response-stage pause holds it exactly as a request-stage pause does. `Fetch.enable` and `disable` are deliberately not named: they are the domain's
   own state, not a request's. The document's request carries the `loaderId` as its `requestId`, which is how
   every client tells a navigation apart.
 - **What is accepted and not effective says so, in place.** `Network.setCacheDisabled` (there is no cache)
-  and `Audits.enable` are answered because a refusal fails an ordinary connection. Two whole lanes are
-  absent with a reason rather than pending: the `Fetch` **response stage** and with it `IO` (an observer
-  cannot answer `OnResponse`, so a response-stage pause could only continue unchanged), and the **WebSocket**
-  events and `eventSourceMessageReceived` (a socket's handshake is not a fetch and is not observed; a stream
-  *is*, but as bytes rather than as the events they decode into, so its requests are in the log as
-  `ResourceType: EventSource` and its messages are nowhere).
+  and `Audits.enable` are answered because a refusal fails an ordinary connection. The `Fetch` **response stage** is here: a
+  pattern asking for `requestStage: "Response"` pauses with the response's status and headers, and
+  `continueResponse`, `fulfillRequest` and `failRequest` answer one — a default pattern still pauses the
+  request stage only, that being the protocol's own default, and pausing both would double every pause a
+  recorded client expects. **`IO`, `Fetch.getResponseBody` and `takeResponseBodyAsStream` are still absent,
+  for a different reason than they used to be**: the pause has the response's *headers* while its body is
+  still on the socket, so there are no bytes to hand a client without buffering them first, which is a
+  budget decision rather than a hook. Still absent with a reason: `eventSourceMessageReceived` (a stream is
+  observed as bytes rather than as the events they decode into, so its requests are in the log as
+  `ResourceType: EventSource` and its messages are nowhere), and the three `webSocketFrame*` events (the
+  engine's socket observer is told about the two handshakes and the close, and a frame never reaches it).
+  **The other four WebSocket events are here**, over that observer, and a socket is deliberately *not* in
+  the request log: it stays open for as long as the page wants it, so an entry would leave a request
+  outstanding for that whole time and `networkIdle` would never fire. Its identifier is `ws-`-prefixed for
+  the same reason — a client must not be able to ask `getResponseBody` of a socket.
   **`Network`'s timing document is no longer among them, and the shape of the answer is the point**: the
   transport measures the one interval it can see exactly — the hop going out and its headers coming back —
   so `requestTime` and `receiveHeaders*` are real and every phase behind the host's own `HttpClient` (proxy,

--- a/Jint.Browser/DevTools/FetchDomain.cs
+++ b/Jint.Browser/DevTools/FetchDomain.cs
@@ -32,20 +32,21 @@ namespace Jint.Browser.DevTools;
 /// thread that read them, and what they release is the fetch the loop is blocked on.
 /// </para>
 /// <para>
-/// <b>The <c>Request</c> stage only, and the reason has changed.</b> A pattern asking for
-/// <c>requestStage: "Response"</c> is still accepted and still matches nothing, but no longer because the
-/// engine cannot answer one: <c>FetchObserver.OnResponseAsync</c> is asked about the response that ends the
-/// chain and its answer substitutes, rewrites or fails it
-/// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 1). What is left is the
-/// wiring — this domain, <c>PageNetworkRecorder</c> and <c>IPageNetworkListener</c> — which is why
-/// <c>Fetch.continueResponse</c> is still absent and a response-stage pattern still matches nothing rather
-/// than pausing at something a client could not answer.
+/// <b>Both stages, and the response stage is opt-in per pattern.</b> A pattern asking for
+/// <c>requestStage: "Response"</c> pauses when the response's headers are in and its body has not been read,
+/// carrying <c>responseStatusCode</c>, <c>responseStatusText</c> and <c>responseHeaders</c>;
+/// <see cref="ContinueResponseAsync"/> lets it through with the status line and the header list rewritable,
+/// and <see cref="FulfillRequestAsync"/> and <see cref="FailRequestAsync"/> answer one too. A pattern that
+/// names no stage means <c>Request</c>, which is the protocol's own default — pausing both stages for it
+/// would double every pause a recorded client expects. The engine seam under it is
+/// <c>FetchObserver.OnResponseAsync</c>
+/// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 1).
 /// </para>
 /// <para>
 /// <b><c>Fetch.getResponseBody</c> and <c>Fetch.takeResponseBodyAsStream</c> (and with them the whole
-/// <c>IO</c> domain) need something further</b>: the seam hands the observer a response's headers while its
-/// body is still on the socket, so there are no bytes to give a paused client without buffering them first.
-/// <c>Network.getResponseBody</c> is what answers a body here.
+/// <c>IO</c> domain) need something further</b>: the pause has the response's headers while its body is
+/// still on the socket, so there are no bytes to give a paused client without buffering them first — a
+/// budget decision rather than a hook. <c>Network.getResponseBody</c> is what answers a body here.
 /// </para>
 /// <para>
 /// <b>No authentication challenge exists here.</b> <c>handleAuthRequests</c> is accepted and
@@ -60,6 +61,7 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
 {
     private readonly PageTarget _target;
     private readonly ConcurrentDictionary<string, PausedRequest> _paused = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, PausedResponse> _pausedResponses = new(StringComparer.Ordinal);
 
     private volatile RequestPattern[] _patterns = [];
     private long _lastInterception;
@@ -167,7 +169,102 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
         }
     }
 
-    /// <summary>Lets every paused request go, which disabling and detaching both do.</summary>
+    /// <summary>Whether this domain wants to be asked about <paramref name="request"/>'s response.</summary>
+    /// <remarks>
+    /// The response stage is opt-in per pattern, unlike the request stage: a client that named no
+    /// <c>requestStage</c> asked for the protocol's default, which is <c>Request</c>, and pausing its
+    /// responses as well would double every pause it expects.
+    /// </remarks>
+    internal bool WantsResponse(PageNetworkRequest request)
+    {
+        if (!IsEnabled)
+        {
+            return false;
+        }
+
+        foreach (var pattern in _patterns)
+        {
+            if (IsResponseStage(pattern) && Matches(pattern, request, RequestStageValues.Response))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Holds one response until the client answers it, and turns that answer into a decision.
+    /// </summary>
+    /// <remarks>
+    /// The same wait <see cref="PauseAsync"/> makes, at the other stage, and bounded by the same nothing of
+    /// this domain's own — the fetch carries the page's timeout and the document's token. A pause the token
+    /// ends delivers the response, because a fetch that has been abandoned is about to fail anyway.
+    /// </remarks>
+    internal async ValueTask<PageNetworkResponseDecision> PauseResponseAsync(
+        PageNetworkRequest request,
+        PageNetworkResponse response,
+        string frameId,
+        CancellationToken cancellationToken)
+    {
+        var id = "interception-job-" + Interlocked.Increment(ref _lastInterception).ToString(CultureInfo.InvariantCulture);
+        var paused = new PausedResponse();
+
+        _pausedResponses[id] = paused;
+
+        EmitDetached(ProtocolFetchEvents.RequestPaused(new RequestPausedEvent
+        {
+            RequestId = id,
+            Request = Describe(request),
+            FrameId = frameId,
+            ResourceType = ResourceTypeOf(request.Kind),
+            NetworkId = request.RequestId,
+
+            // What makes this a response-stage pause to every client: the protocol says the status code and
+            // the headers are present exactly then.
+            ResponseStatusCode = response.Status,
+            ResponseStatusText = response.StatusText,
+            ResponseHeaders = [.. response.Headers.Select(header => new HeaderEntry { Name = header.Name, Value = header.Value })],
+        }));
+
+        try
+        {
+            using var registration = cancellationToken.Register(
+                static state => ((PausedResponse) state!).Answer(PageNetworkResponseDecision.Proceed),
+                paused);
+
+            return await paused.Completion.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            _pausedResponses.TryRemove(id, out _);
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-continueResponse — the response
+    /// stage's own "let it through", with the status line and the header list rewritable and the body not:
+    /// the bytes have not been read and are still coming, so what this changes is what the response
+    /// <i>says</i>. <c>binaryResponseHeaders</c> is the same list in one <c>\0</c>-separated blob and is
+    /// read when a client sent it instead of <c>responseHeaders</c>.
+    /// </remarks>
+    protected override ValueTask<EmptyResult> ContinueResponseAsync(ContinueResponseRequest parameters, CommandContext context)
+    {
+        var paused = TakeResponse(parameters.RequestId);
+
+        IReadOnlyList<PageHeader>? headers = parameters.ResponseHeaders is { } declared
+            ? Headers(declared)
+            : Headers(parameters.BinaryResponseHeaders);
+
+        paused.Answer(headers is null && parameters.ResponseCode is null && parameters.ResponsePhrase is null
+            ? PageNetworkResponseDecision.Proceed
+            : PageNetworkResponseDecision.Continue(parameters.ResponseCode, parameters.ResponsePhrase, headers));
+
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <summary>Lets every paused request and response go, which disabling and detaching both do.</summary>
     internal void ContinueEverything()
     {
         foreach (var id in _paused.Keys)
@@ -177,13 +274,21 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
                 paused.Answer(PageNetworkDecision.Proceed);
             }
         }
+
+        foreach (var id in _pausedResponses.Keys)
+        {
+            if (_pausedResponses.TryRemove(id, out var paused))
+            {
+                paused.Answer(PageNetworkResponseDecision.Proceed);
+            }
+        }
     }
 
     /// <inheritdoc/>
     /// <remarks>
-    /// <c>interceptResponse</c> is accepted and never honoured, for the reason the class remarks give: this
-    /// browser has no response stage to pause at, so asking to be paused again after the response is asking
-    /// for something that would never arrive.
+    /// <c>interceptResponse</c> is accepted and never honoured: a client asking to be paused again after the
+    /// response is asking for a second pause on a request it has already released, and the way to get a
+    /// response-stage pause here is a pattern that asks for one.
     /// </remarks>
     protected override ValueTask<EmptyResult> ContinueRequestAsync(ContinueRequestRequest parameters, CommandContext context)
     {
@@ -206,14 +311,21 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
     /// </remarks>
     protected override ValueTask<EmptyResult> FulfillRequestAsync(FulfillRequestRequest parameters, CommandContext context)
     {
-        var paused = Take(parameters.RequestId);
-
         IReadOnlyList<PageHeader>? headers = parameters.ResponseHeaders is { } declared
             ? Headers(declared)
             : Headers(parameters.BinaryResponseHeaders);
 
         var body = parameters.Body is { } encoded ? Convert.FromBase64String(encoded) : [];
 
+        // Either stage: Chrome answers a response-stage pause with this command too, and there the bytes the
+        // server sent are discarded unread rather than never asked for.
+        if (_pausedResponses.TryRemove(parameters.RequestId, out var pausedResponse))
+        {
+            pausedResponse.Answer(PageNetworkResponseDecision.Fulfill(parameters.ResponseCode, headers, body, parameters.ResponsePhrase));
+            return new ValueTask<EmptyResult>(EmptyResult.Instance);
+        }
+
+        var paused = Take(parameters.RequestId);
         paused.Answer(PageNetworkDecision.Fulfill(parameters.ResponseCode, headers, body, parameters.ResponsePhrase));
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
@@ -221,6 +333,13 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
     /// <inheritdoc/>
     protected override ValueTask<EmptyResult> FailRequestAsync(FailRequestRequest parameters, CommandContext context)
     {
+        // Either stage, like fulfillRequest above.
+        if (_pausedResponses.TryRemove(parameters.RequestId, out var pausedResponse))
+        {
+            pausedResponse.Answer(PageNetworkResponseDecision.Fail(NetworkError(parameters.ErrorReason)));
+            return new ValueTask<EmptyResult>(EmptyResult.Instance);
+        }
+
         var paused = Take(parameters.RequestId);
         paused.Answer(PageNetworkDecision.Fail(NetworkError(parameters.ErrorReason)));
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
@@ -237,15 +356,31 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
         return paused!;
     }
 
+    /// <summary>The paused response one identifier names, or Chrome's own refusal.</summary>
+    private PausedResponse TakeResponse(string requestId)
+    {
+        if (!_pausedResponses.TryRemove(requestId, out var paused))
+        {
+            Throw.ServerError("Invalid InterceptionId.");
+        }
+
+        return paused!;
+    }
+
+    /// <summary>Whether one pattern asks about the response stage.</summary>
+    private static bool IsResponseStage(RequestPattern pattern)
+        => pattern.RequestStage is { } stage && string.Equals(stage, RequestStageValues.Response, StringComparison.Ordinal);
+
     /// <summary>Whether one pattern asks about one request.</summary>
     /// <remarks>
-    /// <c>requestStage: "Response"</c> matches nothing here until this domain is wired to the engine's
-    /// response stage; see the class remarks. A pattern with no
+    /// A pattern is asked about one stage at a time; a pattern with no
     /// <c>urlPattern</c> means every URL, which is the protocol's default.
     /// </remarks>
-    private static bool Matches(RequestPattern pattern, PageNetworkRequest request)
+    private static bool Matches(RequestPattern pattern, PageNetworkRequest request, string stage = RequestStageValues.Request)
     {
-        if (pattern.RequestStage is { } stage && string.Equals(stage, RequestStageValues.Response, StringComparison.Ordinal))
+        // A pattern with no requestStage means the protocol's default, which is Request.
+        var wanted = pattern.RequestStage ?? RequestStageValues.Request;
+        if (!string.Equals(wanted, stage, StringComparison.Ordinal))
         {
             return false;
         }
@@ -366,5 +501,19 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
 
         /// <summary>Answers the pause, ignoring a second answer for the same request.</summary>
         internal void Answer(PageNetworkDecision decision) => Completion.TrySetResult(decision);
+    }
+
+    /// <summary>
+    /// The response stage's own pause. A separate type from <see cref="PausedRequest"/> because the two
+    /// stages are answered with different decisions, and a separate map for the same reason — one identifier
+    /// space, two things it can name, and a command that looked in the wrong one would answer a client's
+    /// <c>continueResponse</c> with "Invalid InterceptionId" for an identifier it had just been given.
+    /// </summary>
+    private sealed class PausedResponse
+    {
+        internal TaskCompletionSource<PageNetworkResponseDecision> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Answers the pause, ignoring a second answer for the same response.</summary>
+        internal void Answer(PageNetworkResponseDecision decision) => Completion.TrySetResult(decision);
     }
 }

--- a/Jint.Browser/DevTools/NetworkDomain.Events.cs
+++ b/Jint.Browser/DevTools/NetworkDomain.Events.cs
@@ -83,6 +83,90 @@ internal sealed partial class NetworkDomain
     }
 
     /// <summary>The final response's headers are in.</summary>
+    /// <summary>
+    /// The four <c>WebSocket</c> events, over the engine's own <c>WebSocketObserver</c>
+    /// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 2).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A socket is not in the request log and takes no <c>Network.requestWillBeSent</c>.</b> That is the
+    /// protocol's own shape — Chrome gives a socket its own four events and its own identifier — and it is
+    /// also what keeps a page with an open socket from being a page whose network never goes quiet.
+    /// </para>
+    /// <para>
+    /// <b><c>webSocketFrameSent</c>, <c>webSocketFrameReceived</c> and <c>webSocketFrameError</c> are not
+    /// emitted</b>, and that is honest rather than pending: the engine's observer is told about the two
+    /// handshakes and the close, and a frame never reaches it. Reporting frames would mean an observer on
+    /// the message path, which is a decision about what a socket costs when somebody is watching.
+    /// </para>
+    /// </remarks>
+    internal void WebSocketCreated(string socketId, string url)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(ProtocolNetworkEvents.WebSocketCreated(new WebSocketCreatedEvent
+        {
+            RequestId = socketId,
+            Url = url,
+        }));
+    }
+
+    /// <inheritdoc cref="WebSocketCreated"/>
+    internal void WebSocketHandshakeRequest(string socketId, IReadOnlyList<PageHeader> headers)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(ProtocolNetworkEvents.WebSocketWillSendHandshakeRequest(new WebSocketWillSendHandshakeRequestEvent
+        {
+            RequestId = socketId,
+            Timestamp = Timestamp(),
+            WallTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000d,
+            Request = new WebSocketRequest { Headers = Map(headers) },
+        }));
+    }
+
+    /// <inheritdoc cref="WebSocketCreated"/>
+    internal void WebSocketHandshakeResponse(string socketId, int status, string statusText, IReadOnlyList<PageHeader> headers)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(ProtocolNetworkEvents.WebSocketHandshakeResponseReceived(new WebSocketHandshakeResponseReceivedEvent
+        {
+            RequestId = socketId,
+            Timestamp = Timestamp(),
+            Response = new WebSocketResponse
+            {
+                Status = status,
+                StatusText = statusText,
+                Headers = Map(headers),
+            },
+        }));
+    }
+
+    /// <inheritdoc cref="WebSocketCreated"/>
+    internal void WebSocketClosed(string socketId)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        EmitDetached(ProtocolNetworkEvents.WebSocketClosed(new WebSocketClosedEvent
+        {
+            RequestId = socketId,
+            Timestamp = Timestamp(),
+        }));
+    }
+
     internal void ResponseReceived(PageNetworkRequest request, PageNetworkResponse response, string frameId)
     {
         if (!IsEnabled)

--- a/Jint.Browser/DevTools/NetworkDomain.cs
+++ b/Jint.Browser/DevTools/NetworkDomain.cs
@@ -34,8 +34,11 @@ namespace Jint.Browser.DevTools;
 /// was handed over and <c>receiveHeadersStart</c>/<c>receiveHeadersEnd</c> when its headers were in, so a
 /// client reads a real time to first byte, while proxy, DNS, connect, TLS, worker and push are <c>-1</c> —
 /// the protocol's value for a phase that did not happen here — because a document of zeros would read as a
-/// page that loaded instantly. <c>WebSocket</c> and <c>EventSource</c> produce no events either — the engine
-/// deliberately does not observe those two handshakes, and half a report is worse than none.
+/// page that loaded instantly. A <c>WebSocket</c> takes the four events the protocol gives a socket — its
+/// creation, both handshakes and its close — over the engine's own socket observer, and no
+/// <c>webSocketFrame*</c> event, because that observer is never told about a frame. <c>EventSource</c>
+/// produces none of its own: its stream is observed as bytes rather than as the events they decode into, so
+/// its request is in the log as <c>ResourceType: EventSource</c> and its messages are nowhere.
 /// </para>
 /// <para>
 /// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Network/"/>.

--- a/Jint.Browser/DevTools/PageTarget.Network.cs
+++ b/Jint.Browser/DevTools/PageTarget.Network.cs
@@ -159,6 +159,51 @@ internal sealed partial class PageTarget : IPageNetworkListener
     }
 
     /// <inheritdoc/>
+    async ValueTask<PageNetworkResponseDecision> IPageNetworkListener.ResponseWillBeDeliveredAsync(
+        PageNetworkRequest request,
+        PageNetworkResponse response,
+        CancellationToken cancellationToken)
+    {
+        if (_interceptor is not { } interceptor || !interceptor.WantsResponse(request))
+        {
+            return PageNetworkResponseDecision.Proceed;
+        }
+
+        return await interceptor.PauseResponseAsync(request, response, FrameId, cancellationToken).ConfigureAwait(false);
+    }
+
+    void IPageNetworkListener.WebSocketCreated(string socketId, string url)
+    {
+        foreach (var domain in NetworkDomains())
+        {
+            domain.WebSocketCreated(socketId, url);
+        }
+    }
+
+    void IPageNetworkListener.WebSocketHandshakeRequest(string socketId, IReadOnlyList<PageHeader> headers)
+    {
+        foreach (var domain in NetworkDomains())
+        {
+            domain.WebSocketHandshakeRequest(socketId, headers);
+        }
+    }
+
+    void IPageNetworkListener.WebSocketHandshakeResponse(string socketId, int status, string statusText, IReadOnlyList<PageHeader> headers)
+    {
+        foreach (var domain in NetworkDomains())
+        {
+            domain.WebSocketHandshakeResponse(socketId, status, statusText, headers);
+        }
+    }
+
+    void IPageNetworkListener.WebSocketClosed(string socketId)
+    {
+        foreach (var domain in NetworkDomains())
+        {
+            domain.WebSocketClosed(socketId);
+        }
+    }
+
     void IPageNetworkListener.ResponseReceived(PageNetworkRequest request, PageNetworkResponse response)
     {
         foreach (var domain in NetworkDomains())

--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -208,7 +208,12 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     /// </remarks>
     internal override bool RunsOffThread(string method) => method switch
     {
-        "Fetch.continueRequest" or "Fetch.failRequest" or "Fetch.fulfillRequest" => true,
+        // continueResponse joins the three for the same reason and it is not a weaker one: a <script src>
+        // a running script inserted is fetched with the loop *blocked* on the whole fetch — ParserDriver's
+        // `fetch.GetAwaiter().GetResult()` — so the loop is held from the request stage through the body
+        // read, and a response-stage pause holds it exactly as a request-stage pause does. All four look one
+        // entry up in a dictionary and complete a promise: no engine, no JsValue, no node.
+        "Fetch.continueRequest" or "Fetch.failRequest" or "Fetch.fulfillRequest" or "Fetch.continueResponse" => true,
         _ => false,
     };
 

--- a/Jint.Browser/Runtime/BrowserEngineFactory.cs
+++ b/Jint.Browser/Runtime/BrowserEngineFactory.cs
@@ -177,6 +177,10 @@ internal static class BrowserEngineFactory
         fetch.CookieJar = request.Network.CookieJar;
         fetch.Observer = request.Requests;
 
+        // The socket half of the same recorder. Two engine seams, one page-side consumer: a socket is not a
+        // request, so it takes no entry in the log and only reaches the Network domain's own four events.
+        fetch.WebSocketObserver = request.Requests.Sockets;
+
         // https://fetch.spec.whatwg.org/#default-user-agent-value: what this document's fetches, its
         // XMLHttpRequests and — through the worker provider — its workers put on the wire is the same string
         // navigator.userAgent answers. An override a client sets *after* the engine was built reaches the

--- a/Jint.Browser/Runtime/PageNetworkListener.cs
+++ b/Jint.Browser/Runtime/PageNetworkListener.cs
@@ -113,6 +113,60 @@ internal sealed record PageNetworkResponse(
     bool FromInterception,
     FetchTiming? Timing);
 
+/// <summary>What a listener decided about one response.</summary>
+/// <remarks>
+/// The response half of <see cref="PageNetworkDecision"/>, and deliberately a separate type: what a client
+/// may do to a response is not what it may do to a request. There is no <c>Continue</c> with a rewritten URL
+/// or method — the response has already been produced — and <c>Fulfill</c> discards a body that is still on
+/// the socket rather than one that was never sent.
+/// </remarks>
+internal sealed class PageNetworkResponseDecision
+{
+    private PageNetworkResponseDecision()
+    {
+    }
+
+    /// <summary>Deliver the response as the server sent it.</summary>
+    internal static PageNetworkResponseDecision Proceed { get; } = new() { Kind = PageNetworkDecisionKind.Proceed };
+
+    internal PageNetworkDecisionKind Kind { get; private init; }
+
+    internal int Status { get; private init; }
+
+    internal string? StatusText { get; private init; }
+
+    internal IReadOnlyList<PageHeader>? Headers { get; private init; }
+
+    internal ReadOnlyMemory<byte> Body { get; private init; }
+
+    internal string? Error { get; private init; }
+
+    /// <summary>Deliver the response with its status line or headers rewritten — <c>Fetch.continueResponse</c>.</summary>
+    internal static PageNetworkResponseDecision Continue(int? status, string? statusText, IReadOnlyList<PageHeader>? headers)
+        => new()
+        {
+            Kind = PageNetworkDecisionKind.Continue,
+            Status = status ?? 0,
+            StatusText = statusText,
+            Headers = headers,
+        };
+
+    /// <summary>Answer with the client's own response — <c>Fetch.fulfillRequest</c> from a response pause.</summary>
+    internal static PageNetworkResponseDecision Fulfill(int status, IReadOnlyList<PageHeader>? headers, ReadOnlyMemory<byte> body, string? statusText)
+        => new()
+        {
+            Kind = PageNetworkDecisionKind.Fulfill,
+            Status = status,
+            StatusText = statusText,
+            Headers = headers,
+            Body = body,
+        };
+
+    /// <summary>Fail it — <c>Fetch.failRequest</c> from a response pause.</summary>
+    internal static PageNetworkResponseDecision Fail(string error)
+        => new() { Kind = PageNetworkDecisionKind.Fail, Error = error };
+}
+
 /// <summary>What a listener decided about one hop.</summary>
 /// <remarks>
 /// It is deliberately not <c>Jint.WebApi.Fetch.FetchInterception</c>: that type is the engine's preview
@@ -238,7 +292,24 @@ internal interface IPageNetworkListener
     /// </remarks>
     ValueTask<PageNetworkDecision> RequestWillBeSentAsync(PageNetworkRequest request, CancellationToken cancellationToken);
 
-    /// <summary>The final response's headers are in and its body has not been read.</summary>
+    /// <summary>
+    /// The final response's headers are in and its body has not been read; answer what should happen to it.
+    /// </summary>
+    /// <param name="request">The request, as its last hop went out.</param>
+    /// <param name="response">The response, as the server sent it.</param>
+    /// <param name="cancellationToken">Cancelled when the fetch is abandoned or times out.</param>
+    /// <remarks>
+    /// <b>The ask, and <see cref="ResponseReceived"/> is the notification.</b> They are separate calls and
+    /// both happen, in that order, exactly as the engine's own <c>OnResponseAsync</c> and <c>OnResponse</c>
+    /// are — so a client that rewrote a status sees its own value in the announcement that follows. The wait
+    /// is bounded by the page's own timeouts, and it holds the transport thread the request is on.
+    /// </remarks>
+    ValueTask<PageNetworkResponseDecision> ResponseWillBeDeliveredAsync(
+        PageNetworkRequest request,
+        PageNetworkResponse response,
+        CancellationToken cancellationToken);
+
+    /// <summary>The final response, after any answer above has been applied.</summary>
     /// <param name="request">The request, as its last hop went out.</param>
     /// <param name="response">The response.</param>
     void ResponseReceived(PageNetworkRequest request, PageNetworkResponse response);
@@ -260,6 +331,32 @@ internal interface IPageNetworkListener
     /// <param name="canceled">Whether it was abandoned rather than refused.</param>
     /// <param name="blockedReason">Why a client blocked it, or <see langword="null"/>.</param>
     void LoadingFailed(string requestId, PageRequestKind kind, string errorText, bool canceled, string? blockedReason);
+
+    /// <summary>A socket was constructed.</summary>
+    /// <param name="socketId">The socket, which is not a request identifier.</param>
+    /// <param name="url">The URL the script asked for.</param>
+    /// <remarks>
+    /// <b>The four socket calls are outside the request lifecycle</b>, and that is the point of them being
+    /// four calls rather than entries in the log: a socket stays open for as long as the page wants it, so
+    /// counting one as an outstanding request would leave a host waiting for a network that never goes quiet.
+    /// </remarks>
+    void WebSocketCreated(string socketId, string url);
+
+    /// <summary>A socket's opening handshake is going out.</summary>
+    /// <param name="socketId">The socket.</param>
+    /// <param name="headers">The headers this engine set on it; the rest are inside <c>ClientWebSocket</c>.</param>
+    void WebSocketHandshakeRequest(string socketId, IReadOnlyList<PageHeader> headers);
+
+    /// <summary>A socket's opening handshake was answered.</summary>
+    /// <param name="socketId">The socket.</param>
+    /// <param name="status">The HTTP status, which is <c>101</c> for a handshake that succeeded.</param>
+    /// <param name="statusText">The reason phrase, which may be empty.</param>
+    /// <param name="headers">The response headers.</param>
+    void WebSocketHandshakeResponse(string socketId, int status, string statusText, IReadOnlyList<PageHeader> headers);
+
+    /// <summary>A socket closed, for any reason.</summary>
+    /// <param name="socketId">The socket.</param>
+    void WebSocketClosed(string socketId);
 
     /// <summary>A reference the page saw and deliberately did not follow.</summary>
     /// <param name="request">The reference, as a request that was never sent.</param>

--- a/Jint.Browser/Runtime/PageNetworkRecorder.cs
+++ b/Jint.Browser/Runtime/PageNetworkRecorder.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Jint.WebApi.Fetch;
+using Jint.WebApi.WebSockets;
 
 namespace Jint.Browser.Runtime;
 
@@ -325,6 +326,106 @@ internal sealed class PageNetworkRecorder : FetchObserver
         return Translate(entry, decision);
     }
 
+    /// <summary>
+    /// The response stage: the client is asked what to do with the response before its body is read, and
+    /// before <see cref="OnResponse"/> announces it.
+    /// </summary>
+    /// <remarks>
+    /// <b>It holds the transport thread the request is on, and that is the point.</b> A
+    /// <c>&lt;script src&gt;</c> a running script inserted is fetched with the page loop <i>blocked</i> on
+    /// the whole fetch rather than pumping through it, so a response-stage pause holds the loop exactly as a
+    /// request-stage one does — which is why the command that releases it is named in
+    /// <c>PageTarget.RunsOffThread</c> beside the three that release a request.
+    /// </remarks>
+    public override async ValueTask<FetchResponseInterception?> OnResponseAsync(
+        ObservedFetchResponse response,
+        CancellationToken cancellationToken)
+    {
+        if (response.IsRedirect || _listener is not { } listener)
+        {
+            return null;
+        }
+
+        Entry? entry;
+        PageNetworkResponse described;
+
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(response.Id.Value, out entry))
+            {
+                return null;
+            }
+
+            described = Describe(entry.RequestId, response)!;
+        }
+
+        if (entry.LastHop is not { } hop)
+        {
+            return null;
+        }
+
+        PageNetworkResponseDecision decision;
+        try
+        {
+            decision = await listener.ResponseWillBeDeliveredAsync(hop, described, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // a watcher that failed must not decide the response; see IPageNetworkListener
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+            return null;
+        }
+
+        return Translate(decision);
+    }
+
+    /// <summary>The client's answer, as the engine's own preview type.</summary>
+    private static FetchResponseInterception? Translate(PageNetworkResponseDecision decision)
+    {
+        switch (decision.Kind)
+        {
+            case PageNetworkDecisionKind.Fail:
+                return FetchResponseInterception.Fail(decision.Error ?? "net::ERR_FAILED");
+
+            case PageNetworkDecisionKind.Fulfill:
+                return FetchResponseInterception.Fulfill(
+                    decision.Status,
+                    Headers(decision.Headers),
+                    decision.Body,
+                    decision.StatusText);
+
+            case PageNetworkDecisionKind.Continue:
+                return FetchResponseInterception.Continue(
+                    decision.Status == 0 ? null : decision.Status,
+                    decision.StatusText,
+                    Headers(decision.Headers));
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>One header list in the engine's spelling, or <see langword="null"/> for none.</summary>
+    private static FetchHeader[]? Headers(IReadOnlyList<PageHeader>? headers)
+    {
+        if (headers is null)
+        {
+            return null;
+        }
+
+        var translated = new FetchHeader[headers.Count];
+        for (var i = 0; i < translated.Length; i++)
+        {
+            translated[i] = new FetchHeader(headers[i].Name, headers[i].Value);
+        }
+
+        return translated;
+    }
+
     /// <inheritdoc />
     public override void OnResponse(ObservedFetchResponse response)
     {
@@ -362,6 +463,89 @@ internal sealed class PageNetworkRecorder : FetchObserver
         if (_listener is { } listener && entry.LastHop is { } hop)
         {
             Safely(() => listener.ResponseReceived(hop, described));
+        }
+    }
+
+    /// <summary>
+    /// The socket half of this recorder, which is a second observer because the engine has two seams —
+    /// <c>FetchObserver</c> for requests and <c>WebSocketObserver</c> for sockets — and one class can derive
+    /// from only one of them.
+    /// </summary>
+    /// <remarks>
+    /// It writes to no log and holds no state: a socket is not a request, so it neither takes an entry nor
+    /// appears in <c>Page.Requests</c>. All it does is turn four engine callbacks into four listener calls,
+    /// on the transport thread they arrived on.
+    /// </remarks>
+    internal WebSocketObserver Sockets => _sockets ??= new SocketRecorder(this);
+
+    private WebSocketObserver? _sockets;
+
+    private sealed class SocketRecorder : WebSocketObserver
+    {
+        private readonly PageNetworkRecorder _recorder;
+
+        internal SocketRecorder(PageNetworkRecorder recorder)
+        {
+            _recorder = recorder;
+        }
+
+        public override void OnCreated(WebSocketId id, Uri url)
+        {
+            if (_recorder._listener is { } listener)
+            {
+                var socketId = Name(id);
+                var absolute = url.AbsoluteUri;
+                Safely(() => listener.WebSocketCreated(socketId, absolute));
+            }
+        }
+
+        public override void OnHandshakeRequest(ObservedWebSocketHandshake handshake)
+        {
+            if (_recorder._listener is { } listener)
+            {
+                var socketId = Name(handshake.Id);
+                var headers = Translate(handshake.Headers);
+                Safely(() => listener.WebSocketHandshakeRequest(socketId, headers));
+            }
+        }
+
+        public override void OnHandshakeResponse(ObservedWebSocketResponse response)
+        {
+            if (_recorder._listener is { } listener)
+            {
+                var socketId = Name(response.Id);
+                var headers = Translate(response.Headers);
+                var status = response.Status;
+                Safely(() => listener.WebSocketHandshakeResponse(socketId, status, string.Empty, headers));
+            }
+        }
+
+        public override void OnClosed(WebSocketId id, int code, string reason, bool wasClean)
+        {
+            if (_recorder._listener is { } listener)
+            {
+                var socketId = Name(id);
+                Safely(() => listener.WebSocketClosed(socketId));
+            }
+        }
+
+        /// <summary>
+        /// One socket's protocol identifier. A request identifier here is the bare number the engine minted,
+        /// so the prefix is what keeps the two spaces apart: a client must not be able to mistake a socket
+        /// for a request it can ask a body of, and the engine's own counters are separate already.
+        /// </summary>
+        private static string Name(WebSocketId id)
+            => "ws-" + id.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        private static PageHeader[] Translate(IReadOnlyList<FetchHeader> headers)
+        {
+            var translated = new PageHeader[headers.Count];
+            for (var i = 0; i < translated.Length; i++)
+            {
+                translated[i] = new PageHeader(headers[i].Name, headers[i].Value);
+            }
+
+            return translated;
         }
     }
 

--- a/Jint.DevTools/Protocol/Generated/Fetch.g.cs
+++ b/Jint.DevTools/Protocol/Generated/Fetch.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/browser_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, Fetch entries, sha256:fdd25ab0ff9b
+//     manifest: tools/devtools-protocol/manifest.json, Fetch entries, sha256:b01623b203c2
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -468,6 +468,12 @@ namespace Jint.DevTools.Domains
                 case "continueRequest":
                 {
                     var result = await ContinueRequestAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.FetchContinueRequestRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "continueResponse":
+                {
+                    var result = await ContinueResponseAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.FetchContinueResponseRequest), context).ConfigureAwait(false);
                     return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
                 }
 

--- a/Jint.DevTools/Protocol/Generated/Network.g.cs
+++ b/Jint.DevTools/Protocol/Generated/Network.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/browser_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, Network entries, sha256:569f79078fb3
+//     manifest: tools/devtools-protocol/manifest.json, Network entries, sha256:1644bfa99ccc
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and

--- a/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:9b32516cf85f
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:ff928e6894f7
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and

--- a/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:9b32516cf85f
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:ff928e6894f7
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -151,6 +151,7 @@ namespace Jint.DevTools.Protocol
             "Emulation.setUserAgentOverride",
             "Emulation.setVisibleSize",
             "Fetch.continueRequest",
+            "Fetch.continueResponse",
             "Fetch.disable",
             "Fetch.enable",
             "Fetch.failRequest",
@@ -287,6 +288,10 @@ namespace Jint.DevTools.Protocol
             "Network.requestWillBeSentExtraInfo",
             "Network.responseReceived",
             "Network.responseReceivedExtraInfo",
+            "Network.webSocketClosed",
+            "Network.webSocketCreated",
+            "Network.webSocketHandshakeResponseReceived",
+            "Network.webSocketWillSendHandshakeRequest",
             "Page.domContentEventFired",
             "Page.frameNavigated",
             "Page.frameRequestedNavigation",

--- a/Jint.Tests.Browser/DevTools/FetchDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/FetchDomainTests.cs
@@ -310,6 +310,168 @@ public class FetchDomainTests
     }
 
     /// <summary>A page, its target, and an attachment ready to intercept.</summary>
+    // ---------------------------------------------------------------- the response stage
+
+    /// <summary>
+    /// A pattern asking for <c>requestStage: "Response"</c> pauses with the response's status and headers,
+    /// and <c>Fetch.continueResponse</c> lets it through —
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-continueResponse.
+    /// </summary>
+    /// <remarks>
+    /// The whole stage was absent while <c>FetchObserver.OnResponse</c> was a notification an observer could
+    /// not answer (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 1).
+    /// </remarks>
+    [Test]
+    public async Task AResponseStagePausePresentsTheStatusAndHeadersAndContinueResponseLetsItThrough()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><head><title>Delivered</title></head><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*","requestStage":"Response"}]}""");
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+
+        var paused = await fixture.PausedAsync();
+        paused.GetProperty("responseStatusCode").GetInt32().Should().Be(200);
+        paused.GetProperty("request").GetProperty("url").GetString().Should().Be(server.Url("/page"));
+        paused.TryGetProperty("responseHeaders", out var headers).Should().BeTrue();
+        headers.GetArrayLength().Should().BeGreaterThan(0);
+
+        await fixture.Session.ResultAsync(
+            "Fetch.continueResponse",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment);
+
+        await navigation.WaitAsync(Bound);
+
+        (await fixture.Page.TitleAsync()).Should().Be("Delivered");
+        server.Received.Should().ContainSingle(received => received.Path == "/page");
+    }
+
+    /// <summary>
+    /// And it rewrites: <c>continueResponse</c> with a status and headers changes what the response
+    /// <i>says</i>, while the body the server sent still arrives.
+    /// </summary>
+    [Test]
+    public async Task ContinueResponseCanRewriteTheStatusAndHeadersAndKeepTheBody()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text("the real body"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        // The answer is parked on the page rather than awaited here: Page.EvaluateAsync converts what the
+        // expression returned, and what this one returns is a promise.
+        await fixture.Page.EvaluateAsync("""
+            window.__answer = null;
+            fetch('/data').then(r => r.text().then(t => {
+              window.__answer = r.status + '|' + r.headers.get('x-rewritten') + '|' + t;
+            }));
+            """);
+
+        var paused = await fixture.PausedAsync();
+        await fixture.Session.ResultAsync(
+            "Fetch.continueResponse",
+            $$"""
+            {"requestId":"{{paused.GetProperty("requestId").GetString()}}","responseCode":203,
+             "responsePhrase":"Rewritten",
+             "responseHeaders":[{"name":"content-type","value":"text/plain"},{"name":"x-rewritten","value":"yes"}]}
+            """,
+            fixture.Attachment);
+
+        (await fixture.Page.WaitForAsync("window.__answer !== null", Bound)).Should().BeTrue();
+        (await fixture.Page.EvaluateAsync<string>("window.__answer")).Should().Be("203|yes|the real body");
+    }
+
+    /// <summary>
+    /// <c>Fetch.fulfillRequest</c> answers a <i>response</i>-stage pause too: the bytes the server sent are
+    /// discarded unread and the client's own response is what the page gets.
+    /// </summary>
+    [Test]
+    public async Task FulfillRequestAnswersAResponseStagePause()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><head><title>Origin</title></head><body>from the server</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*","requestStage":"Response"}]}""");
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        var paused = await fixture.PausedAsync();
+
+        var body = Convert.ToBase64String(Encoding.UTF8.GetBytes("<html><head><title>Substituted</title></head><body>from the client</body></html>"));
+        await fixture.Session.ResultAsync(
+            "Fetch.fulfillRequest",
+            $$"""
+            {"requestId":"{{paused.GetProperty("requestId").GetString()}}","responseCode":200,
+             "responseHeaders":[{"name":"Content-Type","value":"text/html; charset=utf-8"}],
+             "body":"{{body}}"}
+            """,
+            fixture.Attachment);
+
+        await navigation.WaitAsync(Bound);
+
+        (await fixture.Page.TitleAsync()).Should().Be("Substituted");
+        (await fixture.Page.ContentAsync()).Should().Contain("from the client");
+
+        // Unlike a request-stage fulfil, the origin *was* reached: the pause is after the response came back.
+        server.Received.Should().ContainSingle(received => received.Path == "/page");
+    }
+
+    /// <summary>And <c>Fetch.failRequest</c> fails one, which the page sees as a navigation failure.</summary>
+    [Test]
+    public async Task FailRequestAnswersAResponseStagePause()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*","requestStage":"Response"}]}""");
+
+        var navigate = fixture.Session.SendAsync("Page.navigate", $$"""{"url":"{{server.Url("/page")}}"}""", fixture.Attachment);
+
+        var paused = await fixture.PausedAsync();
+        await fixture.Session.ResultAsync(
+            "Fetch.failRequest",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}","errorReason":"AccessDenied"}""",
+            fixture.Attachment);
+
+        var reply = await navigate.WaitAsync(Bound);
+        reply.GetProperty("result").GetProperty("errorText").GetString().Should().Be("net::ERR_ACCESS_DENIED");
+    }
+
+    /// <summary>
+    /// A client that named no <c>requestStage</c> asked for the protocol's default, which is
+    /// <c>Request</c> — so it is paused once, before the request goes out, and never again after it comes
+    /// back. Pausing both stages for one pattern would double every pause every recorded client expects.
+    /// </summary>
+    [Test]
+    public async Task ADefaultPatternPausesTheRequestStageOnly()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><head><title>Once</title></head><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync();
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+
+        var paused = await fixture.PausedAsync();
+        paused.TryGetProperty("responseStatusCode", out var status).Should().BeFalse("a request-stage pause has no response yet");
+        _ = status;
+
+        await fixture.ContinueAsync(paused);
+        await navigation.WaitAsync(Bound);
+
+        fixture.Session.EventsOf("Fetch.requestPaused", fixture.Attachment).Should().HaveCount(
+            1,
+            "the default stage is Request, so the response is never paused at");
+    }
+
     private sealed class InterceptionFixture : IAsyncDisposable
     {
         private InterceptionFixture(PageSession session, Page page, string attachment, string frameId)

--- a/Jint.Tests.Browser/DevTools/NetworkDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/NetworkDomainTests.cs
@@ -376,6 +376,55 @@ public class NetworkDomainTests
         (await fixture.Page.EvaluateAsync<string>("navigator.userAgent")).Should().Be("ViaNetwork/1.0");
     }
 
+    /// <summary>
+    /// A <c>WebSocket</c> reaches a client as the <c>Network</c> domain's own four events rather than as a
+    /// request — https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-webSocketCreated.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A socket is deliberately not in the request log.</b> It stays open for as long as the page wants
+    /// it, so an entry would leave a request outstanding for that whole time and a client waiting for the
+    /// network to go quiet would wait for ever
+    /// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 2).
+    /// </para>
+    /// <para>
+    /// The URL here is one the context's own filter refuses, which is what lets this run with no WebSocket
+    /// server: a refused socket is still created and still closes, which is the pair that proves the whole
+    /// chain — the engine's observer, the recorder, the listener, the target, the domain, the client. What
+    /// the two <i>handshake</i> events carry is pinned one level down, in
+    /// <c>Jint.Tests/Runtime/WebApi/WebSocketTests</c>, over a connection double.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task ASocketReachesAClientAsTheFourWebSocketEventsAndNotAsARequest()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        // A page does not carry WebSocket by default, so the host turns it on the way an embedder would.
+        var options = new BrowserOptions().ConfigureEngine(
+            engine => engine.WebApi.Features |= WebApiFeatures.WebSocket);
+
+        await using var fixture = await NetworkFixture.OpenAsync(server, options);
+        await fixture.NavigateAsync("/page");
+
+        await fixture.Page.EvaluateAsync("new WebSocket('wss://elsewhere.invalid/socket');");
+
+        var created = await fixture.Session.EventAsync("Network.webSocketCreated", sessionId: fixture.Attachment, timeoutSeconds: 30);
+        created.GetProperty("url").GetString().Should().Be("wss://elsewhere.invalid/socket");
+
+        var socketId = created.GetProperty("requestId").GetString();
+        socketId.Should().StartWith("ws-", "a socket identifier is not a request identifier");
+
+        var closed = await fixture.Session.EventAsync("Network.webSocketClosed", sessionId: fixture.Attachment, timeoutSeconds: 30);
+        closed.GetProperty("requestId").GetString().Should().Be(socketId);
+
+        // And nothing about it is in the request log, which is what keeps the network able to go quiet.
+        fixture.Page.Requests.Should().NotContain(
+            request => request.Url.StartsWith("wss:", StringComparison.Ordinal),
+            "a socket is not a request and must not be one that never finishes");
+    }
+
     [Test]
     public async Task CookiesRoundTripThroughTheContextsJar()
     {

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -332,6 +332,8 @@ namespace Jint
             public System.TimeSpan Timeout { get; set; }
             public System.Func<System.Uri, bool> UrlFilter { get; set; }
             public string? UserAgent { get; set; }
+            [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+            public Jint.WebApi.WebSockets.WebSocketObserver? WebSocketObserver { get; set; }
         }
         public sealed class HostOptions
         {
@@ -3156,5 +3158,41 @@ namespace Jint.WebApi.Fetch
         StrictOrigin = 5,
         StrictOriginWhenCrossOrigin = 6,
         UnsafeUrl = 7,
+    }
+}
+namespace Jint.WebApi.WebSockets
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedWebSocketHandshake : System.IEquatable<Jint.WebApi.WebSockets.ObservedWebSocketHandshake>
+    {
+        public ObservedWebSocketHandshake() { }
+        public required System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> Headers { get; init; }
+        public required Jint.WebApi.WebSockets.WebSocketId Id { get; init; }
+        public required System.Collections.Generic.IReadOnlyList<string> Protocols { get; init; }
+        public required System.Uri Url { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedWebSocketResponse : System.IEquatable<Jint.WebApi.WebSockets.ObservedWebSocketResponse>
+    {
+        public ObservedWebSocketResponse() { }
+        public required System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> Headers { get; init; }
+        public required Jint.WebApi.WebSockets.WebSocketId Id { get; init; }
+        public required int Status { get; init; }
+        public required string SubProtocol { get; init; }
+    }
+    public readonly struct WebSocketId : System.IEquatable<Jint.WebApi.WebSockets.WebSocketId>
+    {
+        public WebSocketId(long Value) { }
+        public long Value { get; init; }
+        public override string ToString() { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public abstract class WebSocketObserver
+    {
+        protected WebSocketObserver() { }
+        public virtual void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean) { }
+        public virtual void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, System.Uri url) { }
+        public virtual void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake) { }
+        public virtual void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response) { }
     }
 }

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -332,6 +332,8 @@ namespace Jint
             public System.TimeSpan Timeout { get; set; }
             public System.Func<System.Uri, bool> UrlFilter { get; set; }
             public string? UserAgent { get; set; }
+            [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+            public Jint.WebApi.WebSockets.WebSocketObserver? WebSocketObserver { get; set; }
         }
         public sealed class HostOptions
         {
@@ -3156,5 +3158,41 @@ namespace Jint.WebApi.Fetch
         StrictOrigin = 5,
         StrictOriginWhenCrossOrigin = 6,
         UnsafeUrl = 7,
+    }
+}
+namespace Jint.WebApi.WebSockets
+{
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedWebSocketHandshake : System.IEquatable<Jint.WebApi.WebSockets.ObservedWebSocketHandshake>
+    {
+        public ObservedWebSocketHandshake() { }
+        public required System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> Headers { get; init; }
+        public required Jint.WebApi.WebSockets.WebSocketId Id { get; init; }
+        public required System.Collections.Generic.IReadOnlyList<string> Protocols { get; init; }
+        public required System.Uri Url { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedWebSocketResponse : System.IEquatable<Jint.WebApi.WebSockets.ObservedWebSocketResponse>
+    {
+        public ObservedWebSocketResponse() { }
+        public required System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> Headers { get; init; }
+        public required Jint.WebApi.WebSockets.WebSocketId Id { get; init; }
+        public required int Status { get; init; }
+        public required string SubProtocol { get; init; }
+    }
+    public readonly struct WebSocketId : System.IEquatable<Jint.WebApi.WebSockets.WebSocketId>
+    {
+        public WebSocketId(long Value) { }
+        public long Value { get; init; }
+        public override string ToString() { }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public abstract class WebSocketObserver
+    {
+        protected WebSocketObserver() { }
+        public virtual void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean) { }
+        public virtual void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, System.Uri url) { }
+        public virtual void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake) { }
+        public virtual void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response) { }
     }
 }

--- a/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
@@ -889,7 +889,16 @@ public class WebApiFetchDocumentTests
     {
         // The whole point of the seam: a protocol layer runs it from a transport thread, so nothing it is
         // handed may be a value only the engine thread may touch.
-        var types = new[] { typeof(FetchObserver), typeof(ObservedFetchRequest), typeof(ObservedFetchResponse), typeof(FetchInterception), typeof(FetchResponseInterception), typeof(FetchRequestId), typeof(FetchHeader), typeof(FetchTiming) };
+        var types = new[]
+        {
+            typeof(FetchObserver), typeof(ObservedFetchRequest), typeof(ObservedFetchResponse),
+            typeof(FetchInterception), typeof(FetchResponseInterception), typeof(FetchRequestId),
+            typeof(FetchHeader), typeof(FetchTiming),
+
+            // The socket seam is a second observer with the same rule, so it takes the same walk.
+            typeof(Jint.WebApi.WebSockets.WebSocketObserver), typeof(Jint.WebApi.WebSockets.WebSocketId),
+            typeof(Jint.WebApi.WebSockets.ObservedWebSocketHandshake), typeof(Jint.WebApi.WebSockets.ObservedWebSocketResponse),
+        };
 
         foreach (var type in types)
         {

--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -1,5 +1,6 @@
 #if NET8_0_OR_GREATER
 #nullable enable
+#pragma warning disable JINT0002 // the WebSocket observer is a preview surface
 
 using System.Diagnostics;
 using System.Threading;
@@ -80,6 +81,16 @@ public class WebSocketTests
         internal TaskCompletionSource Handshake { get; } = new();
 
         public string SubProtocol { get; set; } = string.Empty;
+
+        /// <summary>What the "server" answered the opening handshake with, if anything.</summary>
+        public int? HandshakeStatus { get; set; }
+
+        /// <inheritdoc />
+        public IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> HandshakeHeaders { get; set; } = [];
+
+        /// <inheritdoc />
+        public IReadOnlyList<Jint.WebApi.Fetch.FetchHeader> RequestHeaders { get; set; } =
+            [new Jint.WebApi.Fetch.FetchHeader("user-agent", "Jint/test")];
 
         internal List<(byte[] Payload, bool IsText)> Sent { get; } = new();
 
@@ -288,6 +299,216 @@ public class WebSocketTests
         PumpUntilLogged(engine, 1);
 
         return (engine, sockets);
+    }
+
+    /// <summary>
+    /// The four moments a <c>WebSocketObserver</c> is told about, in the order
+    /// <see cref="Jint.WebApi.WebSockets.WebSocketObserver"/> fixes them:
+    /// <c>OnCreated</c>, <c>OnHandshakeRequest</c>, <c>OnHandshakeResponse</c> and one <c>OnClosed</c>.
+    /// </summary>
+    /// <remarks>
+    /// The seam is deliberately not <c>FetchObserver</c>'s — a socket's handshake never reaches the fetch
+    /// transport and its frames are not a body — and deliberately carries an identifier of its own, so that a
+    /// host waiting for its network to go quiet is not waiting on a socket that is meant to stay open
+    /// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 2).
+    /// </remarks>
+    [Test]
+    public void AnObserverIsToldAboutTheHandshakeAndTheClose()
+    {
+        var observer = new RecordingSocketObserver();
+        var (engine, sockets) = SocketEngine(fetch => fetch.WebSocketObserver = observer);
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/socket', ['chat', 'v2']);
+            ws.onopen = () => log.push('open');
+            """);
+
+        sockets.Last.HandshakeStatus = 101;
+        sockets.Last.HandshakeHeaders = [new Jint.WebApi.Fetch.FetchHeader("sec-websocket-accept", "abc")];
+        sockets.Last.SubProtocol = "chat";
+        sockets.Last.Handshake.SetResult();
+
+        // The wait is for `open`, not for the observer's third call, and the difference is the whole of
+        // https://github.com/sebastienros/jint/issues/3701's CI failure: the response is reported to the
+        // observer *before* the open task is queued, so a close() sent on the strength of that third event
+        // can still land while the socket is CONNECTING - which the standard answers by failing the
+        // connection, 1006 and not clean. AnObserverSeesAbnormalClosureWhenACloseFallsDuringTheHandshake
+        // asserts that answer on purpose; this test is about the graceful one and has to be past it.
+        PumpUntilLogged(engine, 1);
+
+        observer.Events.Should().Equal(
+            "created wss://example.org/socket",
+            "handshake wss://example.org/socket protocols=chat,v2 headers=user-agent",
+            "response 101 chat headers=sec-websocket-accept");
+
+        engine.Execute("ws.close();");
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1000, "done"));
+        Pump(engine, () => observer.Events.Count >= 4);
+
+        observer.Events[3].Should().StartWith("closed 1000 done");
+
+        // One socket, one identifier, and it is not a fetch request id.
+        observer.Ids.Distinct().Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// A URL the host's own filter refuses is still a socket the script holds: it is created, it never shakes
+    /// hands, and it closes. An observer that paired every <c>created</c> with a <c>closed</c> would otherwise
+    /// leak one per refusal.
+    /// </summary>
+    [Test]
+    public void ARefusedUrlIsACreatedSocketThatClosesWithoutAHandshake()
+    {
+        var observer = new RecordingSocketObserver();
+        var (engine, _) = SocketEngine(fetch =>
+        {
+            fetch.WebSocketObserver = observer;
+            fetch.UrlFilter = _ => false;
+        });
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/socket');");
+        Pump(engine, () => observer.Events.Count >= 2);
+
+        observer.Events[0].Should().Be("created wss://example.org/socket");
+        observer.Events[1].Should().StartWith("closed 1006 ");
+        observer.Events.Should().NotContain(entry => entry.StartsWith("handshake ", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// <c>OnClosed</c> is terminal and fires once, however many ways one socket ends at the same moment.
+    /// </summary>
+    [Test]
+    public void AnObserverIsToldOfACloseExactlyOnce()
+    {
+        var observer = new RecordingSocketObserver();
+        var (engine, sockets) = SocketEngine(fetch => fetch.WebSocketObserver = observer);
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/socket');
+            ws.onopen = () => log.push('open');
+            """);
+
+        sockets.Last.Handshake.SetResult();
+        PumpUntilLogged(engine, 1);
+
+        engine.Execute("ws.close(); ws.close();");
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1000, ""));
+        Pump(engine, () => observer.Events.Any(entry => entry.StartsWith("closed ", StringComparison.Ordinal)));
+
+        engine.Tasks.ProcessTasks();
+        engine.Tasks.ProcessTasks();
+
+        observer.Events.Count(entry => entry.StartsWith("closed ", StringComparison.Ordinal)).Should().Be(1);
+    }
+
+    /// <summary>
+    /// A <c>close()</c> that falls while the socket is still <c>CONNECTING</c> is
+    /// https://websockets.spec.whatwg.org/#dom-websocket-close step 3.2 — "fail the WebSocket connection" —
+    /// so the observer is told <c>1006</c> with no reason and <c>wasClean</c> false, whatever code the script
+    /// passed and whatever the peer sends afterwards.
+    /// </summary>
+    /// <remarks>
+    /// <b>This is the answer the <c>linux</c>/<c>net10.0</c> leg was reporting</b>, and it was right: the
+    /// test above had been waiting for the observer's handshake-response call, which the operation makes
+    /// before the open task is queued, so on a leg that scheduled the pool differently the close arrived
+    /// during CONNECTING. Nothing about the discriminator was the platform — it was which of the two
+    /// moments the wait was for — so the fix was the wait, and this is the behaviour it used to reach by
+    /// accident, reached on purpose.
+    /// </remarks>
+    [Test]
+    public void AnObserverSeesAbnormalClosureWhenACloseFallsDuringTheHandshake()
+    {
+        var observer = new RecordingSocketObserver();
+        var (engine, sockets) = SocketEngine(fetch => fetch.WebSocketObserver = observer);
+
+        engine.Execute("var ws = new WebSocket('wss://example.org/socket');");
+
+        // Deliberately not waiting for `open`: the handshake is still in flight, which is what makes this the
+        // CONNECTING branch rather than a graceful close.
+        engine.Evaluate("ws.readyState").AsNumber().Should().Be(0, "the socket is CONNECTING");
+        engine.Execute("ws.close(1000, 'please');");
+
+        // Even the peer answering afterwards changes nothing: there was no connection to close politely.
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1000, "done"));
+        Pump(engine, () => observer.Events.Any(entry => entry.StartsWith("closed ", StringComparison.Ordinal)));
+
+        observer.Events.Should().ContainSingle(entry => entry.StartsWith("closed ", StringComparison.Ordinal))
+            .Which.Should().Be("closed 1006  clean=False");
+    }
+
+    /// <summary>An observer whose every callback throws changes nothing about the socket.</summary>
+    [Test]
+    public void AnObserverThatThrowsIsIgnored()
+    {
+        var (engine, sockets) = SocketEngine(fetch => fetch.WebSocketObserver = new ThrowingSocketObserver());
+
+        engine.Execute("""
+            var ws = new WebSocket('wss://example.org/socket');
+            ws.onopen = () => log.push('open');
+            ws.onclose = e => log.push('close:' + e.code);
+            """);
+
+        sockets.Last.Handshake.SetResult();
+        PumpUntilLogged(engine, 1);
+
+        sockets.Last.Deliver(WebSocketReceipt.Closed(1000, "done"));
+        PumpUntilLogged(engine, 2);
+
+        Log(engine).Should().Be("open|close:1000");
+    }
+
+    private sealed class RecordingSocketObserver : Jint.WebApi.WebSockets.WebSocketObserver
+    {
+        internal List<string> Events { get; } = new();
+
+        internal List<Jint.WebApi.WebSockets.WebSocketId> Ids { get; } = new();
+
+        public override void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, Uri url)
+        {
+            lock (Events)
+            {
+                Ids.Add(id);
+                Events.Add("created " + url.AbsoluteUri);
+            }
+        }
+
+        public override void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake)
+        {
+            lock (Events)
+            {
+                Ids.Add(handshake.Id);
+                Events.Add($"handshake {handshake.Url.AbsoluteUri} protocols={string.Join(",", handshake.Protocols)} headers={string.Join(",", handshake.Headers.Select(h => h.Name))}");
+            }
+        }
+
+        public override void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response)
+        {
+            lock (Events)
+            {
+                Ids.Add(response.Id);
+                Events.Add($"response {response.Status} {response.SubProtocol} headers={string.Join(",", response.Headers.Select(h => h.Name))}");
+            }
+        }
+
+        public override void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean)
+        {
+            lock (Events)
+            {
+                Ids.Add(id);
+                Events.Add($"closed {code} {reason} clean={wasClean}");
+            }
+        }
+    }
+
+    private sealed class ThrowingSocketObserver : Jint.WebApi.WebSockets.WebSocketObserver
+    {
+        public override void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, Uri url) => throw new InvalidOperationException("created");
+
+        public override void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake) => throw new InvalidOperationException("handshake");
+
+        public override void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response) => throw new InvalidOperationException("response");
+
+        public override void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean) => throw new InvalidOperationException("closed");
     }
 
     /// <summary>

--- a/Jint/Options.WebApi.cs
+++ b/Jint/Options.WebApi.cs
@@ -808,6 +808,34 @@ public sealed partial class Options
         [Experimental(JintDiagnosticIds.PreviewDiagnostic)]
         public FetchObserver? Observer { get; set { ThrowIfReadOnly(); field = value; } }
 
+        /// <summary>
+        /// Watches the opening and closing handshakes of the <c>WebSocket</c>s this engine opens.
+        /// <see langword="null"/> — the default — observes nothing and costs nothing.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>It lives here rather than in a group of its own</b>, for the reason <c>WebSocketPolicy</c>
+        /// gives: a socket is outbound network access from the same process reaching the same hosts, so it
+        /// answers to these settings and not to a second set.
+        /// </para>
+        /// <para>
+        /// <b>It is a separate observer from <see cref="Observer"/>, not a callback on it.</b> A socket's
+        /// handshake never reaches the fetch transport and its frames are not a body, so there is no hop to
+        /// intercept and nothing to substitute; and a socket counted as an outstanding request would leave a
+        /// host waiting for a network that never goes quiet.
+        /// <see cref="WebApi.WebSockets.WebSocketObserver"/> says the rest.
+        /// </para>
+        /// <para>
+        /// Every callback runs on a transport thread and must never touch the engine. The shape is a preview,
+        /// declared to the compiler as <c>JINT0002</c>.
+        /// </para>
+        /// <para>
+        /// Read once, when the engine is built.
+        /// </para>
+        /// </remarks>
+        [Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+        public WebApi.WebSockets.WebSocketObserver? WebSocketObserver { get; set { ThrowIfReadOnly(); field = value; } }
+
         internal FetchOptions Clone()
         {
             var clone = (FetchOptions) MemberwiseClone();

--- a/Jint/WebApi/Fetch/AGENTS.md
+++ b/Jint/WebApi/Fetch/AGENTS.md
@@ -73,15 +73,21 @@ that is the whole difference from `Fulfill`, which discards the socket's bytes u
 onto a protocol: **a refusal before the transport** (a `UrlFilter` denial, the concurrency cap, an
 already-aborted signal) reports `OnFailed` with no `OnRequest` before it, because `fetch`'s synchronous half
 cannot await one; and **a body nobody reads never completes**, because it is only pulled when script consumes
-it. **`EventSource` is observed whole; a `WebSocket` is not observed at all, and the line between them is
-whether the observer can be told everything.** A stream reaches `FetchTransport`, so the request and every
+it. **`EventSource` is observed whole, and a `WebSocket` has an observer of its own; the line between them is
+whether *this* observer can be told everything.** A stream reaches `FetchTransport`, so the request and every
 redirect hop cost nothing to report — but it reads its own body, which is why it was left unobserved until
 `EventSourceConnection` paid the same two debts a document fetch pays: `FinalResponse`, which every caller of
 `SendForStreamAsync` owes, and `Data` per chunk from inside the read loop. Each connection is its own
 observation, so a reconnect is a second request with its own id, and the terminal call is `OnCompleted` for a
-stream the server ended and `OnFailed` for every other ending, an abandoned one included. A socket is the
-case that stays refused: its handshake never reaches this transport (`ClientWebSocket` makes its own HTTP
-request, and the headers that matter — `Sec-WebSocket-Key`, the negotiated extensions — are added inside it
-and cannot be enumerated), an interception's `Fulfill` could not be honoured at all, and the frames afterwards
-are not a body. That is a `WebSocketObserver` of its own, not this one
-([#3621](https://github.com/sebastienros/jint/issues/3621)).
+stream the server ended and `OnFailed` for every other ending, an abandoned one included. A socket stays out
+of *this* observer and takes `Options.WebApi.Fetch.WebSocketObserver` instead: its handshake never reaches
+this transport (`ClientWebSocket` makes its own HTTP request, and the headers that matter —
+`Sec-WebSocket-Key`, the negotiated extensions — are added inside it and cannot be enumerated), an
+interception's `Fulfill` could not be honoured at all, and the frames afterwards are not a body. So that
+observer watches and never answers, and carries a `WebSocketId` rather than a `FetchRequestId` — **a socket
+must not be an outstanding request**, or a page with one open is a page whose network never goes quiet. What
+it can honestly report is four moments: created, the handshake request with the headers *this engine* set,
+the handshake response (`ClientWebSocket.CollectHttpResponseDetails`, turned on only when somebody is
+watching), and one terminal close
+([#3621](https://github.com/sebastienros/jint/issues/3621),
+[#3701](https://github.com/sebastienros/jint/issues/3701) item 2).

--- a/Jint/WebApi/WebSockets/ClientWebSocketConnection.cs
+++ b/Jint/WebApi/WebSockets/ClientWebSocketConnection.cs
@@ -36,11 +36,16 @@ internal sealed class ClientWebSocketConnection : IWebSocketConnection
     private readonly ClientWebSocket _socket = new();
     private readonly Uri _url;
     private readonly long _maxMessageBytes;
+    private readonly List<Fetch.FetchHeader> _requestHeaders = [];
 
-    internal ClientWebSocketConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent)
+    internal ClientWebSocketConnection(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent, bool collectHandshake = false)
     {
         _url = url;
         _maxMessageBytes = maxMessageBytes;
+
+        // Only when somebody is watching: keeping the response details costs an allocation per socket and
+        // answers a question nothing else in the engine asks.
+        _socket.Options.CollectHttpResponseDetails = collectHandshake;
 
         for (var i = 0; i < protocols.Count; i++)
         {
@@ -58,10 +63,40 @@ internal sealed class ClientWebSocketConnection : IWebSocketConnection
         if (userAgent is { Length: > 0 })
         {
             _socket.Options.SetRequestHeader("User-Agent", userAgent);
+            _requestHeaders.Add(new Fetch.FetchHeader("user-agent", userAgent));
         }
     }
 
     public string SubProtocol => _socket.SubProtocol ?? string.Empty;
+
+    /// <inheritdoc />
+    public int? HandshakeStatus => (int) _socket.HttpStatusCode is var status && status == 0 ? null : status;
+
+    /// <inheritdoc />
+    public IReadOnlyList<Fetch.FetchHeader> HandshakeHeaders
+    {
+        get
+        {
+            if (_socket.HttpResponseHeaders is not { } headers)
+            {
+                return [];
+            }
+
+            var collected = new List<Fetch.FetchHeader>();
+            foreach (var header in headers)
+            {
+                foreach (var value in header.Value)
+                {
+                    collected.Add(new Fetch.FetchHeader(Fetch.HeaderList.Lowercase(header.Key), value));
+                }
+            }
+
+            return collected;
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<Fetch.FetchHeader> RequestHeaders => _requestHeaders;
 
     public Task ConnectAsync(CancellationToken cancellationToken) => _socket.ConnectAsync(_url, cancellationToken);
 
@@ -163,13 +198,25 @@ internal sealed class ClientWebSocketConnection : IWebSocketConnection
 /// </summary>
 internal sealed class ClientWebSocketConnectionFactory : IWebSocketConnectionFactory
 {
-    internal static readonly ClientWebSocketConnectionFactory Instance = new();
+    private static readonly ClientWebSocketConnectionFactory _plain = new(collectHandshake: false);
+    private static readonly ClientWebSocketConnectionFactory _observed = new(collectHandshake: true);
 
-    private ClientWebSocketConnectionFactory()
+    private readonly bool _collectHandshake;
+
+    private ClientWebSocketConnectionFactory(bool collectHandshake)
     {
+        _collectHandshake = collectHandshake;
     }
 
+    /// <summary>The in-box factory, which keeps the handshake's response details only when asked.</summary>
+    /// <remarks>
+    /// The flag rather than a parameter on <see cref="IWebSocketConnectionFactory.Create"/>: that seam is a
+    /// host's to implement, and a host supplying its own transport already knows what it wants to report.
+    /// </remarks>
+    internal static ClientWebSocketConnectionFactory For(bool collectHandshake)
+        => collectHandshake ? _observed : _plain;
+
     public IWebSocketConnection Create(Uri url, IReadOnlyList<string> protocols, long maxMessageBytes, string? userAgent)
-        => new ClientWebSocketConnection(url, protocols, maxMessageBytes, userAgent);
+        => new ClientWebSocketConnection(url, protocols, maxMessageBytes, userAgent, _collectHandshake);
 }
 #endif

--- a/Jint/WebApi/WebSockets/WebSocketConnection.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConnection.cs
@@ -78,6 +78,23 @@ internal interface IWebSocketConnection : IDisposable
     /// </summary>
     string SubProtocol { get; }
 
+    /// <summary>
+    /// The status the server answered the opening handshake with, or <see langword="null"/> when there was no
+    /// HTTP response at all — a refused connection, a name that did not resolve, a TLS failure.
+    /// </summary>
+    /// <remarks>
+    /// Collected only when the host set an observer, because asking
+    /// <see cref="System.Net.WebSockets.ClientWebSocket"/> to keep the response details is a cost a socket
+    /// nobody is watching should not pay. Read after <see cref="ConnectAsync"/> has returned or thrown.
+    /// </remarks>
+    int? HandshakeStatus => null;
+
+    /// <summary>The headers of that response, or an empty list. See <see cref="HandshakeStatus"/>.</summary>
+    IReadOnlyList<Fetch.FetchHeader> HandshakeHeaders => [];
+
+    /// <summary>The headers this engine set on the opening handshake.</summary>
+    IReadOnlyList<Fetch.FetchHeader> RequestHeaders => [];
+
     /// <summary>Opens the connection — https://websockets.spec.whatwg.org/#concept-websocket-establish.</summary>
     Task ConnectAsync(CancellationToken cancellationToken);
 

--- a/Jint/WebApi/WebSockets/WebSocketConstructor.cs
+++ b/Jint/WebApi/WebSockets/WebSocketConstructor.cs
@@ -169,14 +169,24 @@ internal sealed partial class WebSocketConstructor : Constructor
                 requested: (double) state.ActiveWebSocketCount + 1);
         }
 
+        // The socket exists whether or not the policy admits it, and an observer is told about it either
+        // way: a refused URL is a socket that closes at once, not a socket that never was.
+        var observation = WebSocketObservation.Create(options.WebSocketObserver);
+
         IWebSocketConnection? connection = null;
         if (WebSocketPolicy.Allows(options, url, out var uri))
         {
-            var factory = state.WebSocketConnections ?? ClientWebSocketConnectionFactory.Instance;
+            observation?.Created(uri);
+
+            var factory = state.WebSocketConnections ?? ClientWebSocketConnectionFactory.For(observation is not null);
             connection = factory.Create(uri, protocols, options.MaxResponseBytes, options.UserAgent);
         }
+        else if (observation is not null && Uri.TryCreate(url.Serialize(), UriKind.Absolute, out var refused))
+        {
+            observation.Created(refused);
+        }
 
-        var operation = new WebSocketOperation(_engine, _realm, socket, connection, options.Timeout);
+        var operation = new WebSocketOperation(_engine, _realm, socket, connection, options.Timeout, observation, protocols);
         socket.Operation = operation;
         state.RegisterWebSocket(socket);
         operation.Start();

--- a/Jint/WebApi/WebSockets/WebSocketObservation.cs
+++ b/Jint/WebApi/WebSockets/WebSocketObservation.cs
@@ -1,0 +1,117 @@
+#if NET8_0_OR_GREATER
+using System.Threading;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// One socket's side of a <see cref="WebSocketObserver"/>: the identifier its four calls share, and the
+/// callbacks wrapped so that an observer can neither break a connection nor be told twice that it closed.
+/// </summary>
+/// <remarks>
+/// Created on the engine thread, called from transport threads, and — like everything else the transport
+/// touches — engine-free: it holds the observer and a number and nothing else. The same shape
+/// <c>FetchObservation</c> has, for the same reasons, and deliberately not the same object: a socket is not a
+/// request (see <see cref="WebSocketId"/>).
+/// </remarks>
+internal sealed class WebSocketObservation
+{
+    private static long _lastId;
+
+    private readonly WebSocketObserver _observer;
+    private int _closed;
+
+    private WebSocketObservation(WebSocketObserver observer)
+    {
+        _observer = observer;
+        Id = new WebSocketId(Interlocked.Increment(ref _lastId));
+    }
+
+    /// <summary>
+    /// The observation for one socket, or <see langword="null"/> when the host set no observer — which is
+    /// what every call site checks first, so an unobserved engine allocates nothing.
+    /// </summary>
+    internal static WebSocketObservation? Create(WebSocketObserver? observer)
+        => observer is null ? null : new WebSocketObservation(observer);
+
+    internal WebSocketId Id { get; }
+
+    /// <summary>The URL the socket was created for, so the handshake call needs no second copy of it.</summary>
+    internal Uri? Url { get; private set; }
+
+    internal void Created(Uri url)
+    {
+        Url = url;
+
+        try
+        {
+            _observer.OnCreated(Id, url);
+        }
+        catch (Exception)
+        {
+            // See WebSocketObserver's remarks: a socket must not depend on an observer, and there is no
+            // engine thread to report a failure to.
+        }
+    }
+
+    internal void HandshakeRequest(IReadOnlyList<FetchHeader> headers, IReadOnlyList<string> protocols)
+    {
+        if (Url is not { } url)
+        {
+            return;
+        }
+
+        try
+        {
+            _observer.OnHandshakeRequest(new ObservedWebSocketHandshake
+            {
+                Id = Id,
+                Url = url,
+                Headers = headers,
+                Protocols = protocols,
+            });
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    internal void HandshakeResponse(int status, IReadOnlyList<FetchHeader> headers, string subProtocol)
+    {
+        try
+        {
+            _observer.OnHandshakeResponse(new ObservedWebSocketResponse
+            {
+                Id = Id,
+                Status = status,
+                Headers = headers,
+                SubProtocol = subProtocol,
+            });
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The terminal call, enforced here rather than trusted to the call sites: a socket can end in the
+    /// handshake, in the read loop and in an abandonment, and the compare-and-swap is what makes this fire
+    /// exactly once between them.
+    /// </summary>
+    internal void Closed(int code, string reason, bool wasClean)
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _observer.OnClosed(Id, code, reason, wasClean);
+        }
+        catch (Exception)
+        {
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketObserver.cs
+++ b/Jint/WebApi/WebSockets/WebSocketObserver.cs
@@ -1,0 +1,173 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Jint.WebApi.Fetch;
+
+namespace Jint.WebApi.WebSockets;
+
+/// <summary>
+/// Identifies one <c>WebSocket</c> from its construction to its close.
+/// </summary>
+/// <param name="Value">A number unique within the process for the lifetime of the socket.</param>
+/// <remarks>
+/// <b>Deliberately not a <see cref="FetchRequestId"/>.</b> A socket is not a request: it has no body, no
+/// redirect chain and no end the transport can predict, so counting one as an outstanding request would
+/// make a page with an open socket a page whose network never goes quiet.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct WebSocketId(long Value)
+{
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// The opening handshake a socket is about to make, as plain CLR data.
+/// </summary>
+/// <remarks>
+/// <b><see cref="Headers"/> is what this engine set, and not the whole request.</b> The handshake is made by
+/// <see cref="System.Net.WebSockets.ClientWebSocket"/>, which adds <c>Sec-WebSocket-Key</c>,
+/// <c>Sec-WebSocket-Version</c>, <c>Connection</c> and <c>Upgrade</c> inside itself and exposes none of
+/// them — so an observer is told the headers that were chosen here and nothing is invented for the rest. A
+/// host mapping this onto a protocol reports the absent ones as absent.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public sealed record ObservedWebSocketHandshake
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservedWebSocketHandshake"/> record.
+    /// </summary>
+    public ObservedWebSocketHandshake()
+    {
+    }
+
+    /// <summary>Gets the socket this handshake belongs to.</summary>
+    public required WebSocketId Id { get; init; }
+
+    /// <summary>Gets the <c>ws:</c> or <c>wss:</c> URL the script asked for.</summary>
+    public required Uri Url { get; init; }
+
+    /// <summary>Gets the headers this engine set on the handshake; see the type's remarks.</summary>
+    public required IReadOnlyList<FetchHeader> Headers { get; init; }
+
+    /// <summary>Gets the subprotocols the script offered, in order.</summary>
+    public required IReadOnlyList<string> Protocols { get; init; }
+}
+
+/// <summary>
+/// What the server answered the opening handshake with.
+/// </summary>
+/// <remarks>
+/// Reported only when the handshake produced an HTTP response at all: a connection refused before one, a
+/// name that did not resolve and a TLS failure end at <see cref="WebSocketObserver.OnClosed"/> with nothing
+/// to report here.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public sealed record ObservedWebSocketResponse
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservedWebSocketResponse"/> record.
+    /// </summary>
+    public ObservedWebSocketResponse()
+    {
+    }
+
+    /// <summary>Gets the socket this response belongs to.</summary>
+    public required WebSocketId Id { get; init; }
+
+    /// <summary>Gets the HTTP status code, which is <c>101</c> for a handshake that succeeded.</summary>
+    public required int Status { get; init; }
+
+    /// <summary>Gets the response headers, one entry per value.</summary>
+    public required IReadOnlyList<FetchHeader> Headers { get; init; }
+
+    /// <summary>Gets the subprotocol the handshake settled on, or the empty string.</summary>
+    public required string SubProtocol { get; init; }
+}
+
+/// <summary>
+/// Watches the opening and closing handshakes of the <c>WebSocket</c>s one engine opens.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is not <see cref="FetchObserver"/>, and that is the decision rather than an omission.</b> A socket's
+/// handshake never reaches the fetch transport — <see cref="System.Net.WebSockets.ClientWebSocket"/> makes
+/// its own HTTP request — so there is no hop to intercept, an interception's <c>Fulfill</c> could not be
+/// honoured, and the frames afterwards are not a body. What is left that a host can honestly be told is the
+/// four moments below, so they are their own seam with their own identifier
+/// (<see href="https://github.com/sebastienros/jint/issues/3701">#3701</see> item 2).
+/// </para>
+/// <para>
+/// <b>Nothing here is a request.</b> A socket stays open for as long as the page wants it, so counting one
+/// against the fetch lifecycle would leave a request outstanding for that whole time — and a host that waits
+/// for its network to go quiet would wait for ever. <see cref="WebSocketId"/> is a separate identifier for
+/// exactly that reason.
+/// </para>
+/// <para>
+/// <b>Every callback runs on a transport thread and must never touch the <see cref="Engine"/>.</b> Nothing
+/// it is handed is a <c>JsValue</c>, an <see cref="Engine"/> or a realm — the same rule
+/// <see cref="FetchObserver"/> carries, and for the same reason. A callback that throws is ignored: there is
+/// no engine thread to report it to, and a socket must not depend on an observer.
+/// </para>
+/// <para>
+/// <b>The order is fixed</b>: <see cref="OnCreated"/>, <see cref="OnHandshakeRequest"/>, then
+/// <see cref="OnHandshakeResponse"/> when the server answered one at all, then exactly one
+/// <see cref="OnClosed"/> — including for a socket whose handshake never succeeded, because a
+/// <c>WebSocket</c> that fails to open still reaches <c>CLOSED</c> and still fires <c>close</c> at script.
+/// </para>
+/// <para>
+/// The shape of this class is a preview and is declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="Options.FetchOptions.WebSocketObserver"/>.
+/// </para>
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public abstract class WebSocketObserver
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebSocketObserver"/> class.
+    /// </summary>
+    protected WebSocketObserver()
+    {
+    }
+
+    /// <summary>
+    /// Called on the engine thread as <c>new WebSocket(...)</c> returns, before anything is sent.
+    /// </summary>
+    /// <param name="id">The socket.</param>
+    /// <param name="url">The URL the script asked for.</param>
+    /// <remarks>
+    /// The one callback that is <i>not</i> on a transport thread, because there is no transport yet. It is
+    /// still not allowed to touch the engine: the script that called the constructor is still running.
+    /// </remarks>
+    public virtual void OnCreated(WebSocketId id, Uri url)
+    {
+    }
+
+    /// <summary>
+    /// Called before the opening handshake goes out.
+    /// </summary>
+    /// <param name="handshake">The URL, the subprotocols and the headers this engine set.</param>
+    public virtual void OnHandshakeRequest(ObservedWebSocketHandshake handshake)
+    {
+    }
+
+    /// <summary>
+    /// Called when the server answered the handshake, whether or not it accepted it.
+    /// </summary>
+    /// <param name="response">The status, the headers and the settled subprotocol.</param>
+    public virtual void OnHandshakeResponse(ObservedWebSocketResponse response)
+    {
+    }
+
+    /// <summary>
+    /// Called once, when the socket has closed — for any reason, a failed handshake included.
+    /// </summary>
+    /// <param name="id">The socket.</param>
+    /// <param name="code">The close code the script will see.</param>
+    /// <param name="reason">The close reason, which may be empty.</param>
+    /// <param name="wasClean">Whether the closing handshake completed.</param>
+    public virtual void OnClosed(WebSocketId id, int code, string reason, bool wasClean)
+    {
+    }
+}
+#endif

--- a/Jint/WebApi/WebSockets/WebSocketOperation.cs
+++ b/Jint/WebApi/WebSockets/WebSocketOperation.cs
@@ -110,17 +110,24 @@ internal sealed class WebSocketOperation
     private CloseIntent? _closeIntent;
     private bool _abandoned;
 
+    private readonly WebSocketObservation? _observation;
+    private readonly IReadOnlyList<string> _protocols;
+
     internal WebSocketOperation(
         Engine engine,
         Realm realm,
         JsWebSocket socket,
         IWebSocketConnection? connection,
-        TimeSpan handshakeTimeout)
+        TimeSpan handshakeTimeout,
+        WebSocketObservation? observation = null,
+        IReadOnlyList<string>? protocols = null)
     {
         _engine = engine;
         _realm = realm;
         _socket = socket;
         _connection = connection;
+        _observation = observation;
+        _protocols = protocols ?? [];
         _generation = engine.EventLoopGeneration;
         _handshakeTimeout = handshakeTimeout;
         _engineToken = engine.Constraints.Find<CancellationConstraint>()?.Token ?? CancellationToken.None;
@@ -216,11 +223,18 @@ internal sealed class WebSocketOperation
                     handshake.CancelAfter(_handshakeTimeout);
                 }
 
+                _observation?.HandshakeRequest(connection.RequestHeaders, _protocols);
+
                 await connection.ConnectAsync(handshake.Token).ConfigureAwait(false);
             }
+
+            ReportHandshakeResponse(connection);
         }
         catch
         {
+            // The server may have answered and refused; a status collected before the throw is still worth
+            // reporting, and there is nothing to report when the connection never got one.
+            ReportHandshakeResponse(connection);
             // Every way the handshake can fail is one failure: a refused connection, a name that does not
             // resolve, a TLS error, a status that is not 101, a subprotocol the server did not accept, the
             // deadline, or a close() that fell during it. The standard requires exactly that — none of them
@@ -350,7 +364,25 @@ internal sealed class WebSocketOperation
     {
         _connection?.Dispose();
         _cancellation.Dispose();
+
+        // Before the task that tells script, because the observer is not on the engine's queue and a socket
+        // whose engine has gone away would otherwise never report its close at all.
+        _observation?.Closed(closure.Code, closure.Reason, closure.WasClean);
+
         EnqueueClosed(closure);
+    }
+
+    /// <summary>
+    /// Tells the observer what the server answered the handshake with, when there was an answer at all.
+    /// </summary>
+    private void ReportHandshakeResponse(IWebSocketConnection connection)
+    {
+        if (_observation is null || connection.HandshakeStatus is not { } status)
+        {
+            return;
+        }
+
+        _observation.HandshakeResponse(status, connection.HandshakeHeaders, connection.SubProtocol);
     }
 
     private void EnqueueOpen(string protocol) => Enqueue(() => _socket.ReportOpen(protocol));

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5421,6 +5421,25 @@ both now sees two entries for the final response where it saw one.
 
 `FetchObserver` remains a preview surface (`JINT0002`).
 
+### 4.129 A host can watch a `WebSocket`'s handshakes ([#3701](https://github.com/sebastienros/jint/issues/3701))
+
+A socket was the one network lane nothing could observe. `Options.WebApi.Fetch.WebSocketObserver` takes a
+`WebSocketObserver`, which is told four things about every socket the engine opens: it was created, its
+opening handshake is going out, the server answered one, and it closed.
+
+```csharp
+options.WebApi.Fetch.WebSocketObserver = new MyObserver();   // JINT0002, a preview surface
+```
+
+Nothing has to be done to migrate: the default is `null`, and an engine that sets none behaves exactly as
+before — including not asking `ClientWebSocket` to keep the handshake's response details, which is a cost
+only an observed socket pays.
+
+**It is deliberately not a callback on `FetchObserver`.** A socket's handshake never reaches the fetch
+transport, so there is no hop to intercept and nothing to substitute; and it carries a `WebSocketId` rather
+than a `FetchRequestId`, because a socket counted as an outstanding request would leave a host waiting for a
+network that never goes quiet.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so

--- a/tools/devtools-protocol/manifest.json
+++ b/tools/devtools-protocol/manifest.json
@@ -142,26 +142,32 @@
   // project does not reference and no recorded client sends the command; and DOM.enable's
   // includeWhitespace is ignored, because every child node is reported either way.
   //
-  // Input is dispatchMouseEvent alone. The keyboard half - dispatchKeyEvent, insertText,
-  // imeSetComposition - is the next campaign item, and answering one of them now would be a silent
-  // success where a client feature-detecting it wants the truth.
+  // Input is the four commands a client drives a page with: dispatchMouseEvent, and the keyboard half of
+  // dispatchKeyEvent, insertText and imeSetComposition. The other nine name a touch screen, a drag, a
+  // synthesised gesture and input suppression, and answering one of those now would be a silent success
+  // where a client feature-detecting it wants the truth.
   // Storage is generated for three commands and no more. Every recorded client reads and writes a page's
   // cookies through Storage.getCookies and Storage.setCookies rather than through Network's, which is the
   // whole reason the domain is here; the other twenty commands name IndexedDB, cache storage, shared
   // storage, interest groups, attribution reporting and quota, and every one of those is a store this
   // browser does not have.
   //
-  // The Fetch response stage is absent, and with it Fetch.continueResponse, Fetch.getResponseBody,
-  // Fetch.takeResponseBodyAsStream and the whole IO domain. FetchObserver.OnResponse is a notification an
-  // observer cannot answer, so a response-stage pause could only ever continue unchanged and a client that
-  // called fulfillRequest from one would be silently ignored - which is worse than not pausing at all.
-  // Network.getResponseBody is what answers a body here. Fetch.continueWithAuth is absent for a smaller
+  // The Fetch response stage is here now, over FetchObserver.OnResponseAsync: a pattern asking for
+  // requestStage "Response" pauses, and continueResponse, fulfillRequest and failRequest answer one.
+  // Fetch.getResponseBody, Fetch.takeResponseBodyAsStream and the whole IO domain are still absent, and for
+  // a different reason than they used to be: the pause has the response's *headers* while its body is still
+  // on the socket, so there are no bytes to hand a client without buffering them first, which is a budget
+  // decision rather than a hook. Network.getResponseBody is what answers a body here.
+  // Fetch.continueWithAuth is absent for a smaller
   // reason: nothing in this browser answers a 401 with credentials, so there is no challenge to be asked
   // about and Fetch.authRequired is never sent.
   //
-  // Network's WebSocket and EventSource events are absent because the engine deliberately does not observe
-  // those two handshakes (Jint/WebApi/AGENTS.md says why), and its timing document because no phase of a
-  // request is measured. Network.requestServedFromCache is never sent: there is no cache.
+  // Network's four WebSocket events are here, over the engine's own WebSocketObserver: a socket's creation,
+  // both of its handshakes and its close. webSocketFrameSent, webSocketFrameReceived and webSocketFrameError
+  // are absent because that observer is never told about a frame, and eventSourceMessageReceived because a
+  // stream is observed as bytes rather than as the events they decode into. The timing document is absent
+  // because no phase of a request is measured. Network.requestServedFromCache is never sent: there is no
+  // cache.
   //
   // Emulation is effective rather than stored: the media type and the Level 5 preference features feed the
   // page's own media environment, so matchMedia answers them and a MediaQueryList whose answer moved fires
@@ -285,6 +291,7 @@
     "Emulation.setUserAgentOverride",
     "Emulation.setVisibleSize",
     "Fetch.continueRequest",
+    "Fetch.continueResponse",
     "Fetch.disable",
     "Fetch.enable",
     "Fetch.failRequest",
@@ -424,6 +431,10 @@
     "Network.requestWillBeSentExtraInfo",
     "Network.responseReceived",
     "Network.responseReceivedExtraInfo",
+    "Network.webSocketClosed",
+    "Network.webSocketCreated",
+    "Network.webSocketHandshakeResponseReceived",
+    "Network.webSocketWillSendHandshakeRequest",
     "Page.domContentEventFired",
     "Page.frameNavigated",
     "Page.frameRequestedNavigation",


### PR DESCRIPTION
Refs #3701 — items 1 and 2, wired.

> **Stacked on #3823**, which is stacked on #3821. Review the top commit; the two below are those PRs'. Merge them first and this rebases to its own fifteen files.

Both seams were named in the manifest and in two instruction files as *absent with a reason*. The reasons are now false, so they are rewritten here rather than left to rot.

## The `Fetch` response stage

Over `FetchObserver.OnResponseAsync`. A pattern asking for `requestStage: "Response"` pauses with `responseStatusCode`, `responseStatusText` and `responseHeaders`; **`Fetch.continueResponse`** answers one, and `fulfillRequest` and `failRequest` answer one too. A pattern naming no stage still pauses the request stage alone — that is the protocol's own default, and pausing both for one pattern would double every pause a recorded client expects.

It crosses the three layers, as predicted:

- `IPageNetworkListener` grows an **ask** (`ResponseWillBeDeliveredAsync`) beside its `ResponseReceived` notification — the same ask/notify split the engine seam has, so a client that rewrote a status sees its own value in the announcement that follows.
- `PageNetworkRecorder` overrides `OnResponseAsync` and translates a `PageNetworkResponseDecision` into the engine's `FetchResponseInterception`.
- `FetchDomain` holds the pause in a **second map**: the two stages are answered with different decisions and one identifier space names both, so a command looking in the wrong one would answer "Invalid InterceptionId" for an identifier it had just handed out.

### `RunsOffThread` — I checked, and yes

**`Fetch.continueResponse` belongs there, for a reason no weaker than the other three's.** A `<script src>` a running script inserted is fetched with the loop *blocked* on the whole fetch — `ParserDriver`'s `fetch.GetAwaiter().GetResult()`, not `PumpUntil` — so the loop is held from the request stage through the body read, and the response-stage ask happens inside that window. A response-stage pause therefore holds the loop exactly as a request-stage pause does, and a `continueResponse` that had to reach the loop would deadlock on the very fetch it is releasing. It clears the bar the thread rule sets: like the other three it looks one entry up in a dictionary and completes a promise — no engine, no `JsValue`, no node.

## The four `Network` WebSocket events

Over #3823's socket observer. `PageNetworkRecorder` grows a **second** observer for them, because the engine has two seams and one class can derive from only one; it writes to no log and holds no state.

**A socket takes no entry in the request log, and its identifier is `ws-`-prefixed.** Both are the constraint the issue named, met structurally: a socket stays open for as long as the page wants it, so an entry would leave a request outstanding for that whole time and `networkIdle` would never fire — and a client must not be able to ask `getResponseBody` of a socket. `webSocketFrameSent`, `webSocketFrameReceived` and `webSocketFrameError` stay absent, honestly: the observer is told about the two handshakes and the close, and a frame never reaches it.

## What is still out, and why

**`Fetch.getResponseBody`, `takeResponseBodyAsStream` and the whole `IO` domain.** The pause has the response's *headers* while its body is still on the socket, so there are no bytes to hand a paused client without buffering them first — a budget decision (how much, whose, dropped how) rather than a hook. `Network.getResponseBody` answers a body here. **Worth an issue** rather than a guess in this PR.

## What was verified

Six tests. `Jint.Tests.Browser/DevTools/FetchDomainTests`: the response-stage pause carrying status and headers with `continueResponse` letting it through, `continueResponse` rewriting a status and headers while the server's own body still arrives, `fulfillRequest` and `failRequest` answering a response pause, and a default pattern pausing exactly once. `NetworkDomainTests`: a socket reaching a client as its own events and **not** as a request.

That last one uses a URL the context's filter refuses, which is what lets it run with no WebSocket server: a refused socket is still created and still closes, which is the pair that proves the whole chain — engine observer, recorder, listener, target, domain, client. What the two *handshake* events carry is pinned one level down in `Jint.Tests/Runtime/WebApi/WebSocketTests` over a connection double, because the connection factory is engine-internal and a browser test cannot inject one.

- `Jint.Tests.Browser` — 1 714 / 1 718, 0 failed.
- `Jint.Tests.DevTools` — 405 / 407, 0 failed (the manifest and generated-protocol currency checks).
- `Jint.Tests` — 12 300 / 12 300 / 8 492, 0 failed.
- `Jint.Tests.PublicInterface` — 3 603 / 3 613 / 2 879, 0 failed.

Manifest: `Fetch.continueResponse` under `implementedMethods`, the four socket events under `implementedEvents`, regenerated — the diff is three generated files, the rest is line-ending noise git normalizes away.

## Fixed in passing

The manifest's `Fetch` paragraph, `FetchDomain`'s class and `Matches` remarks, and `Jint.Browser/DevTools/AGENTS.md` on both lanes and on `RunsOffThread` — every one of them explained an absence that this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
