### PR TITLE
Profiling tests: the two share assertions are made over a profile large enough that one descheduled moment cannot decide them

### DIFF
--- a/Jint.Tests.DevTools/Session/ProfilerSessionTests.cs
+++ b/Jint.Tests.DevTools/Session/ProfilerSessionTests.cs
@@ -48,6 +48,30 @@ public class ProfilerSessionTests
     /// <summary>Enough work to be sampled many times over, and short enough to be a unit test.</summary>
     private const string Workload = "work(200)";
 
+    /// <summary>
+    /// The same work, forty times over. It exists only for
+    /// <see cref="ACpuBoundScriptAttributesMostOfItsTimeToItsHotFunction"/>, whose assertion is a *share* and
+    /// is therefore the one assertion here a loaded machine can move.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A time delta is the gap to the next sample, so an uninterruptible moment is charged whole to the frame
+    /// observed before it — right for a panel, and enough to <b>reorder</b> a small profile when the moment
+    /// lands on <c>outer</c> rather than on <c>inner</c>. That is what this test failed on, at
+    /// <see cref="Workload"/>'s size, with no profiler change in the pull request.
+    /// </para>
+    /// <para>
+    /// <b>Measured, because the size is the whole point.</b> <see cref="Workload"/> records <b>31</b> samples
+    /// over about 35 ms, of which <c>outer</c> holds roughly 430 units against <c>inner</c>'s 34,300: one
+    /// stall of about 34 ms — the length of the whole recording — landing on the single <c>outer</c> sample
+    /// reorders it. This one records <b>1,007</b> samples over about 530 ms with <c>inner</c> at 0.971–0.976,
+    /// so the same reordering needs a stall roughly <b>fifteen times longer</b> and has about thirty times as
+    /// many samples to miss. Forty times the work does not make a hiccup less likely; it makes it
+    /// proportionally negligible, which is the only lever a test has over a scheduler.
+    /// </para>
+    /// </remarks>
+    private const string DominantWorkload = "work(8000)";
+
     [Test]
     public async Task AProfileHasANodeForEveryFunctionThatRan()
     {
@@ -191,7 +215,7 @@ public class ProfilerSessionTests
         await using var session = await AttachedSession.CreateAsync();
         await session.Target.PostAsync(engine => engine.Execute(Source, "main.js"));
 
-        var profile = await RecordAsync(session, Workload);
+        var profile = await RecordAsync(session, DominantWorkload);
 
         var byId = profile.Nodes.ToDictionary(node => node.Id, node => node.CallFrame.FunctionName);
         var byFunction = new Dictionary<string, long>(StringComparer.Ordinal);

--- a/Jint.Tests/Runtime/SamplingProfilerTests.cs
+++ b/Jint.Tests/Runtime/SamplingProfilerTests.cs
@@ -51,6 +51,53 @@ public class SamplingProfilerTests
         total;
         """;
 
+    /// <summary>
+    /// The same three functions and the same loop, forty times over. It exists only for
+    /// <see cref="TheHotFunctionDominatesSelfTime"/>, and the size is the assertion's whole robustness.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A share of sample <i>weight</i> is hostage to the scheduler, and the smaller the profile the more
+    /// hostage it is.</b> The sampler fires at the engine's check points, so a sample's weight is the number
+    /// of whole intervals until the next one and an uninterruptible gap is charged to the stack observed
+    /// before it — which is exactly right for reading a profile, and exactly what lets one descheduled
+    /// moment on a loaded CI runner dominate a ratio. <see cref="NestedHotLoop"/> is measured at <b>318</b>
+    /// samples and about 318 units of weight, of which four are outside the loop: about <b>75</b> units
+    /// landing on any other frame drops the share below 0.8, and at that size 75 units is a hiccup of
+    /// roughly a millisecond and a half. This one measures <b>12,625</b> samples and about 13,450 units,
+    /// fifty of them outside the loop, so the same failure needs about <b>3,300</b> units — nineteen
+    /// milliseconds of continuous descheduling landing on one non-loop sample. Thirteen times the hiccup for
+    /// about seventy milliseconds of test.
+    /// </para>
+    /// <para>
+    /// The other six users of <see cref="NestedHotLoop"/> assert provenance, naming and rooting rather than
+    /// shares, so none of them needs this and none of them pays for it.
+    /// </para>
+    /// </remarks>
+    private const string DominantHotLoop = """
+        function innermost(n) {
+            var sum = 0;
+            for (var i = 0; i < n; i++) {
+                sum += i % 7;
+            }
+            return sum;
+        }
+
+        function middle(n) {
+            return innermost(n);
+        }
+
+        function outermost(n) {
+            return middle(n);
+        }
+
+        var total = 0;
+        for (var round = 0; round < 800; round++) {
+            total += outermost(1000);
+        }
+        total;
+        """;
+
     private static Engine CreateProfilingEngine() => new(options => options.Profiling.Enabled = true);
 
     /// <summary>
@@ -101,30 +148,36 @@ public class SamplingProfilerTests
     public void TheHotFunctionDominatesSelfTime()
     {
         var engine = CreateProfilingEngine();
-        var parsed = Parse(Profile(engine, NestedHotLoop));
+        var parsed = Parse(Profile(engine, DominantHotLoop));
 
-        parsed.SampleCount.Should().BeGreaterThan(10);
+        // Not "more than ten": the sampler fires at check points, so the count is a function of the work and
+        // not of the machine, and DominantHotLoop measures 12,625 of them on every run. A floor two orders
+        // below that catches a sampler that stopped firing without pinning a number that is not a contract.
+        parsed.SampleCount.Should().BeGreaterThan(1_000);
 
         var self = parsed.SelfWeightByFunction();
         var inclusive = parsed.InclusiveWeightByFunction();
         var total = self.Values.Sum();
 
         self.Should().ContainKey("innermost");
-        // A wall-clock sampler over-attributes to whichever frame is on top when a descheduled thread is
-        // sampled, so on a loaded CI runner this share has read 0.881, 0.842, 0.895 and exactly 0.800 with no
-        // profiler change in the pull request; 0.8 still says the loop dominates, which is what the test is
-        // about. Inclusive of the floor, because the share is a ratio of a sample count in the low tens and
-        // therefore quantised - 0.800 is 8 samples of 10, a value this comment already calls acceptable, and
-        // a strict > failed it on a loaded ARM leg for a pull request that changes no engine code.
+        // Measured at 0.9963 on an idle machine, and DominantHotLoop's remarks say what it takes to move it:
+        // a descheduled moment is charged to the stack under it, so the floor is about the runner rather than
+        // about the profiler. 0.8 still says the loop dominates, which is what the test is about.
+        //
+        // Inclusive of the floor, from #3832, and it stays inclusive: at DominantHotLoop's size the share is
+        // no longer a ratio of a few dozen samples that can land on 0.800 exactly, but an inclusive bound is
+        // what the sentence above means either way and costs nothing to keep.
         (self["innermost"] / total).Should().BeGreaterThanOrEqualTo(0.8, "the loop is the only work the script does");
 
         // middle and outermost do nothing but delegate, so they own almost no self time and almost all of
         // the inclusive time - which is the shape a call tree has to show for a profile to be worth reading.
         Weight(self, "middle").Should().BeLessThan(self["innermost"]);
-        // The inclusive shares drift the same way the self share does on a loaded runner (0.885 seen on a
-        // docs-only pull request); 0.8 still says every frame above the loop carries it.
-        (inclusive["outermost"] / total).Should().BeGreaterThan(0.8);
-        (inclusive["middle"] / total).Should().BeGreaterThan(0.8);
+        // The inclusive shares drift the same way the self share does, and for the same reason; 0.8 still says
+        // every frame above the loop carries it. Inclusive of the floor for the same reason #3832 made the
+        // self share inclusive: these are the same ratio of the same weights, and a bound that is strict on
+        // one and not the others would fail on exactly the runs the other two survive.
+        (inclusive["outermost"] / total).Should().BeGreaterThanOrEqualTo(0.8);
+        (inclusive["middle"] / total).Should().BeGreaterThanOrEqualTo(0.8);
         inclusive["(program)"].Should().BeApproximately(total, 1e-9, "every sample is rooted at the program");
     }
 

--- a/Jint/Profiling/FirefoxProfileWriter.cs
+++ b/Jint/Profiling/FirefoxProfileWriter.cs
@@ -108,6 +108,18 @@ internal static class FirefoxProfileWriter
     /// intervals it covers — at least one — so a gap is charged to the stack observed before it, which is
     /// the call site the engine went into.
     /// </summary>
+    /// <remarks>
+    /// <b>What that costs a test that asserts a share of weight.</b> The sample <i>count</i> is deterministic
+    /// — the sampler fires at check points, so it is a function of the work and not of the machine — but the
+    /// weights are not: one descheduled moment is billed whole to whichever stack was observed before it, so
+    /// on a small profile a single stall can own a large fraction of the total. Measured: a profile of 318
+    /// samples has about four units of weight outside its hot loop, and roughly seventy-five landing anywhere
+    /// else — a stall of about a millisecond and a half — moves the loop's share below 0.8. The lever is the
+    /// denominator, not the floor: <c>Jint.Tests/Runtime/SamplingProfilerTests.DominantHotLoop</c> and
+    /// <c>Jint.Tests.DevTools/Session/ProfilerSessionTests.DominantWorkload</c> exist for that reason and
+    /// carry the numbers, and any new assertion over a share belongs on one of them rather than on a profile
+    /// sized for a different question.
+    /// </remarks>
     private static void WriteSamples(TextWriter writer, SampledProfile profile)
     {
         var stacks = profile._sampleStacks;


### PR DESCRIPTION
Follow-up to #3832, and independent of it. **#3832 makes the boundary inclusive, which fixes a share landing *exactly* on 0.8. This fixes a share landing *below* it.** Same symptom, different failure; both are needed.

## Why these two tests fail without a profiler change

Both assert that a hot loop dominates a profile, and both have failed on CI on unrelated pull requests — `TheHotFunctionDominatesSelfTime` at **0.7989** against a floor of 0.8, and `ACpuBoundScriptAttributesMostOfItsTimeToItsHotFunction` by reporting `outer` where `inner` was expected.

Neither closes by moving the floor, because **the quantity asserted is a share of *weight*, and the weight is what the scheduler moves.** The sampler fires at the engine's check points, so a sample's weight is the number of whole intervals until the next one, and an uninterruptible gap is charged to the stack observed before it. That is exactly right for reading a profile — it is where the time went — and exactly what lets one descheduled moment own a large fraction of a **small** profile.

So the size of the profile is the assertion's robustness, and both profiles were small.

## Measured, on an idle machine

| Workload | Samples | Weight outside the loop | Stall needed to break the assertion |
| --- | ---: | ---: | --- |
| `NestedHotLoop` (today) | 318 | 4 of ~318 | **~75 units ≈ 1.5 ms** |
| `DominantHotLoop` (new) | 12,625 | 50 of ~13,450 | ~3,300 units ≈ **19 ms** |
| `work(200)` (today) | 31 | `outer` 430 vs `inner` 34,300 | a stall the length of the **whole recording**, on the one `outer` sample |
| `work(8000)` (new) | 1,007 | `inner` share 0.971–0.976 | **~15× longer**, with ~30× as many samples to miss |

`DominantHotLoop` measures a self share of **0.9963** against 0.9874 before. A millisecond and a half is nothing on a loaded runner; nineteen milliseconds of *continuous* descheduling landing on one of fifty specific samples is a different proposition.

## What it costs

Each new workload is used by **the one test whose assertion is a share**. The other six users of `NestedHotLoop` and the four other users of `Workload` assert provenance, naming, rooting and lifecycle — none needs a larger profile and none pays for one.

- `SamplingProfilerTests`: **815 ms → 1 s**
- `Jint.Tests.DevTools`: **6 s, unchanged**

## One other change in the same test

`SampleCount.Should().BeGreaterThan(10)` becomes `BeGreaterThan(1_000)`. The count is a function of the work rather than of the machine — it measures 12,625 on every run, five runs in a row — so a floor two orders below it still catches a sampler that stopped firing, without pinning a number that is not a contract. The old `> 10` was three orders below the truth and would have passed a sampler that fired eleven times.

## Verification

`Jint.Tests` 12,316 green on net8.0/net10.0 and 8,503 on net472; `Jint.Tests.DevTools` 407/409 green; `SamplingProfilerTests` run five times consecutively, green each time. Release, full build, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
