### PR TITLE
Profiler test: the self-time floor includes 0.8, because a share of a few dozen samples lands on it exactly

### DIFF
--- a/Jint.Tests/Runtime/SamplingProfilerTests.cs
+++ b/Jint.Tests/Runtime/SamplingProfilerTests.cs
@@ -111,9 +111,12 @@ public class SamplingProfilerTests
 
         self.Should().ContainKey("innermost");
         // A wall-clock sampler over-attributes to whichever frame is on top when a descheduled thread is
-        // sampled, so on a loaded CI runner this share has read 0.881, 0.842 and 0.895 with no profiler change
-        // in the pull request; 0.8 still says the loop dominates, which is what the test is about.
-        (self["innermost"] / total).Should().BeGreaterThan(0.8, "the loop is the only work the script does");
+        // sampled, so on a loaded CI runner this share has read 0.881, 0.842, 0.895 and exactly 0.800 with no
+        // profiler change in the pull request; 0.8 still says the loop dominates, which is what the test is
+        // about. Inclusive of the floor, because the share is a ratio of a sample count in the low tens and
+        // therefore quantised - 0.800 is 8 samples of 10, a value this comment already calls acceptable, and
+        // a strict > failed it on a loaded ARM leg for a pull request that changes no engine code.
+        (self["innermost"] / total).Should().BeGreaterThanOrEqualTo(0.8, "the loop is the only work the script does");
 
         // middle and outermost do nothing but delegate, so they own almost no self time and almost all of
         // the inclusive time - which is the shape a call tree has to show for a profile to be worth reading.


### PR DESCRIPTION
`SamplingProfilerTests.TheHotFunctionDominatesSelfTime` asserts the innermost frame owns more than 80% of self time. Its own comment records the flake history and reaches a conclusion the assertion then contradicts:

> A wall-clock sampler over-attributes to whichever frame is on top when a descheduled thread is sampled, so on a loaded CI runner this share has read 0.881, 0.842 and 0.895 with no profiler change in the pull request; **0.8 still says the loop dominates**, which is what the test is about.

But `BeGreaterThan(0.8)` is strict, so **the one value the comment names as the floor is the one value that fails.**

It fired on the `linux - ARM` leg of #3796 — a pull request that changes no engine code — reading exactly `0.800`:

```
##[error]Expected value to be greater than 0.8 because the loop is the only work the script does, but found 0.8.
```

## Why exactly 0.8 is not a coincidence

The share is a ratio of a sample count the test only requires to **exceed ten**, so it is quantised. `0.800` is 8 samples of 10, or 16 of 20, or 20 of 25 — the boundary is one of the most likely values for the ratio to take, not an unlucky near-miss. A floor a low-count ratio can hit exactly should be inclusive, or the test rejects the case its own comment admits.

## What this is not

Not a widened assertion to make a real failure go away. The threshold is unchanged at 0.8 and the test still fails for any share below it; only the boundary itself moves from excluded to included, and the comment now says why. The other two assertions in the test — that `middle` and `outermost` own almost no self time and almost all the inclusive time — are untouched.

`dotnet test -c Release Jint.Tests --filter SamplingProfilerTests`: 13 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz