### PR TITLE
test262: the pinned suite moves to 419d3e0a2, whose only behavioural commit asserts something the engine already does

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "14e8c908e54ae2e770e473bcacf536f8cb654929",
+  "SuiteGitSha": "419d3e0a2273ba01a3bfcbec423f2801425b8e93",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",


### PR DESCRIPTION
One line moves, and the point of the change is the triage behind it rather than the line.

## The range: `14e8c908e..419d3e0a2`, three commits

| Commit | Verdict |
| --- | --- |
| `771005236` linter: catch duplicated items in frontmatter `includes` (#5120) | **Infra.** `tools/lint/**` only, nothing under `test/`. |
| `2808d4143` speed up linting (#5121) | **Infra.** `tools/lint/**` only. |
| `419d3e0a2` Temporal: Test Instant methods reject unrecognized time zone identifiers | **Behavioural.** Two new files. |

`features.txt` is unchanged across the range, so nothing parks in `ExcludedFeatures`.

## The one behavioural commit, and why it needs no engine change

It adds `built-ins/Temporal/Instant/prototype/toString/timezone-string-unknown.js` and its `toZonedDateTimeISO` sibling. Both assert that an unrecognized *named* time zone is a `RangeError` — as a bare identifier, and inside a bracketed annotation on a string that also carries an offset. The second half is the assertion with teeth: the offset must **not** stand in as a fallback for a name the implementation does not know.

Checked against the engine **before** running the suite, so "nothing to implement" is a finding rather than the absence of a failure — all eight assertions across the two files already pass.

## No exclusion is retired, and I checked rather than assumed

The `=== STALE TEST ===` entry says it goes when [tc39/test262#5112](https://github.com/tc39/test262/pull/5112) lands. That PR is **still open**, and the file it corrects — `annexB/language/function-code/block-decl-func-skip-arguments.js` — is still present at the new tip. So the entry is still live debt and stays, and the other banners are untouched.

## Verification

- **test262: 102,585 passed, 0 failed, 107 skipped** (3 m 35 s).
- **Regeneration verified rather than trusted.** Both new files appear in `Generated/`, as four `TestCase` entries covering the strict and sloppy halves, and `Generated/.settings.hash` was rewritten — a green run over a stale generation would look identical without this check.
- `Jint.Tests` 12,314 passed / 0 failed. `Jint.Tests.PublicInterface` 3,614 passed / 0 failed.
- None of the known load-sensitive tests flaked; no re-runs were needed.

One detail worth stating because it is invisible in the diff: `.gitattributes` pins this settings file to `eol=lf`, because the generated suite is cached across operating systems on a hash of it — a CRLF rewrite would change the cache key and turn every cross-OS restore into a full regeneration. The edit was written as bytes and the file confirmed to hold **0 CRLF** afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
