### PR TITLE
A page can open a WebSocket and an EventSource, which is what the socket observer was watching for

### DIFF
--- a/Jint.Browser/Runtime/BrowserEngineFactory.cs
+++ b/Jint.Browser/Runtime/BrowserEngineFactory.cs
@@ -81,15 +81,38 @@ internal static class BrowserEngineFactory
 
             hasStorage = PageStorage.Configure(o, request.Network, request.SessionStores, origin);
 
+            // What a document may reach the network with. The four network features are one decision, not
+            // four: a page is a browsing position, and every one of them is bounded by the same
+            // options.WebApi.Fetch group the context configures below - the HttpClient, AllowedSchemes
+            // (http admits ws, https admits wss), UrlFilter, MaxRedirects and MaxConcurrentRequests. So a
+            // host that has written a network policy for this context has already written the socket's and
+            // the stream's, and granting them adds no reach a page did not already have.
+            //
+            // WebSocket and EventSource are also what Jint.Browser's own protocol layer reports on:
+            // Network.webSocketCreated and its three siblings are raised from the socket observer wired a
+            // hundred lines below, and an EventSource's stream is in the request log as
+            // ResourceType: EventSource. A page that could not open either left both of those unreachable.
             var features = WebApiFeatures.Default
                 | WebApiFeatures.XmlHttpRequest
                 | WebApiFeatures.Fetch
+                | WebApiFeatures.WebSocket
+                | WebApiFeatures.EventSource
                 | WebApiFeatures.Workers;
 
             if (hasStorage)
             {
                 features |= WebApiFeatures.Storage;
             }
+
+            // WebApiFeatures.CacheApi is deliberately NOT here, and the reason is a lifetime rather than a
+            // policy. The engine's default CacheStorageProvider is one per engine with no quota, and a page
+            // builds a new engine on every navigation - so a `caches` granted on the default would be
+            // emptied by every navigation and bounded by nothing, which is a scratchpad under a name that
+            // promises storage. localStorage is granted because PageStorage points it at a provider the
+            // *context* owns and partitions by origin; caches has no such partition yet, and inventing one
+            // is a public seam (StoragePartitionProvider) and a BrowserOptions budget rather than a flag.
+            // Until then a page has no `caches`, which is what it has on an insecure origin in a browser and
+            // what every feature-detecting script is already written for.
 
             o.UseWebApis(features);
 

--- a/Jint.Tests.Browser/DevTools/NetworkDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/NetworkDomainTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Jint.Browser;
 using Jint.Tests.Browser.Navigation;
@@ -390,9 +391,11 @@ public class NetworkDomainTests
     /// <para>
     /// The URL here is one the context's own filter refuses, which is what lets this run with no WebSocket
     /// server: a refused socket is still created and still closes, which is the pair that proves the whole
-    /// chain — the engine's observer, the recorder, the listener, the target, the domain, the client. What
-    /// the two <i>handshake</i> events carry is pinned one level down, in
-    /// <c>Jint.Tests/Runtime/WebApi/WebSocketTests</c>, over a connection double.
+    /// chain — the engine's observer, the recorder, the listener, the target, the domain, the client.
+    /// <see cref="ASocketToTheOriginPutsItsHandshakeRequestOnTheWire"/> is the same chain with a real socket
+    /// on a real origin, which adds the handshake request; what the handshake <i>response</i> carries is
+    /// pinned one level down, in <c>Jint.Tests/Runtime/WebApi/WebSocketTests</c>, because raising it needs a
+    /// server that answers <c>101</c> and the loopback server does not speak the upgrade.
     /// </para>
     /// </remarks>
     [Test]
@@ -401,11 +404,7 @@ public class NetworkDomainTests
         using var server = new LoopbackServer();
         server.MapHtml("/page", "<html><body>ok</body></html>");
 
-        // A page does not carry WebSocket by default, so the host turns it on the way an embedder would.
-        var options = new BrowserOptions().ConfigureEngine(
-            engine => engine.WebApi.Features |= WebApiFeatures.WebSocket);
-
-        await using var fixture = await NetworkFixture.OpenAsync(server, options);
+        await using var fixture = await NetworkFixture.OpenAsync(server);
         await fixture.NavigateAsync("/page");
 
         await fixture.Page.EvaluateAsync("new WebSocket('wss://elsewhere.invalid/socket');");
@@ -423,6 +422,62 @@ public class NetworkDomainTests
         fixture.Page.Requests.Should().NotContain(
             request => request.Url.StartsWith("wss:", StringComparison.Ordinal),
             "a socket is not a request and must not be one that never finishes");
+    }
+
+    /// <summary>
+    /// The same chain with a socket that really goes out: the handshake request a page's <c>WebSocket</c>
+    /// puts on the wire reaches a client as
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-webSocketWillSendHandshakeRequest.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The filter is widened to the loopback port rather than to a scheme</b>, because the context's
+    /// <c>UrlFilter</c> is shown the <c>ws:</c> URL and <see cref="LoopbackServer.Owns"/> requires
+    /// <c>http</c>. One policy covers a document, its subresources and its sockets, which is the property
+    /// being relied on here.
+    /// </para>
+    /// <para>
+    /// The server answers an ordinary response rather than a <c>101</c>, so the connection fails — and by
+    /// then every event but <c>webSocketHandshakeResponseReceived</c> has already been raised. Raising that
+    /// one needs a server that speaks the upgrade, which this one deliberately does not; what it carries is
+    /// pinned over a connection double in <c>Jint.Tests/Runtime/WebApi/WebSocketTests</c>.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task ASocketToTheOriginPutsItsHandshakeRequestOnTheWire()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await NetworkFixture.OpenAsync(
+            server,
+            urlFilter: uri => uri.IsLoopback && uri.Port == server.Port);
+
+        await fixture.NavigateAsync("/page");
+
+        var url = string.Create(CultureInfo.InvariantCulture, $"ws://127.0.0.1:{server.Port}/socket");
+        await fixture.Page.EvaluateAsync($"new WebSocket('{url}');");
+
+        var created = await fixture.EventAsync("Network.webSocketCreated");
+        created.GetProperty("url").GetString().Should().Be(url);
+        var socketId = created.GetProperty("requestId").GetString();
+
+        var handshake = await fixture.EventAsync("Network.webSocketWillSendHandshakeRequest");
+        handshake.GetProperty("requestId").GetString().Should().Be(socketId);
+
+        // The one header the connection sets for itself, and the page's own: a socket goes out claiming to
+        // be the same browser the document's requests claim to be.
+        var agent = await fixture.Page.EvaluateAsync<string>("navigator.userAgent");
+        handshake.GetProperty("request").GetProperty("headers").GetProperty("user-agent").GetString().Should().Be(agent);
+
+        var closed = await fixture.EventAsync("Network.webSocketClosed");
+        closed.GetProperty("requestId").GetString().Should().Be(socketId);
+
+        // And the origin really was asked to upgrade, which is what makes the events above a report of
+        // something rather than a report of nothing.
+        var received = server.Received.Single(request => request.Path == "/socket");
+        received.Header("Upgrade").Should().Be("websocket");
+        received.Header("User-Agent").Should().Be(agent);
     }
 
     [Test]
@@ -543,9 +598,19 @@ public class NetworkDomainTests
 
         internal string FrameId { get; }
 
-        internal static async Task<NetworkFixture> OpenAsync(LoopbackServer server, BrowserOptions? options = null)
+        /// <param name="server">The origin the page loads from.</param>
+        /// <param name="options">The browser's own options, or <see langword="null"/> for the defaults.</param>
+        /// <param name="urlFilter">
+        /// The context's policy, or <see langword="null"/> for <see cref="LoopbackServer.Owns"/>. A test that
+        /// opens a socket passes one, because <c>Owns</c> requires the <c>http</c> scheme and the filter is
+        /// shown the <c>ws:</c> URL.
+        /// </param>
+        internal static async Task<NetworkFixture> OpenAsync(
+            LoopbackServer server,
+            BrowserOptions? options = null,
+            Func<Uri, bool>? urlFilter = null)
         {
-            var session = await PageSession.CreateAsync(new BrowserContextOptions { UrlFilter = server.Owns }, options);
+            var session = await PageSession.CreateAsync(new BrowserContextOptions { UrlFilter = urlFilter ?? server.Owns }, options);
             var page = await session.NewPageAsync();
             var target = await session.TargetForAsync(page);
             var attachment = await session.AttachAsync(target);

--- a/Jint.Tests.Browser/Navigation/PageSocketTests.cs
+++ b/Jint.Tests.Browser/Navigation/PageSocketTests.cs
@@ -1,0 +1,156 @@
+using System.Globalization;
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.Navigation;
+
+/// <summary>
+/// The two streaming network APIs a page opens for itself — <c>WebSocket</c> and <c>EventSource</c> — and the
+/// one it deliberately does not have.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every test here constructs the interface from the page</b>, which is the thing that was missing: the
+/// engine has had both features for a long time, and a page never turned either of them on, so nothing in
+/// this project had ever written <c>new WebSocket(…)</c> against a real document. A test that only asserted
+/// the constructor is a function would have gone on passing if the feature were removed from the engine, so
+/// each of these also puts a request on the wire and reads the server's copy of it.
+/// </para>
+/// <para>
+/// <b>The context's <see cref="BrowserContextOptions.UrlFilter"/> is shown the <c>ws:</c> URL</b>, which is
+/// why these tests widen it rather than reuse <see cref="LoopbackServer.Owns"/>: one policy covers the
+/// document, its subresources, its <c>XMLHttpRequest</c>s, its workers <i>and</i> its sockets, and a filter
+/// written for <c>http</c> alone refuses a socket to the same origin. That is the engine's rule
+/// (<c>Options.FetchOptions.AllowedSchemes</c> admits <c>ws</c> wherever it admits <c>http</c>) surfacing at
+/// the page, and it is worth a test of its own.
+/// </para>
+/// </remarks>
+public sealed class PageSocketTests
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Admits loopback over <c>http</c> and over <c>ws</c>, which is the whole widening these tests need.
+    /// </summary>
+    /// <remarks>
+    /// Loopback-only is what keeps a test off somebody's DNS, which is the property
+    /// <see cref="LoopbackServer.Owns"/> is really there for; the port is not pinned because the point being
+    /// made is about the <i>scheme</i>.
+    /// </remarks>
+    private static bool ReachesLoopback(Uri uri)
+        => uri.IsLoopback
+            && (string.Equals(uri.Scheme, "http", StringComparison.Ordinal) || string.Equals(uri.Scheme, "ws", StringComparison.Ordinal));
+
+    private static string SocketUrl(LoopbackServer server, string path)
+        => string.Create(CultureInfo.InvariantCulture, $"ws://127.0.0.1:{server.Port}{path}");
+
+    [Test]
+    public async Task APageCanConstructAWebSocketAndItsHandshakeReachesTheOrigin()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/page", "<html><body>ok</body></html>"),
+            configureContext: options => options.UrlFilter = ReachesLoopback);
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        (await fixture.Page.EvaluateAsync<string>("typeof WebSocket")).Should().Be("function");
+
+        await fixture.Page.EvaluateAsync(
+            $$"""
+            window.__state = null;
+            window.__socket = new WebSocket('{{SocketUrl(fixture.Server, "/socket")}}');
+            window.__opened = window.__socket.readyState;
+            window.__socket.addEventListener('close', function (e) { window.__state = e.code; });
+            """);
+
+        // https://websockets.spec.whatwg.org/#dom-websocket-connecting — a socket is CONNECTING the moment
+        // the constructor returns, which is the observable proof that the constructor did more than exist.
+        (await fixture.Page.EvaluateAsync<double>("window.__opened")).Should().Be(0);
+
+        // The server answers an ordinary 200 rather than a 101, so the connection fails and the page is told
+        // so. What is being asserted is the request: the socket went out over the page's own transport, to
+        // the page's own origin, with the headers a WebSocket handshake carries.
+        (await fixture.Page.WaitForAsync("window.__state !== null", Bound)).Should().BeTrue();
+
+        var handshake = fixture.Server.Received.Single(received => received.Path == "/socket");
+        handshake.Header("Upgrade").Should().Be("websocket");
+        handshake.Header("Connection").Should().Contain("Upgrade");
+        handshake.Header("Sec-WebSocket-Key").Should().NotBeNullOrEmpty();
+        handshake.Header("Sec-WebSocket-Version").Should().Be("13");
+    }
+
+    [Test]
+    public async Task APageWithAFilterForHttpAloneCannotOpenASocketToItsOwnOrigin()
+    {
+        // The default LoopbackPage filter is LoopbackServer.Owns, which requires the http scheme.
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/page", "<html><body>ok</body></html>"));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        await fixture.Page.EvaluateAsync(
+            $$"""
+            window.__failed = false;
+            var socket = new WebSocket('{{SocketUrl(fixture.Server, "/socket")}}');
+            socket.addEventListener('error', function () { window.__failed = true; });
+            """);
+
+        (await fixture.Page.WaitForAsync("window.__failed === true", Bound)).Should().BeTrue();
+        fixture.Server.Received.Should().NotContain(received => received.Path == "/socket");
+    }
+
+    [Test]
+    public async Task APageCanOpenAnEventSourceAndReadAnEventFromIt()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server =>
+        {
+            server.MapHtml("/page", "<html><body>ok</body></html>");
+            server.Map("/events", _ => new LoopbackResponse { Body = "data: first\n\n" }
+                .With("Content-Type", "text/event-stream")
+                .With("Cache-Control", "no-store"));
+        });
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        (await fixture.Page.EvaluateAsync<string>("typeof EventSource")).Should().Be("function");
+
+        await fixture.Page.EvaluateAsync(
+            """
+            window.__message = null;
+            window.__source = new EventSource('/events');
+            window.__source.addEventListener('message', function (e) {
+                window.__message = e.data;
+                // Closed from the handler so the stream's end cannot start a reconnection the test would
+                // then have to wait out.
+                window.__source.close();
+            });
+            """);
+
+        (await fixture.Page.WaitForAsync("window.__message !== null", Bound)).Should().BeTrue();
+        (await fixture.Page.EvaluateAsync<string>("window.__message")).Should().Be("first");
+
+        var stream = fixture.Server.Received.First(received => received.Path == "/events");
+        stream.Header("Accept").Should().Contain("text/event-stream");
+    }
+
+    /// <summary>
+    /// <c>caches</c> is deliberately absent, and this pins the decision rather than the omission.
+    /// </summary>
+    /// <remarks>
+    /// See <c>BrowserEngineFactory</c>, where the feature set is computed: the engine's default
+    /// <c>CacheStorageProvider</c> is one per engine, and a page builds a new engine on every navigation, so
+    /// a <c>caches</c> granted on the default would be emptied by every navigation — a scratchpad under a
+    /// name that promises otherwise. Granting it needs a provider the browsing context owns and partitions
+    /// by origin, the way <c>localStorage</c> already is, plus a quota; until that exists, absent is the
+    /// honest answer and a page feature-detects its way past it exactly as it does on an insecure origin.
+    /// </remarks>
+    [Test]
+    public async Task APageHasNoCacheStorage()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/page", "<html><body>ok</body></html>"));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        (await fixture.Page.EvaluateAsync<string>("typeof caches")).Should().Be("undefined");
+    }
+}

--- a/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
@@ -923,6 +923,37 @@ public class EventSourceTests
     }
 
     [Test]
+    public void ARelativeUrlIsResolvedAgainstTheBaseUrl()
+    {
+        // Constructor step 3: "let urlRecord be the result of encoding-parsing a URL given url, relative to
+        // settings". Options.WebApi.Fetch.BaseUrl is what stands in for the settings object here, and it is
+        // what Request and WebSocket already resolve against - so all three interfaces read one relative URL
+        // the same way, and a document embedding this engine can write the URL it would write in a browser.
+        var handler = new StubHandler();
+        var (engine, _) = SseEngine(handler, net => net.BaseUrl = new Uri("https://example.org/pages/one.html"));
+
+        engine.Execute("var source = new EventSource('../stream');");
+        Pump(engine, () => handler.Requests.Count > 0, "the connection to be attempted");
+
+        handler.Requests[0].Url.Should().Be(StreamUrl);
+        engine.Execute("source.close();");
+    }
+
+    [Test]
+    public void AnEngineWithNoBaseUrlStillRequiresAnAbsoluteUrl()
+    {
+        // The other half of the same rule: with nothing to resolve against, a relative URL is a failure and
+        // step 4's SyntaxError is what a script gets - not a request to a host nobody named.
+        var handler = new StubHandler();
+        var (engine, _) = SseEngine(handler);
+
+        engine.Evaluate("(() => { try { new EventSource('../stream'); } catch (e) { return e.name; } })()")
+            .AsString().Should().Be("SyntaxError");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Test]
     public void WithCredentialsIsRememberedAndChangesNothing()
     {
         var handler = new StubHandler { Responder = _ => Answer("data: ok\n\n") };

--- a/Jint/WebApi/ServerSentEvents/EventSourceConstructor.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourceConstructor.cs
@@ -53,9 +53,11 @@ internal sealed partial class EventSourceConstructor : Constructor
     /// </summary>
     /// <remarks>
     /// The steps a browser needs and this engine has no counterpart for are the ones about the environment
-    /// the object lives in: there is no settings object to parse the URL relative to (so the URL must be
-    /// absolute), no CORS attribute state to select (see <c>withCredentials</c>) and no client to attribute
-    /// the request to.
+    /// the object lives in: no CORS attribute state to select (see <c>withCredentials</c>) and no client to
+    /// attribute the request to. The <i>settings object</i> the URL is parsed relative to does have a
+    /// counterpart — <see cref="Options.FetchOptions.BaseUrl"/>, which is what a host embedding a document
+    /// sets and what <c>Request</c> and <c>WebSocket</c> already resolve against — so a relative URL is
+    /// resolved here the same way, and only an engine with no base URL requires an absolute one.
     /// </remarks>
     public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
     {
@@ -79,8 +81,10 @@ internal sealed partial class EventSourceConstructor : Constructor
 
         // Step 3: "let urlRecord be the result of encoding-parsing a URL given url, relative to settings", and
         // step 4: "if urlRecord is failure, then throw a SyntaxError DOMException" — a DOMException, not the
-        // TypeError the fetch interfaces raise for the same mistake.
-        var url = UrlParser.Parse(href);
+        // TypeError the fetch interfaces raise for the same mistake. The base URL is the same one Request and
+        // WebSocket parse against, which is what makes new EventSource('/events') mean what it means in a
+        // document rather than being the one of the three that only accepts an absolute URL.
+        var url = UrlParser.Parse(href, state.FetchNetwork.BaseUrl);
         if (url is null)
         {
             ThrowDomException(DomExceptionNames.Syntax, $"Failed to construct 'EventSource': Cannot open an EventSource to '{href}'. The URL is invalid.");

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿[![Build](https://github.com/sebastienros/jint/actions/workflows/build.yml/badge.svg)](https://github.com/sebastienros/jint/actions/workflows/build.yml)
+[![Build](https://github.com/sebastienros/jint/actions/workflows/build.yml/badge.svg)](https://github.com/sebastienros/jint/actions/workflows/build.yml)
 [![NuGet](https://img.shields.io/nuget/v/Jint.svg)](https://www.nuget.org/packages/Jint)
 [![NuGet](https://img.shields.io/nuget/vpre/Jint.svg)](https://www.nuget.org/packages/Jint)
 [![MyGet](https://img.shields.io/myget/jint/vpre/jint.svg?label=MyGet)](https://www.myget.org/feed/jint/package/nuget/Jint)
@@ -1600,8 +1600,10 @@ through `fetch`'s own request pipeline, so `Options.WebApi.Fetch.CookieJar` is n
 
 **It reads `Options.WebApi.Fetch`** — the same transport (`HttpClient` / `HttpClientFactory`) and the same
 policy (`AllowedSchemes`, `UrlFilter`, `MaxRedirects`) that `fetch` uses, so a filter you have already written
-covers both, and every redirect hop is re-checked exactly as it is for a fetch. Three of those settings mean
-something different for a stream:
+covers both, and every redirect hop is re-checked exactly as it is for a fetch. `BaseUrl` is read too, which
+is the standard's *"relative to settings"*: it is the same setting `fetch`, `new Request()` and
+`new WebSocket()` resolve against, so `new EventSource('/updates')` means what it means in a document. Three
+of those settings mean something different for a stream:
 
 - **`Timeout` does not apply.** A connection that is idle for an hour is what an event stream is *for*.
 - **`MaxResponseBytes` does not bound the stream** — nothing could — it bounds **one event**: the data buffer

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -53,7 +53,7 @@ fraction of Chromium's CPU and memory per page, at some multiple of its wall-clo
 
 | v1 delivers | Out of v1 (absent, so feature detection is honest) |
 | --- | --- |
-| Full HTML5 parse with inline, external, `defer`, `async` and module scripts, import maps, `document.write`; generated DOM and CSSOM bindings; tree event dispatch; forms, history, cookies, storage, workers, `fetch`/`XMLHttpRequest`/`WebSocket`/`EventSource`; `MutationObserver`; stub `IntersectionObserver`/`ResizeObserver`; deterministic coordinate input; accessibility tree and markdown snapshots; CDP for Puppeteer/Playwright `connect`; a WPT lane; constraints per page | Layout-dependent APIs (`offsetWidth` is synthetic, `cssom-view`), rendering, screenshots, PDF, WebGL, canvas 2D, media, IndexedDB, WebAssembly, CSP enforcement, TLS-fingerprint stealth, iframe scripting (v1.1), `WindowProxy`, SharedWorker/ServiceWorker, drag and drop, real isolated worlds (v1.1) |
+| Full HTML5 parse with inline, external, `defer`, `async` and module scripts, import maps, `document.write`; generated DOM and CSSOM bindings; tree event dispatch; forms, history, cookies, storage, workers, `fetch`/`XMLHttpRequest`/`WebSocket`/`EventSource`; `MutationObserver`; stub `IntersectionObserver`/`ResizeObserver`; deterministic coordinate input; accessibility tree and markdown snapshots; CDP for Puppeteer/Playwright `connect`; a WPT lane; constraints per page | Layout-dependent APIs (`offsetWidth` is synthetic, `cssom-view`), rendering, screenshots, PDF, WebGL, canvas 2D, media, IndexedDB, `caches` (the engine has it; a page has no origin-partitioned provider to grant it on), WebAssembly, CSP enforcement, TLS-fingerprint stealth, iframe scripting (v1.1), `WindowProxy`, SharedWorker/ServiceWorker, drag and drop, real isolated worlds (v1.1) |
 
 `Page.captureScreenshot` answers a CDP error with a sentence, the way Lightpanda does.
 
@@ -300,18 +300,22 @@ What is accepted and not yet effective is accepted because refusing it fails an 
 each says which campaign item makes it real: `Network.setCacheDisabled` (there is no cache to bypass) and
 `Audits.enable` (nothing to report).
 
-**The network domains are real, and three lanes of them are absent with a reason rather than pending.**
-`Network` reports every request the page makes and `Fetch` pauses one at the **request** stage, both over
-the page's own request log, which is the engine's `FetchObserver`; the document's request carries the
-`loaderId` as its `requestId`, which is what makes a client's `goto` answer a response object. What is not
-there: the `Fetch` **response** stage and with it the `IO` domain, because `FetchObserver.OnResponse` is a
-notification an observer cannot answer, so a response-stage pause could only ever continue unchanged and a
-client that fulfilled from one would be ignored; the **WebSocket and EventSource** events, because the
-engine deliberately does not observe those two handshakes and a socket reported as a request that never
-finishes would also stop `networkIdle` firing; and `Network`'s **timing** document, because no phase of a
-request is measured and a document of zeros reads as a page that loaded instantly. A paused request holds
-the transport thread it is being sent on and never the page loop — the one exception is a `<script src>` a
-running script inserted, which blocks the loop by design.
+**The network domains are real, and what is still absent is absent with a reason rather than pending.**
+`Network` reports every request the page makes, and `Fetch` pauses one at the **request** stage or the
+**response** stage, all over the page's own request log, which is the engine's `FetchObserver`; the
+document's request carries the `loaderId` as its `requestId`, which is what makes a client's `goto` answer a
+response object. A page's `WebSocket` takes the four events the protocol gives a socket — its creation, both
+handshakes and its close — over the engine's own `WebSocketObserver`, and is deliberately *not* in the
+request log, because a socket stays open for as long as the page wants it and an entry would stop
+`networkIdle` firing. What is not there: `Fetch.getResponseBody` and `takeResponseBodyAsStream` and with
+them the `IO` domain, because a response-stage pause has the response's *headers* while its body is still on
+the socket, so handing a client bytes means buffering them first — a budget decision, and
+`Network.getResponseBody` is what answers a body here; the three `webSocketFrame*` events and
+`eventSourceMessageReceived`, because the socket observer is never told about a frame and a stream is
+observed as bytes rather than as the events they decode into; and `Network`'s **timing** document, because
+no phase of a request is measured and a document of zeros reads as a page that loaded instantly. A paused
+request holds the transport thread it is being sent on and never the page loop — the one exception is a
+`<script src>` a running script inserted, which blocks the loop by design.
 
 **`Emulation` is effective, and the question each command answers is *when*.** The viewport, the emulated
 media type and its Level 5 preference features, touch, focus, geolocation, the user agent and the hardware

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1,4 +1,4 @@
-﻿# Migrating from Jint 4.16 to Jint 5
+# Migrating from Jint 4.16 to Jint 5
 
 Jint 5 is under development on `main`. This document is the running record of every change a
 4.16.x embedder has to react to; it is written for someone upgrading, so it says what broke and
@@ -5439,6 +5439,22 @@ only an observed socket pays.
 transport, so there is no hop to intercept and nothing to substitute; and it carries a `WebSocketId` rather
 than a `FetchRequestId`, because a socket counted as an outstanding request would leave a host waiting for a
 network that never goes quiet.
+
+### 4.130 `EventSource` resolves a relative URL against `BaseUrl` ([#3701](https://github.com/sebastienros/jint/issues/3701))
+
+`new EventSource('/events')` used to throw a `SyntaxError` on every engine, because the constructor parsed
+its URL with no base while `Request` and `WebSocket` both parsed theirs against
+`Options.WebApi.Fetch.BaseUrl`. It now reads that base too, which is the standard's *"relative to settings"*
+and what makes one relative URL mean the same thing to all three interfaces.
+
+```csharp
+options.WebApi.Fetch.BaseUrl = new Uri("https://example.org/pages/one.html");
+// new EventSource('../stream')  ->  https://example.org/stream
+```
+
+**An engine that sets no `BaseUrl` is unchanged**: with nothing to resolve against, a relative URL is still
+a `SyntaxError` rather than a request to a host nobody named. The only scripts affected are ones that were
+throwing.
 
 ## 5. New in v5
 


### PR DESCRIPTION
Stacks on #3827 (which stacks on #3823). Only the last commit is this PR's.

`BrowserEngineFactory` computes a page's web-API set in exactly one place, and two of the four network features were never in it:

```
fetch            True
XMLHttpRequest   True
WebSocket        False
EventSource      False
caches           False
Worker           True
```

`WebApiFeatures.Default | XmlHttpRequest | Fetch | Workers` (`| Storage`), with no comment saying why `WebSocket = 1 << 18`, `EventSource = 1 << 17` and `CacheApi = 1 << 19` were left out — which made it read as an omission rather than a decision, and which the design doc's own v1 column contradicts. It was an omission: no test in `Jint.Tests.Browser` had ever constructed either interface from a document, so nothing noticed.

It matters now because #3823 and #3827 build `WebSocketObserver` and the four `Network.webSocket*` events on top of it — observation for a socket a page could not open. The seam was right; the page was the thing that was missing.

## The two flags are one decision, not two

Every network feature a page has is bounded by the same `options.WebApi.Fetch` group the context already configures: the `HttpClient`, `AllowedSchemes` (`http` admits `ws`, `https` admits `wss`), `UrlFilter`, `MaxRedirects` and `MaxConcurrentRequests`. A host that has written a network policy for this context has already written the socket's and the stream's, so granting them adds no reach a page did not already have. The design doc says the same thing from the other side — *"one `UrlFilter` covers document, subresource, XHR, WebSocket, EventSource and worker loads"* — and `PageSocketTests.APageWithAFilterForHttpAloneCannotOpenASocketToItsOwnOrigin` pins it: a context whose filter admits `http` alone refuses a socket to its own origin, and nothing reaches the server.

## `caches` stays off, and now says why

`WebApiFeatures.CacheApi`'s own doc argues against inclusion in `Default` — *"a cache outlives the evaluation that filled it, so where the data goes and what bounds it are decisions a host makes rather than inherits"* — but that is an argument about an **engine inheriting a default**, not about a **browser deciding**, and `BrowserEngineFactory` already makes exactly that kind of decision for `Storage`. So that is not the reason.

The reason is a **lifetime**. `Options.CacheOptions.Provider` defaults to *"a private `InMemoryCacheStorageProvider`… per engine"* with *"no quota"*, and a page builds a new engine on every navigation. A `caches` granted on that default would be emptied by every navigation and bounded by nothing — a scratchpad under a name that promises storage. `localStorage` is granted because `PageStorage` points it at a provider the **context** owns and partitions by origin; `caches` has no such partition, and inventing one is a public seam on `StoragePartitionProvider` plus a `BrowserOptions` budget rather than a flag.

So: off, with the reason written at the point of decision, `caches` named in the design doc's "not in v1" column, and a test pinning it. A page has no `caches` for the same reason it has none on an insecure origin in a browser, and every feature-detecting script is already written for that.

## One defect fixed on the way

Turning `EventSource` on exposed it immediately: `new EventSource('/events')` threw

> SyntaxError: Failed to construct 'EventSource': Cannot open an EventSource to '/events'. The URL is invalid.

`EventSourceConstructor` parsed its URL with `UrlParser.Parse(href)` — no base — while `RequestConstructor` does `UrlParser.Parse(href, network.BaseUrl)` and `WebSocketConstructor` does `UrlParser.Parse(href, _engine._webApi?.FetchNetwork.BaseUrl)`. `EventSource` was the only one of the three that ignored `Options.WebApi.Fetch.BaseUrl`, and its own comment already quoted the step it was skipping: *"let urlRecord be the result of encoding-parsing a URL given url, **relative to settings**"*.

It reads the base now, by the same idiom `WebSocketConstructor` uses. **An engine with no `BaseUrl` is unchanged** — a relative URL there is still a `SyntaxError` rather than a request to a host nobody named — so the only scripts affected are ones that were throwing. §4.130, and both directions are pinned in `EventSourceTests`.

## Tests construct the interface from a real document

That is the gap that let this survive. A test asserting `typeof WebSocket === 'function'` would go on passing if the engine lost the feature, so each of these also puts a request on the wire and reads the server's copy of it.

**`Jint.Tests.Browser/Navigation/PageSocketTests.cs`** — a page constructs a `WebSocket` and its handshake reaches the origin with `Upgrade: websocket`, a `Sec-WebSocket-Key` and `Sec-WebSocket-Version: 13`, with `readyState === CONNECTING` when the constructor returns; a filter for `http` alone refuses a socket to the same origin; a page opens an `EventSource` on a **relative** URL and reads an event out of it; and a page has no `caches`.

**`NetworkDomainTests.ASocketToTheOriginPutsItsHandshakeRequestOnTheWire`** — the protocol chain end to end over a real socket: `Network.webSocketCreated`, `webSocketWillSendHandshakeRequest` carrying the page's own `navigator.userAgent`, and `webSocketClosed`, with the origin's copy of the upgrade request asserted beside them. Three of the four events are now pinned against a real page. `webSocketHandshakeResponseReceived` still needs a server that answers `101`, which `LoopbackServer` deliberately does not speak, so it stays pinned over the connection double in `Jint.Tests/Runtime/WebApi/WebSocketTests`.

**The existing `ASocketReachesAClientAsTheFourWebSocketEventsAndNotAsARequest` loses a workaround** that was this gap written down:

```csharp
// A page does not carry WebSocket by default, so the host turns it on the way an embedder would.
var options = new BrowserOptions().ConfigureEngine(
    engine => engine.WebApi.Features |= WebApiFeatures.WebSocket);
```

## Also in this commit

`docs/design/headless-browser.md`'s protocol section said three lanes were "absent with a reason"; two of the three stopped being true when #3827 landed the `Fetch` response stage and the four socket events, and the paragraph still said both. Rewritten to what is actually absent — `Fetch.getResponseBody`/`takeResponseBodyAsStream` and `IO`, the three `webSocketFrame*` events, `eventSourceMessageReceived`, and the timing document — with each reason.

## Verification

Full solution builds clean. `Jint.Tests` 12323/12323 (net8.0, net10.0) and 8503/8503 (net472); `Jint.Tests.Browser` 1784/1784; `Jint.Tests.PublicInterface` 3623/3623 + 2889/2889 (net472); `Jint.Tests.DevTools` 409/409. The four new `PageSocketTests` were run against unfixed code first: `typeof WebSocket` and `typeof EventSource` both answered `"undefined"`, and `APageHasNoCacheStorage` passed, which is the split this PR keeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
