### PR TITLE
A 401 is a question a client can answer: Fetch.authRequired and continueWithAuth, over a new observer ask

### DIFF
--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -1,4 +1,4 @@
-﻿# Agent instructions: the page-level protocol
+# Agent instructions: the page-level protocol
 
 > **Read this when:** You are touching `Jint.Browser/DevTools/` — a page target, a page-level domain (`Page`, `DOM`,
 > `Network`, `Fetch`, `Input`, `Emulation`, `Accessibility`, `Jint`), or the request log the protocol reads.
@@ -83,7 +83,13 @@ target/runtime split and the manifest are there and none of it is repeated here.
   own state, not a request's. The document's request carries the `loaderId` as its `requestId`, which is how
   every client tells a navigation apart.
 - **What is accepted and not effective says so, in place.** `Network.setCacheDisabled` (there is no cache)
-  and `Audits.enable` are answered because a refusal fails an ordinary connection. The `Fetch` **response stage** is here: a
+  and `Audits.enable` are answered because a refusal fails an ordinary connection. **Authentication is here**:
+  `handleAuthRequests` turns it on, a `401` carrying a `WWW-Authenticate` pauses as `Fetch.authRequired`, and
+  `continueWithAuth` answers it over `FetchObserver.OnAuthRequiredAsync`. Only `Basic` can be answered, every
+  other scheme is still *reported* — being asked is how a client tells "unsupported" from "never challenged" —
+  and `ProvideCredentials` for one of those is refused with an error naming the scheme rather than accepted
+  and dropped. A `407` is a proxy's and is not reported, the proxy belonging to the context's `HttpClient`, so
+  `source` is always `Server`. The `Fetch` **response stage** is here: a
   pattern asking for `requestStage: "Response"` pauses with the response's status and headers, and
   `continueResponse`, `fulfillRequest` and `failRequest` answer one — a default pattern still pauses the
   request stage only, that being the protocol's own default, and pausing both would double every pause a

--- a/Jint.Browser/DevTools/FetchDomain.cs
+++ b/Jint.Browser/DevTools/FetchDomain.cs
@@ -49,9 +49,17 @@ namespace Jint.Browser.DevTools;
 /// budget decision rather than a hook. <c>Network.getResponseBody</c> is what answers a body here.
 /// </para>
 /// <para>
-/// <b>No authentication challenge exists here.</b> <c>handleAuthRequests</c> is accepted and
-/// <c>Fetch.authRequired</c> is never sent: nothing in this browser answers a <c>401</c> with credentials, so
-/// there is no challenge for a client to be asked about, and <c>continueWithAuth</c> is absent.
+/// <b>Authentication challenges are here.</b> <c>handleAuthRequests</c> turns them on, a <c>401</c> carrying
+/// a <c>WWW-Authenticate</c> pauses as <c>Fetch.authRequired</c>, and <c>continueWithAuth</c> answers one
+/// over the engine's <c>FetchObserver.OnAuthRequiredAsync</c>. <b>Only <c>Basic</c> can be answered</b> — it
+/// is the one scheme whose answer is a function of the credentials alone, while <c>Digest</c> needs a nonce
+/// exchange and <c>Negotiate</c> and <c>NTLM</c> a handshake bound to the connection. Every other scheme is
+/// still <i>reported</i>, because being asked is how a client tells "unsupported" from "never challenged",
+/// and <c>continueWithAuth</c> answering <c>ProvideCredentials</c> for one is refused with an error naming
+/// the scheme rather than accepted and dropped: an ask that cannot be honoured must fail visibly. A
+/// <c>407</c> is a proxy's and is not reported at all, the proxy belonging to the <c>HttpClient</c> the
+/// context was given, so <c>source</c> is always <c>Server</c>
+/// (<see href="https://github.com/sebastienros/jint/issues/3828">#3828</see>).
 /// </para>
 /// <para>
 /// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/Fetch/"/>.
@@ -62,8 +70,10 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
     private readonly PageTarget _target;
     private readonly ConcurrentDictionary<string, PausedRequest> _paused = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, PausedResponse> _pausedResponses = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, PausedAuth> _pausedAuth = new(StringComparer.Ordinal);
 
     private volatile RequestPattern[] _patterns = [];
+    private volatile bool _handleAuth;
     private long _lastInterception;
 
     internal FetchDomain(PageTarget target)
@@ -80,6 +90,10 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
     {
         _target.ClaimInterception(this);
         _patterns = parameters.Patterns ?? [];
+
+        // Unlike the patterns, this is not a filter over requests: a challenge has no resource type and no
+        // URL pattern to match, so a client either wants every one of them or none.
+        _handleAuth = parameters.HandleAuthRequests ?? false;
 
         await MarkEnabledAsync(context).ConfigureAwait(false);
         return EmptyResult.Instance;
@@ -241,6 +255,115 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
         }
     }
 
+    /// <summary>Whether this domain asked to be told about authentication challenges.</summary>
+    /// <remarks>
+    /// <c>handleAuthRequests</c> alone, with no pattern consulted: a challenge is a property of a response
+    /// rather than of a request, so there is nothing for a URL pattern or a resource type to match on, and
+    /// the protocol accordingly makes it one flag rather than a stage.
+    /// </remarks>
+    internal bool WantsAuth => IsEnabled && _handleAuth;
+
+    /// <summary>
+    /// Holds one challenge until the client answers it — https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#event-authRequired.
+    /// </summary>
+    /// <remarks>
+    /// The identifier comes from the same counter the two stages use, because the protocol gives a client one
+    /// identifier space and <c>continueWithAuth</c> names an id out of it exactly as <c>continueRequest</c>
+    /// does. A pause the request's own token ends declines the challenge, which delivers the <c>401</c> — a
+    /// fetch that has been abandoned is about to fail anyway.
+    /// </remarks>
+    internal async ValueTask<PageNetworkAuthDecision> PauseAuthAsync(
+        PageNetworkRequest request,
+        PageNetworkAuthChallenge challenge,
+        string frameId,
+        CancellationToken cancellationToken)
+    {
+        var id = "interception-job-" + Interlocked.Increment(ref _lastInterception).ToString(CultureInfo.InvariantCulture);
+        var paused = new PausedAuth { Challenge = challenge };
+
+        _pausedAuth[id] = paused;
+
+        EmitDetached(ProtocolFetchEvents.AuthRequired(new AuthRequiredEvent
+        {
+            RequestId = id,
+            Request = Describe(request),
+            FrameId = frameId,
+            ResourceType = ResourceTypeOf(request.Kind),
+            AuthChallenge = new AuthChallenge
+            {
+                Source = challenge.Source,
+                Origin = OriginOf(challenge.Url),
+                Scheme = challenge.Scheme,
+                Realm = challenge.Realm,
+            },
+        }));
+
+        try
+        {
+            using var registration = cancellationToken.Register(
+                static state => ((PausedAuth) state!).Answer(PageNetworkAuthDecision.Proceed),
+                paused);
+
+            return await paused.Completion.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            _pausedAuth.TryRemove(id, out _);
+        }
+    }
+
+    /// <summary>The scheme and authority of a URL, which is what the protocol calls a challenge's origin.</summary>
+    private static string OriginOf(string url)
+        => Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.GetLeftPart(UriPartial.Authority) : url;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-continueWithAuth — the three
+    /// answers the protocol admits. <c>Default</c> and <c>CancelAuth</c> both deliver the <c>401</c>: a
+    /// browser tells them apart by whether it puts its own dialog up, and there is no dialog here.
+    /// <c>ProvideCredentials</c> sends the challenged hop again with an <c>Authorization</c> header, once.
+    /// </para>
+    /// <para>
+    /// <b><c>ProvideCredentials</c> for a scheme this browser cannot answer is an error, not a no-op.</b>
+    /// Only <c>Basic</c> can be answered from a username and a password alone; a client that offered
+    /// credentials for a <c>Digest</c> or a <c>Negotiate</c> challenge is told so by name, and the
+    /// <c>401</c> is then delivered. Accepting the command and quietly changing nothing would be the same
+    /// silent discard this whole lane exists to remove.
+    /// </para>
+    /// </remarks>
+    protected override ValueTask<EmptyResult> ContinueWithAuthAsync(ContinueWithAuthRequest parameters, CommandContext context)
+    {
+        if (!_pausedAuth.TryRemove(parameters.RequestId, out var paused))
+        {
+            return Throw.ServerError<ValueTask<EmptyResult>>(
+                "Invalid InterceptionId.",
+                "no authentication challenge is paused under that identifier");
+        }
+
+        var answer = parameters.AuthChallengeResponse;
+        if (!string.Equals(answer.Response, AuthChallengeResponseResponseValues.ProvideCredentials, StringComparison.Ordinal))
+        {
+            paused.Answer(PageNetworkAuthDecision.Proceed);
+            return new ValueTask<EmptyResult>(EmptyResult.Instance);
+        }
+
+        if (!paused.Challenge.CanProvideCredentials)
+        {
+            // Declined first, so the request is released whatever the client does about the error.
+            paused.Answer(PageNetworkAuthDecision.Proceed);
+
+            return Throw.ServerError<ValueTask<EmptyResult>>(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Credentials cannot be provided for a '{paused.Challenge.Scheme}' challenge."),
+                "only Basic can be answered from a username and a password alone; the response was delivered unchanged");
+        }
+
+        paused.Answer(PageNetworkAuthDecision.Credentials(answer.Username ?? "", answer.Password ?? ""));
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
     /// <inheritdoc/>
     /// <remarks>
     /// https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-continueResponse — the response
@@ -280,6 +403,14 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
             if (_pausedResponses.TryRemove(id, out var paused))
             {
                 paused.Answer(PageNetworkResponseDecision.Proceed);
+            }
+        }
+
+        foreach (var id in _pausedAuth.Keys)
+        {
+            if (_pausedAuth.TryRemove(id, out var paused))
+            {
+                paused.Answer(PageNetworkAuthDecision.Proceed);
             }
         }
     }
@@ -515,5 +646,22 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
 
         /// <summary>Answers the pause, ignoring a second answer for the same response.</summary>
         internal void Answer(PageNetworkResponseDecision decision) => Completion.TrySetResult(decision);
+    }
+
+    /// <summary>
+    /// A challenge's own pause, and a third map for the third thing one identifier space can name.
+    /// </summary>
+    /// <remarks>
+    /// It carries the challenge as well as the answer, because <c>continueWithAuth</c> has to refuse
+    /// credentials offered for a scheme this browser cannot answer, and the scheme is only known here.
+    /// </remarks>
+    private sealed class PausedAuth
+    {
+        internal required PageNetworkAuthChallenge Challenge { get; init; }
+
+        internal TaskCompletionSource<PageNetworkAuthDecision> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Answers the pause, ignoring a second answer for the same challenge.</summary>
+        internal void Answer(PageNetworkAuthDecision decision) => Completion.TrySetResult(decision);
     }
 }

--- a/Jint.Browser/DevTools/PageTarget.Network.cs
+++ b/Jint.Browser/DevTools/PageTarget.Network.cs
@@ -172,6 +172,20 @@ internal sealed partial class PageTarget : IPageNetworkListener
         return await interceptor.PauseResponseAsync(request, response, FrameId, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
+    async ValueTask<PageNetworkAuthDecision> IPageNetworkListener.AuthRequiredAsync(
+        PageNetworkRequest request,
+        PageNetworkAuthChallenge challenge,
+        CancellationToken cancellationToken)
+    {
+        if (_interceptor is not { } interceptor || !interceptor.WantsAuth)
+        {
+            return PageNetworkAuthDecision.Proceed;
+        }
+
+        return await interceptor.PauseAuthAsync(request, challenge, FrameId, cancellationToken).ConfigureAwait(false);
+    }
+
     void IPageNetworkListener.WebSocketCreated(string socketId, string url)
     {
         foreach (var domain in NetworkDomains())

--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Jint.Browser.Runtime;
 using Jint.DevTools;
 using Jint.DevTools.Domains;
@@ -189,7 +189,7 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     /// <inheritdoc/>
     /// <remarks>
     /// <para>
-    /// <b>Three commands, and they are the three that release a paused request.</b>
+    /// <b>The commands that release a paused request.</b>
     /// <c>FetchDomain.ContinueRequestAsync</c>, <c>FailRequestAsync</c> and <c>FulfillRequestAsync</c> look
     /// one entry up in a <c>ConcurrentDictionary</c> and complete a <c>TaskCompletionSource</c>; between
     /// them they touch no engine, no <c>JsValue</c> and no node, which is the bar the base class sets.
@@ -212,8 +212,11 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
         // a running script inserted is fetched with the loop *blocked* on the whole fetch — ParserDriver's
         // `fetch.GetAwaiter().GetResult()` — so the loop is held from the request stage through the body
         // read, and a response-stage pause holds it exactly as a request-stage pause does. All four look one
-        // entry up in a dictionary and complete a promise: no engine, no JsValue, no node.
-        "Fetch.continueRequest" or "Fetch.failRequest" or "Fetch.fulfillRequest" or "Fetch.continueResponse" => true,
+        // entry up in a dictionary and complete a promise: no engine, no JsValue, no node. continueWithAuth
+        // is the fifth, and its pause is the same one held at the same point: the challenge arrives on the
+        // hop's own response, with the loop blocked on that fetch if a running script started it.
+        "Fetch.continueRequest" or "Fetch.failRequest" or "Fetch.fulfillRequest" or "Fetch.continueResponse"
+            or "Fetch.continueWithAuth" => true,
         _ => false,
     };
 

--- a/Jint.Browser/Runtime/BrowserEngineFactory.cs
+++ b/Jint.Browser/Runtime/BrowserEngineFactory.cs
@@ -81,15 +81,38 @@ internal static class BrowserEngineFactory
 
             hasStorage = PageStorage.Configure(o, request.Network, request.SessionStores, origin);
 
+            // What a document may reach the network with. The four network features are one decision, not
+            // four: a page is a browsing position, and every one of them is bounded by the same
+            // options.WebApi.Fetch group the context configures below - the HttpClient, AllowedSchemes
+            // (http admits ws, https admits wss), UrlFilter, MaxRedirects and MaxConcurrentRequests. So a
+            // host that has written a network policy for this context has already written the socket's and
+            // the stream's, and granting them adds no reach a page did not already have.
+            //
+            // WebSocket and EventSource are also what Jint.Browser's own protocol layer reports on:
+            // Network.webSocketCreated and its three siblings are raised from the socket observer wired a
+            // hundred lines below, and an EventSource's stream is in the request log as
+            // ResourceType: EventSource. A page that could not open either left both of those unreachable.
             var features = WebApiFeatures.Default
                 | WebApiFeatures.XmlHttpRequest
                 | WebApiFeatures.Fetch
+                | WebApiFeatures.WebSocket
+                | WebApiFeatures.EventSource
                 | WebApiFeatures.Workers;
 
             if (hasStorage)
             {
                 features |= WebApiFeatures.Storage;
             }
+
+            // WebApiFeatures.CacheApi is deliberately NOT here, and the reason is a lifetime rather than a
+            // policy. The engine's default CacheStorageProvider is one per engine with no quota, and a page
+            // builds a new engine on every navigation - so a `caches` granted on the default would be
+            // emptied by every navigation and bounded by nothing, which is a scratchpad under a name that
+            // promises storage. localStorage is granted because PageStorage points it at a provider the
+            // *context* owns and partitions by origin; caches has no such partition yet, and inventing one
+            // is a public seam (StoragePartitionProvider) and a BrowserOptions budget rather than a flag.
+            // Until then a page has no `caches`, which is what it has on an insecure origin in a browser and
+            // what every feature-detecting script is already written for.
 
             o.UseWebApis(features);
 

--- a/Jint.Browser/Runtime/PageNetworkListener.cs
+++ b/Jint.Browser/Runtime/PageNetworkListener.cs
@@ -113,6 +113,56 @@ internal sealed record PageNetworkResponse(
     bool FromInterception,
     FetchTiming? Timing);
 
+/// <summary>An authentication challenge one hop was answered with.</summary>
+/// <remarks>
+/// <c>Source</c> is always <c>Server</c>: a <c>407</c> is a proxy's, and the proxy belongs to the
+/// <c>HttpClient</c> the context was given rather than to this browser.
+/// </remarks>
+/// <param name="Id">The request the challenge answered.</param>
+/// <param name="Url">The absolute URL of the hop that was challenged.</param>
+/// <param name="Status">The status the challenge arrived with, always <c>401</c>.</param>
+/// <param name="Source">Who is challenging, always <c>Server</c>.</param>
+/// <param name="Scheme">The authentication scheme, as the server spelled it.</param>
+/// <param name="Realm">The realm the challenge named, or the empty string.</param>
+/// <param name="CanProvideCredentials">
+/// Whether this browser can turn a username and a password into an answer for <paramref name="Scheme"/> —
+/// true only for <c>Basic</c>.
+/// </param>
+internal sealed record PageNetworkAuthChallenge(
+    string Id,
+    string Url,
+    int Status,
+    string Source,
+    string Scheme,
+    string Realm,
+    bool CanProvideCredentials);
+
+/// <summary>What a listener decided about one authentication challenge.</summary>
+/// <remarks>
+/// The three the protocol's <c>AuthChallengeResponse</c> admits: <c>Default</c> and <c>CancelAuth</c> both
+/// deliver the <c>401</c> and are one answer here, because nothing downstream can tell them apart;
+/// <c>ProvideCredentials</c> is the one that re-sends the hop.
+/// </remarks>
+internal sealed class PageNetworkAuthDecision
+{
+    private PageNetworkAuthDecision()
+    {
+    }
+
+    /// <summary>Deliver the <c>401</c> — the protocol's <c>Default</c> and its <c>CancelAuth</c>.</summary>
+    internal static PageNetworkAuthDecision Proceed { get; } = new();
+
+    internal bool HasCredentials { get; private init; }
+
+    internal string Username { get; private init; } = string.Empty;
+
+    internal string Password { get; private init; } = string.Empty;
+
+    /// <summary>Answer the challenge and send the hop again — <c>Fetch.continueWithAuth</c>.</summary>
+    internal static PageNetworkAuthDecision Credentials(string username, string password)
+        => new() { HasCredentials = true, Username = username, Password = password };
+}
+
 /// <summary>What a listener decided about one response.</summary>
 /// <remarks>
 /// The response half of <see cref="PageNetworkDecision"/>, and deliberately a separate type: what a client
@@ -307,6 +357,24 @@ internal interface IPageNetworkListener
     ValueTask<PageNetworkResponseDecision> ResponseWillBeDeliveredAsync(
         PageNetworkRequest request,
         PageNetworkResponse response,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// A server answered a hop with <c>401</c> and an authentication challenge; answer what should be done
+    /// about it.
+    /// </summary>
+    /// <param name="request">The hop that was challenged, as it went out.</param>
+    /// <param name="challenge">What the server asked for, and whether this browser can answer it.</param>
+    /// <param name="cancellationToken">Cancelled when the fetch is abandoned or times out.</param>
+    /// <remarks>
+    /// <b>There is no notification beside this one</b>, unlike the request and the response: a challenge is
+    /// only ever a question. A listener that is not interested answers
+    /// <see cref="PageNetworkAuthDecision.Proceed"/> and the <c>401</c> is delivered to the page as any other
+    /// response, having already been reported as one.
+    /// </remarks>
+    ValueTask<PageNetworkAuthDecision> AuthRequiredAsync(
+        PageNetworkRequest request,
+        PageNetworkAuthChallenge challenge,
         CancellationToken cancellationToken);
 
     /// <summary>The final response, after any answer above has been applied.</summary>

--- a/Jint.Browser/Runtime/PageNetworkRecorder.cs
+++ b/Jint.Browser/Runtime/PageNetworkRecorder.cs
@@ -383,6 +383,69 @@ internal sealed class PageNetworkRecorder : FetchObserver
         return Translate(decision);
     }
 
+    /// <summary>
+    /// A hop was challenged; asks the listener, which is <c>Fetch.authRequired</c> and the
+    /// <c>continueWithAuth</c> that answers it.
+    /// </summary>
+    /// <remarks>
+    /// <b>A challenge is only ever a question</b>, so unlike a request and a response there is no
+    /// notification beside it. The <c>401</c> itself has already been reported as an ordinary response by the
+    /// time a listener that declines lets it through, so nothing about it is hidden by this existing.
+    /// </remarks>
+    public override async ValueTask<FetchAuthDecision?> OnAuthRequiredAsync(
+        ObservedFetchAuthChallenge challenge,
+        CancellationToken cancellationToken)
+    {
+        if (_listener is not { } listener)
+        {
+            return null;
+        }
+
+        Entry? entry;
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(challenge.Id.Value, out entry))
+            {
+                return null;
+            }
+        }
+
+        if (entry.LastHop is not { } hop)
+        {
+            return null;
+        }
+
+        PageNetworkAuthDecision decision;
+        try
+        {
+            decision = await listener.AuthRequiredAsync(
+                hop,
+                new PageNetworkAuthChallenge(
+                    entry.RequestId,
+                    challenge.Url.ToString(),
+                    challenge.Status,
+                    challenge.Source,
+                    challenge.Scheme,
+                    challenge.Realm,
+                    challenge.CanProvideCredentials),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // a watcher that failed must not decide the request; see IPageNetworkListener
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+            return null;
+        }
+
+        return decision.HasCredentials
+            ? FetchAuthDecision.ProvideCredentials(decision.Username, decision.Password)
+            : null;
+    }
+
     /// <summary>The client's answer, as the engine's own preview type.</summary>
     private static FetchResponseInterception? Translate(PageNetworkResponseDecision decision)
     {

--- a/Jint.DevTools/Protocol/Generated/Fetch.g.cs
+++ b/Jint.DevTools/Protocol/Generated/Fetch.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/browser_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, Fetch entries, sha256:b01623b203c2
+//     manifest: tools/devtools-protocol/manifest.json, Fetch entries, sha256:4f7250c77f22
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -468,6 +468,12 @@ namespace Jint.DevTools.Domains
                 case "continueRequest":
                 {
                     var result = await ContinueRequestAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.FetchContinueRequestRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "continueWithAuth":
+                {
+                    var result = await ContinueWithAuthAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.FetchContinueWithAuthRequest), context).ConfigureAwait(false);
                     return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
                 }
 

--- a/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:ff928e6894f7
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:6325b5e888f5
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and

--- a/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:ff928e6894f7
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:6325b5e888f5
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -152,6 +152,7 @@ namespace Jint.DevTools.Protocol
             "Emulation.setVisibleSize",
             "Fetch.continueRequest",
             "Fetch.continueResponse",
+            "Fetch.continueWithAuth",
             "Fetch.disable",
             "Fetch.enable",
             "Fetch.failRequest",
@@ -279,6 +280,7 @@ namespace Jint.DevTools.Protocol
             "Debugger.paused",
             "Debugger.resumed",
             "Debugger.scriptParsed",
+            "Fetch.authRequired",
             "Fetch.requestPaused",
             "Log.entryAdded",
             "Network.dataReceived",

--- a/Jint.Tests.Browser/DevTools/FetchDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/FetchDomainTests.cs
@@ -309,6 +309,162 @@ public class FetchDomainTests
         error.GetProperty("message").GetString().Should().Be("Invalid InterceptionId.");
     }
 
+    // ---------------------------------------------------------------- authentication
+
+    /// <summary>
+    /// Maps a route that challenges the first request with <paramref name="challenge"/> and answers every
+    /// later one, so a test reads the retry off <see cref="LoopbackServer.Received"/>.
+    /// </summary>
+    private static void MapChallenged(LoopbackServer server, string path, string challenge)
+    {
+        var served = 0;
+        server.Map(path, _ =>
+        {
+            if (Interlocked.Increment(ref served) > 1)
+            {
+                return LoopbackResponse.Html("<html><head><title>Let in</title></head><body>ok</body></html>");
+            }
+
+            return new LoopbackResponse { Status = 401, Reason = "Unauthorized", Body = "no" }
+                .With("WWW-Authenticate", challenge)
+                .With("Content-Type", "text/html; charset=utf-8");
+        });
+    }
+
+    /// <summary>
+    /// The whole lane: a <c>401</c> pauses as <c>Fetch.authRequired</c>, the client answers with
+    /// credentials, and the hop goes again carrying them —
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-continueWithAuth.
+    /// </summary>
+    /// <remarks>
+    /// It is the gap <see href="https://github.com/sebastienros/jint/issues/3828">#3828</see>'s survey put
+    /// first: both client families send <c>handleAuthRequests: true</c> unconditionally whenever they
+    /// intercept, so before this the credentials a client configured were discarded with no error anywhere.
+    /// </remarks>
+    [Test]
+    public async Task AChallengePausesAndContinueWithAuthSendsTheHopAgainWithCredentials()
+    {
+        using var server = new LoopbackServer();
+        MapChallenged(server, "/private", "Basic realm=\"the vault\"");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync("""{"handleAuthRequests":true}""");
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/private"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+
+        // The request stage pauses first, because a default pattern is the request stage's.
+        await fixture.ContinueAsync(await fixture.PausedAsync());
+
+        var challenged = await fixture.Session.EventAsync("Fetch.authRequired", sessionId: fixture.Attachment, timeoutSeconds: 30);
+        var challenge = challenged.GetProperty("authChallenge");
+        challenge.GetProperty("source").GetString().Should().Be("Server");
+        challenge.GetProperty("scheme").GetString().Should().Be("Basic");
+        challenge.GetProperty("realm").GetString().Should().Be("the vault");
+        challenge.GetProperty("origin").GetString().Should().Be(server.Origin);
+        challenged.GetProperty("request").GetProperty("url").GetString().Should().Be(server.Url("/private"));
+
+        await fixture.Session.ResultAsync(
+            "Fetch.continueWithAuth",
+            $$$"""{"requestId":"{{{challenged.GetProperty("requestId").GetString()}}}","authChallengeResponse":{"response":"ProvideCredentials","username":"ada","password":"l0velace"}}""",
+            fixture.Attachment);
+
+        // The retry is a second hop of the same request, so it pauses at the request stage too.
+        await fixture.ContinueAsync(await fixture.PausedAsync(1));
+
+        await navigation.WaitAsync(Bound);
+        (await fixture.Page.TitleAsync()).Should().Be("Let in");
+
+        var expected = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("ada:l0velace"));
+        var attempts = server.Received.Where(received => received.Path == "/private").ToArray();
+        attempts.Should().HaveCount(2);
+        attempts[0].Header("Authorization").Should().BeNull();
+        attempts[1].Header("Authorization").Should().Be(expected);
+    }
+
+    /// <summary>
+    /// <c>CancelAuth</c> delivers the <c>401</c> to the page, which is what a browser does when the user
+    /// dismisses the dialog.
+    /// </summary>
+    [Test]
+    public async Task CancellingAChallengeDeliversTheFourHundredAndOne()
+    {
+        using var server = new LoopbackServer();
+        MapChallenged(server, "/private", "Basic realm=\"the vault\"");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync("""{"handleAuthRequests":true}""");
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/private"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.ContinueAsync(await fixture.PausedAsync());
+
+        var challenged = await fixture.Session.EventAsync("Fetch.authRequired", sessionId: fixture.Attachment, timeoutSeconds: 30);
+        await fixture.Session.ResultAsync(
+            "Fetch.continueWithAuth",
+            $$$"""{"requestId":"{{{challenged.GetProperty("requestId").GetString()}}}","authChallengeResponse":{"response":"CancelAuth"}}""",
+            fixture.Attachment);
+
+        await navigation.WaitAsync(Bound);
+        server.Received.Count(received => received.Path == "/private").Should().Be(1, "a cancelled challenge sends nothing again");
+    }
+
+    /// <summary>
+    /// A scheme this browser cannot answer is still reported, and <c>ProvideCredentials</c> for it is refused
+    /// <b>by name</b> rather than accepted and quietly dropped.
+    /// </summary>
+    /// <remarks>
+    /// Being asked is how a client tells "this browser does not do Digest" from "the server never
+    /// challenged"; the error on the command is how it learns its credentials were understood and could not
+    /// be used. An ask that cannot be honoured must fail visibly, because an ask that silently does nothing
+    /// is the defect this lane exists to remove.
+    /// </remarks>
+    [Test]
+    public async Task CredentialsForASchemeThatCannotBeAnsweredAreRefusedByName()
+    {
+        using var server = new LoopbackServer();
+        MapChallenged(server, "/private", "Digest realm=\"the vault\", nonce=\"abc\"");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync("""{"handleAuthRequests":true}""");
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/private"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.ContinueAsync(await fixture.PausedAsync());
+
+        var challenged = await fixture.Session.EventAsync("Fetch.authRequired", sessionId: fixture.Attachment, timeoutSeconds: 30);
+        challenged.GetProperty("authChallenge").GetProperty("scheme").GetString().Should().Be("Digest");
+
+        var error = await fixture.Session.ErrorAsync(
+            "Fetch.continueWithAuth",
+            $$$"""{"requestId":"{{{challenged.GetProperty("requestId").GetString()}}}","authChallengeResponse":{"response":"ProvideCredentials","username":"ada","password":"l0velace"}}""",
+            fixture.Attachment);
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Credentials cannot be provided for a 'Digest' challenge.");
+
+        // Refused, and the request was still released rather than left hanging on the error.
+        await navigation.WaitAsync(Bound);
+        server.Received.Count(received => received.Path == "/private").Should().Be(1);
+    }
+
+    /// <summary>
+    /// Without <c>handleAuthRequests</c> nothing is reported, which is the protocol's own rule and what keeps
+    /// a client that never asked from being shown a pause it will not answer.
+    /// </summary>
+    [Test]
+    public async Task AChallengeIsNotReportedToAClientThatDidNotAskForOne()
+    {
+        using var server = new LoopbackServer();
+        MapChallenged(server, "/private", "Basic realm=\"the vault\"");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync();
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/private"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.ContinueAsync(await fixture.PausedAsync());
+
+        await navigation.WaitAsync(Bound);
+        server.Received.Count(received => received.Path == "/private").Should().Be(1);
+    }
+
     /// <summary>A page, its target, and an attachment ready to intercept.</summary>
     // ---------------------------------------------------------------- the response stage
 

--- a/Jint.Tests.Browser/DevTools/NetworkDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/NetworkDomainTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Jint.Browser;
 using Jint.Tests.Browser.Navigation;
@@ -390,9 +391,11 @@ public class NetworkDomainTests
     /// <para>
     /// The URL here is one the context's own filter refuses, which is what lets this run with no WebSocket
     /// server: a refused socket is still created and still closes, which is the pair that proves the whole
-    /// chain — the engine's observer, the recorder, the listener, the target, the domain, the client. What
-    /// the two <i>handshake</i> events carry is pinned one level down, in
-    /// <c>Jint.Tests/Runtime/WebApi/WebSocketTests</c>, over a connection double.
+    /// chain — the engine's observer, the recorder, the listener, the target, the domain, the client.
+    /// <see cref="ASocketToTheOriginPutsItsHandshakeRequestOnTheWire"/> is the same chain with a real socket
+    /// on a real origin, which adds the handshake request; what the handshake <i>response</i> carries is
+    /// pinned one level down, in <c>Jint.Tests/Runtime/WebApi/WebSocketTests</c>, because raising it needs a
+    /// server that answers <c>101</c> and the loopback server does not speak the upgrade.
     /// </para>
     /// </remarks>
     [Test]
@@ -401,11 +404,7 @@ public class NetworkDomainTests
         using var server = new LoopbackServer();
         server.MapHtml("/page", "<html><body>ok</body></html>");
 
-        // A page does not carry WebSocket by default, so the host turns it on the way an embedder would.
-        var options = new BrowserOptions().ConfigureEngine(
-            engine => engine.WebApi.Features |= WebApiFeatures.WebSocket);
-
-        await using var fixture = await NetworkFixture.OpenAsync(server, options);
+        await using var fixture = await NetworkFixture.OpenAsync(server);
         await fixture.NavigateAsync("/page");
 
         await fixture.Page.EvaluateAsync("new WebSocket('wss://elsewhere.invalid/socket');");
@@ -423,6 +422,62 @@ public class NetworkDomainTests
         fixture.Page.Requests.Should().NotContain(
             request => request.Url.StartsWith("wss:", StringComparison.Ordinal),
             "a socket is not a request and must not be one that never finishes");
+    }
+
+    /// <summary>
+    /// The same chain with a socket that really goes out: the handshake request a page's <c>WebSocket</c>
+    /// puts on the wire reaches a client as
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-webSocketWillSendHandshakeRequest.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The filter is widened to the loopback port rather than to a scheme</b>, because the context's
+    /// <c>UrlFilter</c> is shown the <c>ws:</c> URL and <see cref="LoopbackServer.Owns"/> requires
+    /// <c>http</c>. One policy covers a document, its subresources and its sockets, which is the property
+    /// being relied on here.
+    /// </para>
+    /// <para>
+    /// The server answers an ordinary response rather than a <c>101</c>, so the connection fails — and by
+    /// then every event but <c>webSocketHandshakeResponseReceived</c> has already been raised. Raising that
+    /// one needs a server that speaks the upgrade, which this one deliberately does not; what it carries is
+    /// pinned over a connection double in <c>Jint.Tests/Runtime/WebApi/WebSocketTests</c>.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task ASocketToTheOriginPutsItsHandshakeRequestOnTheWire()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await NetworkFixture.OpenAsync(
+            server,
+            urlFilter: uri => uri.IsLoopback && uri.Port == server.Port);
+
+        await fixture.NavigateAsync("/page");
+
+        var url = string.Create(CultureInfo.InvariantCulture, $"ws://127.0.0.1:{server.Port}/socket");
+        await fixture.Page.EvaluateAsync($"new WebSocket('{url}');");
+
+        var created = await fixture.EventAsync("Network.webSocketCreated");
+        created.GetProperty("url").GetString().Should().Be(url);
+        var socketId = created.GetProperty("requestId").GetString();
+
+        var handshake = await fixture.EventAsync("Network.webSocketWillSendHandshakeRequest");
+        handshake.GetProperty("requestId").GetString().Should().Be(socketId);
+
+        // The one header the connection sets for itself, and the page's own: a socket goes out claiming to
+        // be the same browser the document's requests claim to be.
+        var agent = await fixture.Page.EvaluateAsync<string>("navigator.userAgent");
+        handshake.GetProperty("request").GetProperty("headers").GetProperty("user-agent").GetString().Should().Be(agent);
+
+        var closed = await fixture.EventAsync("Network.webSocketClosed");
+        closed.GetProperty("requestId").GetString().Should().Be(socketId);
+
+        // And the origin really was asked to upgrade, which is what makes the events above a report of
+        // something rather than a report of nothing.
+        var received = server.Received.Single(request => request.Path == "/socket");
+        received.Header("Upgrade").Should().Be("websocket");
+        received.Header("User-Agent").Should().Be(agent);
     }
 
     [Test]
@@ -543,9 +598,19 @@ public class NetworkDomainTests
 
         internal string FrameId { get; }
 
-        internal static async Task<NetworkFixture> OpenAsync(LoopbackServer server, BrowserOptions? options = null)
+        /// <param name="server">The origin the page loads from.</param>
+        /// <param name="options">The browser's own options, or <see langword="null"/> for the defaults.</param>
+        /// <param name="urlFilter">
+        /// The context's policy, or <see langword="null"/> for <see cref="LoopbackServer.Owns"/>. A test that
+        /// opens a socket passes one, because <c>Owns</c> requires the <c>http</c> scheme and the filter is
+        /// shown the <c>ws:</c> URL.
+        /// </param>
+        internal static async Task<NetworkFixture> OpenAsync(
+            LoopbackServer server,
+            BrowserOptions? options = null,
+            Func<Uri, bool>? urlFilter = null)
         {
-            var session = await PageSession.CreateAsync(new BrowserContextOptions { UrlFilter = server.Owns }, options);
+            var session = await PageSession.CreateAsync(new BrowserContextOptions { UrlFilter = urlFilter ?? server.Owns }, options);
             var page = await session.NewPageAsync();
             var target = await session.TargetForAsync(page);
             var attachment = await session.AttachAsync(target);

--- a/Jint.Tests.Browser/Navigation/PageSocketTests.cs
+++ b/Jint.Tests.Browser/Navigation/PageSocketTests.cs
@@ -1,0 +1,156 @@
+using System.Globalization;
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.Navigation;
+
+/// <summary>
+/// The two streaming network APIs a page opens for itself — <c>WebSocket</c> and <c>EventSource</c> — and the
+/// one it deliberately does not have.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every test here constructs the interface from the page</b>, which is the thing that was missing: the
+/// engine has had both features for a long time, and a page never turned either of them on, so nothing in
+/// this project had ever written <c>new WebSocket(…)</c> against a real document. A test that only asserted
+/// the constructor is a function would have gone on passing if the feature were removed from the engine, so
+/// each of these also puts a request on the wire and reads the server's copy of it.
+/// </para>
+/// <para>
+/// <b>The context's <see cref="BrowserContextOptions.UrlFilter"/> is shown the <c>ws:</c> URL</b>, which is
+/// why these tests widen it rather than reuse <see cref="LoopbackServer.Owns"/>: one policy covers the
+/// document, its subresources, its <c>XMLHttpRequest</c>s, its workers <i>and</i> its sockets, and a filter
+/// written for <c>http</c> alone refuses a socket to the same origin. That is the engine's rule
+/// (<c>Options.FetchOptions.AllowedSchemes</c> admits <c>ws</c> wherever it admits <c>http</c>) surfacing at
+/// the page, and it is worth a test of its own.
+/// </para>
+/// </remarks>
+public sealed class PageSocketTests
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Admits loopback over <c>http</c> and over <c>ws</c>, which is the whole widening these tests need.
+    /// </summary>
+    /// <remarks>
+    /// Loopback-only is what keeps a test off somebody's DNS, which is the property
+    /// <see cref="LoopbackServer.Owns"/> is really there for; the port is not pinned because the point being
+    /// made is about the <i>scheme</i>.
+    /// </remarks>
+    private static bool ReachesLoopback(Uri uri)
+        => uri.IsLoopback
+            && (string.Equals(uri.Scheme, "http", StringComparison.Ordinal) || string.Equals(uri.Scheme, "ws", StringComparison.Ordinal));
+
+    private static string SocketUrl(LoopbackServer server, string path)
+        => string.Create(CultureInfo.InvariantCulture, $"ws://127.0.0.1:{server.Port}{path}");
+
+    [Test]
+    public async Task APageCanConstructAWebSocketAndItsHandshakeReachesTheOrigin()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/page", "<html><body>ok</body></html>"),
+            configureContext: options => options.UrlFilter = ReachesLoopback);
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        (await fixture.Page.EvaluateAsync<string>("typeof WebSocket")).Should().Be("function");
+
+        await fixture.Page.EvaluateAsync(
+            $$"""
+            window.__state = null;
+            window.__socket = new WebSocket('{{SocketUrl(fixture.Server, "/socket")}}');
+            window.__opened = window.__socket.readyState;
+            window.__socket.addEventListener('close', function (e) { window.__state = e.code; });
+            """);
+
+        // https://websockets.spec.whatwg.org/#dom-websocket-connecting — a socket is CONNECTING the moment
+        // the constructor returns, which is the observable proof that the constructor did more than exist.
+        (await fixture.Page.EvaluateAsync<double>("window.__opened")).Should().Be(0);
+
+        // The server answers an ordinary 200 rather than a 101, so the connection fails and the page is told
+        // so. What is being asserted is the request: the socket went out over the page's own transport, to
+        // the page's own origin, with the headers a WebSocket handshake carries.
+        (await fixture.Page.WaitForAsync("window.__state !== null", Bound)).Should().BeTrue();
+
+        var handshake = fixture.Server.Received.Single(received => received.Path == "/socket");
+        handshake.Header("Upgrade").Should().Be("websocket");
+        handshake.Header("Connection").Should().Contain("Upgrade");
+        handshake.Header("Sec-WebSocket-Key").Should().NotBeNullOrEmpty();
+        handshake.Header("Sec-WebSocket-Version").Should().Be("13");
+    }
+
+    [Test]
+    public async Task APageWithAFilterForHttpAloneCannotOpenASocketToItsOwnOrigin()
+    {
+        // The default LoopbackPage filter is LoopbackServer.Owns, which requires the http scheme.
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/page", "<html><body>ok</body></html>"));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        await fixture.Page.EvaluateAsync(
+            $$"""
+            window.__failed = false;
+            var socket = new WebSocket('{{SocketUrl(fixture.Server, "/socket")}}');
+            socket.addEventListener('error', function () { window.__failed = true; });
+            """);
+
+        (await fixture.Page.WaitForAsync("window.__failed === true", Bound)).Should().BeTrue();
+        fixture.Server.Received.Should().NotContain(received => received.Path == "/socket");
+    }
+
+    [Test]
+    public async Task APageCanOpenAnEventSourceAndReadAnEventFromIt()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server =>
+        {
+            server.MapHtml("/page", "<html><body>ok</body></html>");
+            server.Map("/events", _ => new LoopbackResponse { Body = "data: first\n\n" }
+                .With("Content-Type", "text/event-stream")
+                .With("Cache-Control", "no-store"));
+        });
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        (await fixture.Page.EvaluateAsync<string>("typeof EventSource")).Should().Be("function");
+
+        await fixture.Page.EvaluateAsync(
+            """
+            window.__message = null;
+            window.__source = new EventSource('/events');
+            window.__source.addEventListener('message', function (e) {
+                window.__message = e.data;
+                // Closed from the handler so the stream's end cannot start a reconnection the test would
+                // then have to wait out.
+                window.__source.close();
+            });
+            """);
+
+        (await fixture.Page.WaitForAsync("window.__message !== null", Bound)).Should().BeTrue();
+        (await fixture.Page.EvaluateAsync<string>("window.__message")).Should().Be("first");
+
+        var stream = fixture.Server.Received.First(received => received.Path == "/events");
+        stream.Header("Accept").Should().Contain("text/event-stream");
+    }
+
+    /// <summary>
+    /// <c>caches</c> is deliberately absent, and this pins the decision rather than the omission.
+    /// </summary>
+    /// <remarks>
+    /// See <c>BrowserEngineFactory</c>, where the feature set is computed: the engine's default
+    /// <c>CacheStorageProvider</c> is one per engine, and a page builds a new engine on every navigation, so
+    /// a <c>caches</c> granted on the default would be emptied by every navigation — a scratchpad under a
+    /// name that promises otherwise. Granting it needs a provider the browsing context owns and partitions
+    /// by origin, the way <c>localStorage</c> already is, plus a quota; until that exists, absent is the
+    /// honest answer and a page feature-detects its way past it exactly as it does on an insecure origin.
+    /// </remarks>
+    [Test]
+    public async Task APageHasNoCacheStorage()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(
+            server => server.MapHtml("/page", "<html><body>ok</body></html>"));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/page"));
+
+        (await fixture.Page.EvaluateAsync<string>("typeof caches")).Should().Be("undefined");
+    }
+}

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -3061,6 +3061,12 @@ namespace Jint.WebApi.Fetch
         public abstract string? GetCookieHeader(System.Uri url);
         public abstract void StoreResponseCookies(System.Uri url, System.Collections.Generic.IReadOnlyList<string> setCookieHeaders);
     }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class FetchAuthDecision
+    {
+        public static Jint.WebApi.Fetch.FetchAuthDecision Cancel() { }
+        public static Jint.WebApi.Fetch.FetchAuthDecision ProvideCredentials(string username, string password) { }
+    }
     public sealed class FetchHandlerOperation
     {
         public System.Exception? Error { get; }
@@ -3094,6 +3100,7 @@ namespace Jint.WebApi.Fetch
     {
         protected FetchObserver() { }
         public virtual int RequestBodyPreviewBytes { get; }
+        public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchAuthDecision?> OnAuthRequiredAsync(Jint.WebApi.Fetch.ObservedFetchAuthChallenge challenge, System.Threading.CancellationToken cancellationToken) { }
         public virtual void OnCompleted(Jint.WebApi.Fetch.FetchRequestId id, long bodyLength) { }
         public virtual void OnData(Jint.WebApi.Fetch.FetchRequestId id, System.ReadOnlySpan<byte> chunk) { }
         public virtual void OnFailed(Jint.WebApi.Fetch.FetchRequestId id, string reason, System.Exception? exception) { }
@@ -3120,6 +3127,18 @@ namespace Jint.WebApi.Fetch
         public System.DateTimeOffset HeadersAt { get; }
         public System.DateTimeOffset SentAt { get; init; }
         public System.TimeSpan TimeToHeaders { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedFetchAuthChallenge : System.IEquatable<Jint.WebApi.Fetch.ObservedFetchAuthChallenge>
+    {
+        public ObservedFetchAuthChallenge() { }
+        public required bool CanProvideCredentials { get; init; }
+        public required Jint.WebApi.Fetch.FetchRequestId Id { get; init; }
+        public string Realm { get; init; }
+        public required string Scheme { get; init; }
+        public string Source { get; init; }
+        public required int Status { get; init; }
+        public required System.Uri Url { get; init; }
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class ObservedFetchRequest : System.IEquatable<Jint.WebApi.Fetch.ObservedFetchRequest>

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -3061,6 +3061,12 @@ namespace Jint.WebApi.Fetch
         public abstract string? GetCookieHeader(System.Uri url);
         public abstract void StoreResponseCookies(System.Uri url, System.Collections.Generic.IReadOnlyList<string> setCookieHeaders);
     }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class FetchAuthDecision
+    {
+        public static Jint.WebApi.Fetch.FetchAuthDecision Cancel() { }
+        public static Jint.WebApi.Fetch.FetchAuthDecision ProvideCredentials(string username, string password) { }
+    }
     public sealed class FetchHandlerOperation
     {
         public System.Exception? Error { get; }
@@ -3094,6 +3100,7 @@ namespace Jint.WebApi.Fetch
     {
         protected FetchObserver() { }
         public virtual int RequestBodyPreviewBytes { get; }
+        public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchAuthDecision?> OnAuthRequiredAsync(Jint.WebApi.Fetch.ObservedFetchAuthChallenge challenge, System.Threading.CancellationToken cancellationToken) { }
         public virtual void OnCompleted(Jint.WebApi.Fetch.FetchRequestId id, long bodyLength) { }
         public virtual void OnData(Jint.WebApi.Fetch.FetchRequestId id, System.ReadOnlySpan<byte> chunk) { }
         public virtual void OnFailed(Jint.WebApi.Fetch.FetchRequestId id, string reason, System.Exception? exception) { }
@@ -3120,6 +3127,18 @@ namespace Jint.WebApi.Fetch
         public System.DateTimeOffset HeadersAt { get; }
         public System.DateTimeOffset SentAt { get; init; }
         public System.TimeSpan TimeToHeaders { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class ObservedFetchAuthChallenge : System.IEquatable<Jint.WebApi.Fetch.ObservedFetchAuthChallenge>
+    {
+        public ObservedFetchAuthChallenge() { }
+        public required bool CanProvideCredentials { get; init; }
+        public required Jint.WebApi.Fetch.FetchRequestId Id { get; init; }
+        public string Realm { get; init; }
+        public required string Scheme { get; init; }
+        public string Source { get; init; }
+        public required int Status { get; init; }
+        public required System.Uri Url { get; init; }
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class ObservedFetchRequest : System.IEquatable<Jint.WebApi.Fetch.ObservedFetchRequest>

--- a/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
@@ -506,6 +506,8 @@ public class WebApiFetchDocumentTests
 
         internal Func<ObservedFetchResponse, FetchResponseInterception?>? OnResponseHandler { get; init; }
 
+        internal Func<ObservedFetchAuthChallenge, FetchAuthDecision?>? OnAuthHandler { get; init; }
+
         public override int RequestBodyPreviewBytes => 16;
 
         public override ValueTask<FetchInterception?> OnRequestAsync(ObservedFetchRequest request, CancellationToken cancellationToken)
@@ -526,6 +528,16 @@ public class WebApiFetchDocumentTests
             }
 
             return new ValueTask<FetchResponseInterception?>(OnResponseHandler?.Invoke(response));
+        }
+
+        public override ValueTask<FetchAuthDecision?> OnAuthRequiredAsync(ObservedFetchAuthChallenge challenge, CancellationToken cancellationToken)
+        {
+            lock (Events)
+            {
+                Events.Add($"auth {challenge.Id} {challenge.Status} {challenge.Source} {challenge.Scheme} realm={challenge.Realm} answerable={challenge.CanProvideCredentials}");
+            }
+
+            return new ValueTask<FetchAuthDecision?>(OnAuthHandler?.Invoke(challenge));
         }
 
         public override void OnResponse(ObservedFetchResponse response)
@@ -827,6 +839,158 @@ public class WebApiFetchDocumentTests
             """)
             .UnwrapIfPromise(TransportSignalCeiling).AsString()
             .Should().Be("true|200|Fine now|yes|the real body");
+    });
+
+    // ---- Fetch.Observer: authentication challenges ----
+
+    /// <summary>
+    /// Builds a handler that challenges the first request with <paramref name="challenge"/> and answers every
+    /// later one with <c>200 authorized</c>, so a test reads the retry off <c>Requests</c>.
+    /// </summary>
+    private static RecordingHandler Challenging(string challenge)
+    {
+        RecordingHandler handler = null!;
+        handler = new RecordingHandler
+        {
+            Responder = _ =>
+            {
+                if (handler.Requests.Count > 1)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("authorized") };
+                }
+
+                var refused = new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("no") };
+                refused.Headers.TryAddWithoutValidation("WWW-Authenticate", challenge);
+                return refused;
+            },
+        };
+
+        return handler;
+    }
+
+    /// <summary>
+    /// The whole of it: a <c>401</c> reaches the observer, the observer answers with credentials, and the hop
+    /// goes again carrying them — which is what <c>Fetch.continueWithAuth</c> is mapped onto.
+    /// </summary>
+    [Test]
+    public Task AnObserverAnswersABasicChallengeAndTheHopGoesAgainWithTheCredentials() => DedicatedThread.RunAsync(() =>
+    {
+        var handler = Challenging("Basic realm=\"the vault\"");
+        var observer = new RecordingObserver
+        {
+            OnAuthHandler = _ => FetchAuthDecision.ProvideCredentials("ada", "l0velace"),
+        };
+
+        var engine = WebEngine(handler, f => f.Observer = observer);
+
+        engine.Evaluate("fetch('https://a.test/private').then(r => r.status + '|' + r.text())")
+            .UnwrapIfPromise(TransportSignalCeiling);
+
+        engine.Evaluate("fetch('https://a.test/private').then(r => r.text())")
+            .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("authorized");
+
+        // RFC 7617: base64 of "ada:l0velace", and the scheme spelled as the server spelled it.
+        var expected = "Basic " + Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("ada:l0velace"));
+        handler.Requests.Should().HaveCountGreaterThan(1);
+        handler.HeaderOf(0, "Authorization").Should().BeNull("the first hop is what provokes the challenge");
+        handler.HeaderOf(1, "Authorization").Should().Be(expected);
+
+        observer.Events.Should().Contain(entry => entry.Contains("Basic realm=the vault answerable=True", StringComparison.Ordinal));
+    });
+
+    /// <summary>
+    /// A challenge the observer declines, and one it is simply not interested in, both deliver the
+    /// <c>401</c> — which is the protocol's <c>CancelAuth</c> and its <c>Default</c>.
+    /// </summary>
+    [Test]
+    public Task ADeclinedChallengeDeliversTheFourHundredAndOne() => DedicatedThread.RunAsync(() =>
+    {
+        foreach (var decision in new Func<ObservedFetchAuthChallenge, FetchAuthDecision?>[]
+                 {
+                     static _ => FetchAuthDecision.Cancel(),
+                     static _ => null,
+                 })
+        {
+            var handler = Challenging("Basic realm=\"the vault\"");
+            var observer = new RecordingObserver { OnAuthHandler = decision };
+            var engine = WebEngine(handler, f => f.Observer = observer);
+
+            engine.Evaluate("fetch('https://a.test/private').then(r => r.status + '|' + r.ok)")
+                .UnwrapIfPromise(TransportSignalCeiling).AsString().Should().Be("401|false");
+
+            handler.Requests.Should().HaveCount(1, "a declined challenge sends nothing again");
+            observer.Events.Should().Contain(entry => entry.StartsWith("auth ", StringComparison.Ordinal));
+        }
+    });
+
+    /// <summary>
+    /// A scheme this engine cannot answer is <b>still reported</b>, and credentials offered for it are
+    /// refused rather than quietly dropped.
+    /// </summary>
+    /// <remarks>
+    /// Being asked is how an observer tells "this engine does not support Digest" from "the server never
+    /// challenged", and <see cref="ObservedFetchAuthChallenge.CanProvideCredentials"/> is the answer it gets
+    /// before it decides. Answering with credentials anyway changes nothing about the request, which is what
+    /// makes the refusal visible rather than silent: the <c>401</c> arrives, one request was sent, and no
+    /// <c>Authorization</c> header was invented for a scheme that would not have accepted it.
+    /// </remarks>
+    [Test]
+    public Task ASchemeTheEngineCannotAnswerIsReportedAndItsCredentialsAreRefused() => DedicatedThread.RunAsync(() =>
+    {
+        var handler = Challenging("Digest realm=\"the vault\", nonce=\"abc\"");
+        var observer = new RecordingObserver
+        {
+            OnAuthHandler = _ => FetchAuthDecision.ProvideCredentials("ada", "l0velace"),
+        };
+
+        var engine = WebEngine(handler, f => f.Observer = observer);
+
+        engine.Evaluate("fetch('https://a.test/private').then(r => r.status)")
+            .UnwrapIfPromise(TransportSignalCeiling).AsNumber().Should().Be(401);
+
+        handler.Requests.Should().HaveCount(1);
+        handler.HeaderOf(0, "Authorization").Should().BeNull();
+        observer.Events.Should().Contain(entry => entry.Contains("Digest realm=the vault answerable=False", StringComparison.Ordinal));
+    });
+
+    /// <summary>
+    /// Exactly one retry: a server that challenges the answered request too gets no third attempt, and the
+    /// second <c>401</c> is delivered.
+    /// </summary>
+    /// <remarks>
+    /// An observer has one credential to offer, so a second ask has nothing new to answer with — and a loop
+    /// is worse than a <c>401</c>.
+    /// </remarks>
+    [Test]
+    public Task ACredentialIsOfferedOnceAndASecondChallengeIsDelivered() => DedicatedThread.RunAsync(() =>
+    {
+        var handler = new RecordingHandler
+        {
+            Responder = _ =>
+            {
+                var refused = new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent("no") };
+                refused.Headers.TryAddWithoutValidation("WWW-Authenticate", "Basic realm=\"the vault\"");
+                return refused;
+            },
+        };
+
+        var asks = 0;
+        var observer = new RecordingObserver
+        {
+            OnAuthHandler = _ =>
+            {
+                asks++;
+                return FetchAuthDecision.ProvideCredentials("ada", "wrong");
+            },
+        };
+
+        var engine = WebEngine(handler, f => f.Observer = observer);
+
+        engine.Evaluate("fetch('https://a.test/private').then(r => r.status)")
+            .UnwrapIfPromise(TransportSignalCeiling).AsNumber().Should().Be(401);
+
+        asks.Should().Be(1, "the retry's own challenge is delivered rather than asked about");
+        handler.Requests.Should().HaveCount(2, "one first attempt and one retry, and no third");
     });
 
     /// <summary>

--- a/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
+++ b/Jint.Tests/Runtime/WebApi/EventSourceTests.cs
@@ -923,6 +923,37 @@ public class EventSourceTests
     }
 
     [Test]
+    public void ARelativeUrlIsResolvedAgainstTheBaseUrl()
+    {
+        // Constructor step 3: "let urlRecord be the result of encoding-parsing a URL given url, relative to
+        // settings". Options.WebApi.Fetch.BaseUrl is what stands in for the settings object here, and it is
+        // what Request and WebSocket already resolve against - so all three interfaces read one relative URL
+        // the same way, and a document embedding this engine can write the URL it would write in a browser.
+        var handler = new StubHandler();
+        var (engine, _) = SseEngine(handler, net => net.BaseUrl = new Uri("https://example.org/pages/one.html"));
+
+        engine.Execute("var source = new EventSource('../stream');");
+        Pump(engine, () => handler.Requests.Count > 0, "the connection to be attempted");
+
+        handler.Requests[0].Url.Should().Be(StreamUrl);
+        engine.Execute("source.close();");
+    }
+
+    [Test]
+    public void AnEngineWithNoBaseUrlStillRequiresAnAbsoluteUrl()
+    {
+        // The other half of the same rule: with nothing to resolve against, a relative URL is a failure and
+        // step 4's SyntaxError is what a script gets - not a request to a host nobody named.
+        var handler = new StubHandler();
+        var (engine, _) = SseEngine(handler);
+
+        engine.Evaluate("(() => { try { new EventSource('../stream'); } catch (e) { return e.name; } })()")
+            .AsString().Should().Be("SyntaxError");
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Test]
     public void WithCredentialsIsRememberedAndChangesNothing()
     {
         var handler = new StubHandler { Responder = _ => Answer("data: ok\n\n") };

--- a/Jint/WebApi/Fetch/AGENTS.md
+++ b/Jint/WebApi/Fetch/AGENTS.md
@@ -61,11 +61,12 @@ compare-and-swap is what makes `OnCompleted`/`OnFailed` fire exactly once betwee
 throws is ignored — there is no engine thread to report it to — while a throw from `OnRequestAsync` or
 `OnResponseAsync` fails the fetch, because those are the callbacks that were asked to decide.
 
-**Two callbacks answer, and each is asked in the one place every lane passes.** `OnRequestAsync` is asked per
-hop, inside the redirect loop. `OnResponseAsync` is asked once, for the response that *ends* the chain, in
-`SendForStreamAsync` — deliberately not in `SendAsync`, because a document fetch, a subresource, an
-`XMLHttpRequest` and an `EventSource` all take the stream lane and only `fetch()` takes the other, so an ask
-placed there would have served the one caller that needed it least. **The ask is not the notification**: who
+**Three callbacks answer, and where each is asked is the decision.** `OnRequestAsync` is asked per hop,
+inside the redirect loop. `OnAuthRequiredAsync` is asked beside it, in the loop's core, because a `401` on a
+document fetch, a subresource and an `XMLHttpRequest` is the case it is for. `OnResponseAsync` is asked once,
+for the response that *ends* the chain, in `SendForStreamAsync` — deliberately not in `SendAsync`, because a
+document fetch, a subresource, an `XMLHttpRequest` and an `EventSource` all take the stream lane and only
+`fetch()` takes the other, so an ask placed there would have served the one caller that needed it least. **The ask is not the notification**: who
 tells the observer about the final response is still per lane (`BeginResponseAsync` for `SendAsync`,
 `FetchObservation.FinalResponse` for everyone else), so both report what the answer produced rather than what
 the socket said. What `Continue` may not rewrite is the body — it has not been read and is still coming — and
@@ -73,7 +74,24 @@ that is the whole difference from `Fulfill`, which discards the socket's bytes u
 onto a protocol: **a refusal before the transport** (a `UrlFilter` denial, the concurrency cap, an
 already-aborted signal) reports `OnFailed` with no `OnRequest` before it, because `fetch`'s synchronous half
 cannot await one; and **a body nobody reads never completes**, because it is only pulled when script consumes
-it. **`EventSource` is observed whole, and a `WebSocket` has an observer of its own; the line between them is
+it. **An authentication challenge is asked about and only `Basic` can be answered, and the second half is a
+*stated* behaviour rather than a shortfall.** A `401` carrying a `WWW-Authenticate` reaches
+`OnAuthRequiredAsync` whatever scheme it names, because being asked is the only way an observer tells "this
+engine does not do `Digest`" from "the server never challenged" — and `ObservedFetchAuthChallenge`
+`.CanProvideCredentials` answers which it is *before* the observer decides. `Basic` is honoured with one
+`Authorization` header built in `FetchTransport.AuthorizeAsync`; `Digest` needs a nonce exchange and
+`Negotiate` and `NTLM` a handshake bound to the connection, none of which a transport that hands the socket
+back after every response can hold. Credentials offered for one of those are **refused, not dropped**: a host
+driving this through a protocol answers `Fetch.continueWithAuth` and gets an error naming the scheme, because
+an ask that cannot be honoured must fail visibly — an ask that silently does nothing is the defect this seam
+removes. **Exactly one retry per request** (`authRetried`), since an observer has one credential to offer and
+a loop is worse than a `401`; the retry is not a redirect and spends none of `MaxRedirects`. A `407` is not
+reported at all — the proxy is the host's `HttpClient`'s — so `Source` is always `Server`. The header the
+retry carries is stripped by `_crossOriginHeaderNames` if a later redirect leaves the origin, which is
+[HTTP-redirect fetch](https://fetch.spec.whatwg.org/#http-redirect-fetch) step 13 and needed no new code
+([#3828](https://github.com/sebastienros/jint/issues/3828)).
+
+**`EventSource` is observed whole, and a `WebSocket` has an observer of its own; the line between them is
 whether *this* observer can be told everything.** A stream reaches `FetchTransport`, so the request and every
 redirect hop cost nothing to report — but it reads its own body, which is why it was left unobserved until
 `EventSourceConnection` paid the same two debts a document fetch pays: `FinalResponse`, which every caller of

--- a/Jint/WebApi/Fetch/FetchObservation.cs
+++ b/Jint/WebApi/Fetch/FetchObservation.cs
@@ -79,6 +79,13 @@ internal sealed class FetchObservation
         => await _observer.OnResponseAsync(response, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
+    /// Asks the observer how to answer an authentication challenge. Like <see cref="RequestAsync"/> and
+    /// <see cref="ResponseAsync"/>, a throw is <b>not</b> swallowed.
+    /// </summary>
+    internal async Task<FetchAuthDecision?> AuthRequiredAsync(ObservedFetchAuthChallenge challenge, CancellationToken cancellationToken)
+        => await _observer.OnAuthRequiredAsync(challenge, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
     /// Reports the final response of an exchange whose body the caller reads itself, then — once those bytes
     /// are counted — <see cref="Completed"/>.
     /// </summary>

--- a/Jint/WebApi/Fetch/FetchObserver.cs
+++ b/Jint/WebApi/Fetch/FetchObserver.cs
@@ -214,6 +214,121 @@ public sealed record ObservedFetchResponse
 }
 
 /// <summary>
+/// An authentication challenge a server answered a request with, before it is delivered as a <c>401</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every challenge is reported, including the ones this engine cannot answer</b>, because the alternative
+/// is the silence this seam exists to remove: an observer that is never asked cannot tell a scheme it does
+/// not support from a server that never challenged. <see cref="CanProvideCredentials"/> is what separates
+/// the two, and it is answered <i>before</i> the observer decides rather than after.
+/// </para>
+/// <para>
+/// <b>Only a server challenge is reported.</b> A <c>407</c> is a proxy's, and the proxy belongs to the
+/// <c>HttpClient</c> the host supplied — setting <c>Proxy-Authorization</c> under a handler that re-frames
+/// the request is not this engine's to do — so <see cref="Source"/> is always <c>Server</c>. The name is
+/// carried anyway, because it is the protocol's own and a client reads it.
+/// </para>
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public sealed record ObservedFetchAuthChallenge
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservedFetchAuthChallenge"/> record.
+    /// </summary>
+    public ObservedFetchAuthChallenge()
+    {
+    }
+
+    /// <summary>Gets the identifier shared by every hop of the request that was challenged.</summary>
+    public required FetchRequestId Id { get; init; }
+
+    /// <summary>Gets the absolute URL of the hop that was challenged.</summary>
+    public required Uri Url { get; init; }
+
+    /// <summary>Gets the status the challenge arrived with, which is always <c>401</c>.</summary>
+    public required int Status { get; init; }
+
+    /// <summary>Gets who is challenging, which is always <c>Server</c> here.</summary>
+    public string Source { get; init; } = "Server";
+
+    /// <summary>
+    /// Gets the authentication scheme, as the server spelled it — <c>Basic</c>, <c>Digest</c>,
+    /// <c>Negotiate</c> and so on.
+    /// </summary>
+    public required string Scheme { get; init; }
+
+    /// <summary>Gets the realm the challenge named, or the empty string when it named none.</summary>
+    public string Realm { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether this engine can turn a username and a password into an answer for <see cref="Scheme"/>.
+    /// </summary>
+    /// <remarks>
+    /// <b>True only for <c>Basic</c>.</b> It is the one scheme whose answer is a function of the credentials
+    /// alone — one <c>Authorization</c> header, no state carried between legs — whereas <c>Digest</c> needs
+    /// a nonce exchange and <c>Negotiate</c> and <c>NTLM</c> need a handshake bound to the connection, and
+    /// none of those is something a transport that hands the socket back after every response can hold.
+    /// <b>An observer that answers <see cref="FetchAuthDecision.ProvideCredentials"/> when this is
+    /// <see langword="false"/> has its answer refused and the <c>401</c> delivered</b>, which is deliberate:
+    /// an ask that cannot be honoured must fail visibly, because an ask that silently does nothing is the
+    /// defect this seam exists to remove. A host driving this through a protocol sees that refusal as an
+    /// error on the command it answered with.
+    /// </remarks>
+    public required bool CanProvideCredentials { get; init; }
+}
+
+/// <summary>
+/// What an observer answers an authentication challenge with.
+/// </summary>
+/// <remarks>
+/// Build one with <see cref="ProvideCredentials"/> or <see cref="Cancel"/>; answering <see langword="null"/>
+/// instead is the protocol's <c>Default</c> — the challenge is left alone and the <c>401</c> is delivered to
+/// whoever asked for the resource.
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public sealed class FetchAuthDecision
+{
+    private FetchAuthDecision()
+    {
+    }
+
+    internal bool HasCredentials { get; private init; }
+
+    internal string Username { get; private init; } = string.Empty;
+
+    internal string Password { get; private init; } = string.Empty;
+
+    /// <summary>
+    /// Answers the challenge and re-sends the request once with the credentials on it.
+    /// </summary>
+    /// <param name="username">The user name.</param>
+    /// <param name="password">The password.</param>
+    /// <remarks>
+    /// <b>Exactly one retry.</b> If the re-sent request is challenged again, that second response is
+    /// delivered rather than asked about: an observer has one credential to offer, so a second ask has
+    /// nothing new to answer with and a loop is worse than a <c>401</c>.
+    /// </remarks>
+    public static FetchAuthDecision ProvideCredentials(string username, string password)
+        => new()
+        {
+            HasCredentials = true,
+            Username = username ?? string.Empty,
+            Password = password ?? string.Empty,
+        };
+
+    /// <summary>
+    /// Declines the challenge, which delivers the <c>401</c> unchanged.
+    /// </summary>
+    /// <remarks>
+    /// The same outcome as answering <see langword="null"/>, and it exists so that a host mapping a protocol
+    /// onto this seam has something to map <c>CancelAuth</c> to — the difference between "I decline" and "I
+    /// am not interested" is worth keeping at the surface even where the bytes agree.
+    /// </remarks>
+    public static FetchAuthDecision Cancel() => new();
+}
+
+/// <summary>
 /// What an observer answers a request with when it does not want the request sent as written.
 /// </summary>
 /// <remarks>
@@ -509,6 +624,43 @@ public abstract class FetchObserver
         ObservedFetchResponse response,
         CancellationToken cancellationToken)
         => new((FetchResponseInterception?) null);
+
+    /// <summary>
+    /// Called when a server answers a hop with <c>401</c> and an authentication challenge; answer
+    /// <see langword="null"/> to leave the challenge alone and let the <c>401</c> be delivered.
+    /// </summary>
+    /// <param name="challenge">What the server asked for.</param>
+    /// <param name="cancellationToken">Cancelled when the fetch is aborted or times out.</param>
+    /// <remarks>
+    /// <para>
+    /// <b>Asked per hop, beside <see cref="OnRequestAsync"/> rather than <see cref="OnResponseAsync"/>.</b>
+    /// A <c>401</c> on a document fetch, on a subresource and on an <c>XMLHttpRequest</c> is exactly the case
+    /// this is for, and only <c>fetch()</c> takes the lane <see cref="OnResponseAsync"/> is asked in — an ask
+    /// placed there would have served the one caller that needed it least.
+    /// </para>
+    /// <para>
+    /// <b>Answering with credentials re-sends that hop once</b>, carrying an <c>Authorization</c> header this
+    /// engine builds. The retry is not a redirect and spends none of <c>MaxRedirects</c>; a challenge on the
+    /// retry is delivered rather than asked about again. The header rides with the request from there on and
+    /// is dropped if a later redirect crosses to another origin, which is
+    /// <see href="https://fetch.spec.whatwg.org/#http-redirect-fetch">HTTP-redirect fetch</see> step 13 and
+    /// costs nothing here because the transport already strips it.
+    /// </para>
+    /// <para>
+    /// <b>Only <c>Basic</c> can be answered</b>, and
+    /// <see cref="ObservedFetchAuthChallenge.CanProvideCredentials"/> says so before the decision is made.
+    /// Every other scheme is still reported — being asked is how an observer tells "unsupported" from "never
+    /// challenged" — and credentials offered for one are refused rather than quietly dropped.
+    /// </para>
+    /// <para>
+    /// Like <see cref="OnRequestAsync"/> and <see cref="OnResponseAsync"/>, a throw here fails the fetch:
+    /// this is a call that was asked to decide.
+    /// </para>
+    /// </remarks>
+    public virtual ValueTask<FetchAuthDecision?> OnAuthRequiredAsync(
+        ObservedFetchAuthChallenge challenge,
+        CancellationToken cancellationToken)
+        => new((FetchAuthDecision?) null);
 
     /// <summary>
     /// Called for each chunk of the final response's body as it is read off the wire.

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -583,6 +583,10 @@ internal static class FetchTransport
         var referrer = request.Referrer;
         ObservedFetchResponse? redirectResponse = null;
 
+        // One retry per request, not per hop: an observer has one credential to offer, so a second ask has
+        // nothing new to answer with and a loop is worse than delivering the 401.
+        var authRetried = false;
+
         while (true)
         {
             // The first hop's filter has already been run on the engine thread, where the fetch was started;
@@ -687,6 +691,25 @@ internal static class FetchTransport
                 // all, rather than a browser's opaque-redirect filtered response — which exists to hide a
                 // cross-origin redirect from a page, a concern an embedded engine with no origin does not have.
                 var status = (int) response.StatusCode;
+
+                // The challenge is offered before the response is handed anywhere, because answering it
+                // re-sends this hop rather than producing one. It is asked here, in the core, beside the
+                // per-hop request ask and not beside the final-response one: a 401 on a document fetch, on a
+                // subresource and on an XMLHttpRequest all pass through here, and only fetch() takes the lane
+                // AnswerResponseAsync is asked in.
+                if (status == UnauthorizedStatus
+                    && !authRetried
+                    && observation is not null
+                    && ReadChallenge(response) is { } challenge
+                    && await AuthorizeAsync(observation, challenge, uri, headers, cancellationToken).ConfigureAwait(false))
+                {
+                    // Not a redirect and not counted as one: the same URL is asked again, once, with the
+                    // Authorization header now in `headers` so every later hop carries it - until one crosses
+                    // to another origin, where _crossOriginHeaderNames strips it as the standard asks.
+                    authRetried = true;
+                    continue;
+                }
+
                 if (!FetchValues.IsRedirectStatus(status)
                     || string.Equals(request.Redirect, JsRequest.RedirectManual, StringComparison.Ordinal))
                 {
@@ -749,6 +772,126 @@ internal static class FetchTransport
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// The one authentication scheme this transport can answer from a username and a password alone.
+    /// </summary>
+    /// <remarks>
+    /// <c>Digest</c> needs a nonce exchange and <c>Negotiate</c> and <c>NTLM</c> a handshake bound to the
+    /// connection; a transport that hands the socket back after every response holds neither. Both are still
+    /// <i>reported</i> — see <see cref="ObservedFetchAuthChallenge.CanProvideCredentials"/>.
+    /// </remarks>
+    private const string BasicScheme = "Basic";
+
+    /// <summary>The status a server challenges with. A <c>407</c> is a proxy's and is not this engine's.</summary>
+    private const int UnauthorizedStatus = 401;
+
+    /// <summary>
+    /// The first <c>WWW-Authenticate</c> challenge on a response, or <see langword="null"/> when it carried
+    /// none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The first, not the strongest.</b> A server may offer several and a browser picks the one it likes
+    /// best; there is only one this engine can answer, so choosing between them would be a choice with one
+    /// outcome. What a client is told is what the server said first, and if that is a scheme this engine
+    /// cannot answer, that is the honest report.
+    /// </para>
+    /// <para>
+    /// The realm comes from the challenge's <c>Parameter</c>, which is the whole
+    /// <c>auth-param</c> list; only <c>realm</c> is read out of it, unquoted, because that is the one
+    /// parameter the protocol's own challenge type carries.
+    /// </para>
+    /// </remarks>
+    private static (string Scheme, string Realm)? ReadChallenge(HttpResponseMessage response)
+    {
+        foreach (var header in response.Headers.WwwAuthenticate)
+        {
+            if (string.IsNullOrEmpty(header.Scheme))
+            {
+                continue;
+            }
+
+            return (header.Scheme, ReadRealm(header.Parameter));
+        }
+
+        return null;
+    }
+
+    /// <summary>Pulls <c>realm="…"</c> out of a challenge's parameter list.</summary>
+    private static string ReadRealm(string? parameter)
+    {
+        if (string.IsNullOrEmpty(parameter))
+        {
+            return string.Empty;
+        }
+
+        foreach (var part in parameter!.Split(','))
+        {
+            var trimmed = part.Trim();
+            if (!trimmed.StartsWith("realm=", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var value = trimmed.Substring("realm=".Length).Trim();
+            if (value.Length >= 2 && value[0] == '"' && value[value.Length - 1] == '"')
+            {
+                value = value.Substring(1, value.Length - 2);
+            }
+
+            return value;
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Asks the observer about a challenge and, when it answers with credentials this engine can use, puts
+    /// them on <paramref name="headers"/> for the retry.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when the hop should be sent again; <see langword="false"/> to deliver the
+    /// <c>401</c> as it is — which covers a declined challenge, an uninterested observer, and credentials
+    /// offered for a scheme this engine cannot answer.
+    /// </returns>
+    private static async Task<bool> AuthorizeAsync(
+        FetchObservation observation,
+        (string Scheme, string Realm) challenge,
+        Uri uri,
+        List<HeaderEntry> headers,
+        CancellationToken cancellationToken)
+    {
+        var basic = string.Equals(challenge.Scheme, BasicScheme, StringComparison.OrdinalIgnoreCase);
+
+        var decision = await observation.AuthRequiredAsync(
+            new ObservedFetchAuthChallenge
+            {
+                Id = observation.Id,
+                Url = uri,
+                Status = UnauthorizedStatus,
+                Scheme = challenge.Scheme,
+                Realm = challenge.Realm,
+                CanProvideCredentials = basic,
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (decision is not { HasCredentials: true } || !basic)
+        {
+            return false;
+        }
+
+        // https://www.rfc-editor.org/rfc/rfc7617 - the user-pass is joined by a colon and encoded as UTF-8,
+        // which is what the "charset" parameter asks for and what every server that omits it expects anyway.
+        var credentials = Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes(decision.Username + ":" + decision.Password));
+
+        // The script's own Authorization header, if it wrote one, has already failed against this server -
+        // the challenge is the proof - so the answer replaces it rather than joining it.
+        headers.RemoveAll(static entry => string.Equals(entry.LowerName, "authorization", StringComparison.OrdinalIgnoreCase));
+        headers.Add(new HeaderEntry("authorization", BasicScheme + " " + credentials));
+        return true;
     }
 
     /// <summary>

--- a/Jint/WebApi/ServerSentEvents/EventSourceConstructor.cs
+++ b/Jint/WebApi/ServerSentEvents/EventSourceConstructor.cs
@@ -53,9 +53,11 @@ internal sealed partial class EventSourceConstructor : Constructor
     /// </summary>
     /// <remarks>
     /// The steps a browser needs and this engine has no counterpart for are the ones about the environment
-    /// the object lives in: there is no settings object to parse the URL relative to (so the URL must be
-    /// absolute), no CORS attribute state to select (see <c>withCredentials</c>) and no client to attribute
-    /// the request to.
+    /// the object lives in: no CORS attribute state to select (see <c>withCredentials</c>) and no client to
+    /// attribute the request to. The <i>settings object</i> the URL is parsed relative to does have a
+    /// counterpart — <see cref="Options.FetchOptions.BaseUrl"/>, which is what a host embedding a document
+    /// sets and what <c>Request</c> and <c>WebSocket</c> already resolve against — so a relative URL is
+    /// resolved here the same way, and only an engine with no base URL requires an absolute one.
     /// </remarks>
     public override ObjectInstance Construct(JsCallArguments arguments, JsValue newTarget)
     {
@@ -79,8 +81,10 @@ internal sealed partial class EventSourceConstructor : Constructor
 
         // Step 3: "let urlRecord be the result of encoding-parsing a URL given url, relative to settings", and
         // step 4: "if urlRecord is failure, then throw a SyntaxError DOMException" — a DOMException, not the
-        // TypeError the fetch interfaces raise for the same mistake.
-        var url = UrlParser.Parse(href);
+        // TypeError the fetch interfaces raise for the same mistake. The base URL is the same one Request and
+        // WebSocket parse against, which is what makes new EventSource('/events') mean what it means in a
+        // document rather than being the one of the three that only accepts an absolute URL.
+        var url = UrlParser.Parse(href, state.FetchNetwork.BaseUrl);
         if (url is null)
         {
             ThrowDomException(DomExceptionNames.Syntax, $"Failed to construct 'EventSource': Cannot open an EventSource to '{href}'. The URL is invalid.");

--- a/README.md
+++ b/README.md
@@ -2651,7 +2651,10 @@ document, every script and style sheet the parse loads, every `fetch` and `XMLHt
 modules — with Chrome's own resource types, so `page.on('request')` and `page.on('response')` fire and a
 `goto` answers a response object with the status, the headers and the body. `Fetch.enable` is real
 interception: a request is paused before it goes on the wire, and the client continues it (rewriting the URL,
-the method, the headers or the body), fulfils it from its own bytes, or fails it. A paused request holds only
+the method, the headers or the body), fulfils it from its own bytes, or fails it. With
+`handleAuthRequests` it also pauses a `401` as `Fetch.authRequired`, and `continueWithAuth` answers one —
+`Basic` is honoured, every other scheme is reported and credentials offered for it are refused by name rather
+than accepted and dropped. A paused request holds only
 its own connection — the page's timers go on firing, and the command that releases it is answered while it
 waits. Around them, `Network.setExtraHTTPHeaders` and `setUserAgentOverride` reach every request the page
 makes, `setBlockedURLs` refuses a URL before a socket is opened,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿[![Build](https://github.com/sebastienros/jint/actions/workflows/build.yml/badge.svg)](https://github.com/sebastienros/jint/actions/workflows/build.yml)
+[![Build](https://github.com/sebastienros/jint/actions/workflows/build.yml/badge.svg)](https://github.com/sebastienros/jint/actions/workflows/build.yml)
 [![NuGet](https://img.shields.io/nuget/v/Jint.svg)](https://www.nuget.org/packages/Jint)
 [![NuGet](https://img.shields.io/nuget/vpre/Jint.svg)](https://www.nuget.org/packages/Jint)
 [![MyGet](https://img.shields.io/myget/jint/vpre/jint.svg?label=MyGet)](https://www.myget.org/feed/jint/package/nuget/Jint)
@@ -1600,8 +1600,10 @@ through `fetch`'s own request pipeline, so `Options.WebApi.Fetch.CookieJar` is n
 
 **It reads `Options.WebApi.Fetch`** — the same transport (`HttpClient` / `HttpClientFactory`) and the same
 policy (`AllowedSchemes`, `UrlFilter`, `MaxRedirects`) that `fetch` uses, so a filter you have already written
-covers both, and every redirect hop is re-checked exactly as it is for a fetch. Three of those settings mean
-something different for a stream:
+covers both, and every redirect hop is re-checked exactly as it is for a fetch. `BaseUrl` is read too, which
+is the standard's *"relative to settings"*: it is the same setting `fetch`, `new Request()` and
+`new WebSocket()` resolve against, so `new EventSource('/updates')` means what it means in a document. Three
+of those settings mean something different for a stream:
 
 - **`Timeout` does not apply.** A connection that is idle for an hour is what an event stream is *for*.
 - **`MaxResponseBytes` does not bound the stream** — nothing could — it bounds **one event**: the data buffer

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -53,7 +53,7 @@ fraction of Chromium's CPU and memory per page, at some multiple of its wall-clo
 
 | v1 delivers | Out of v1 (absent, so feature detection is honest) |
 | --- | --- |
-| Full HTML5 parse with inline, external, `defer`, `async` and module scripts, import maps, `document.write`; generated DOM and CSSOM bindings; tree event dispatch; forms, history, cookies, storage, workers, `fetch`/`XMLHttpRequest`/`WebSocket`/`EventSource`; `MutationObserver`; stub `IntersectionObserver`/`ResizeObserver`; deterministic coordinate input; accessibility tree and markdown snapshots; CDP for Puppeteer/Playwright `connect`; a WPT lane; constraints per page | Layout-dependent APIs (`offsetWidth` is synthetic, `cssom-view`), rendering, screenshots, PDF, WebGL, canvas 2D, media, IndexedDB, WebAssembly, CSP enforcement, TLS-fingerprint stealth, iframe scripting (v1.1), `WindowProxy`, SharedWorker/ServiceWorker, drag and drop, real isolated worlds (v1.1) |
+| Full HTML5 parse with inline, external, `defer`, `async` and module scripts, import maps, `document.write`; generated DOM and CSSOM bindings; tree event dispatch; forms, history, cookies, storage, workers, `fetch`/`XMLHttpRequest`/`WebSocket`/`EventSource`; `MutationObserver`; stub `IntersectionObserver`/`ResizeObserver`; deterministic coordinate input; accessibility tree and markdown snapshots; CDP for Puppeteer/Playwright `connect`; a WPT lane; constraints per page | Layout-dependent APIs (`offsetWidth` is synthetic, `cssom-view`), rendering, screenshots, PDF, WebGL, canvas 2D, media, IndexedDB, `caches` (the engine has it; a page has no origin-partitioned provider to grant it on), WebAssembly, CSP enforcement, TLS-fingerprint stealth, iframe scripting (v1.1), `WindowProxy`, SharedWorker/ServiceWorker, drag and drop, real isolated worlds (v1.1) |
 
 `Page.captureScreenshot` answers a CDP error with a sentence, the way Lightpanda does.
 
@@ -300,18 +300,22 @@ What is accepted and not yet effective is accepted because refusing it fails an 
 each says which campaign item makes it real: `Network.setCacheDisabled` (there is no cache to bypass) and
 `Audits.enable` (nothing to report).
 
-**The network domains are real, and three lanes of them are absent with a reason rather than pending.**
-`Network` reports every request the page makes and `Fetch` pauses one at the **request** stage, both over
-the page's own request log, which is the engine's `FetchObserver`; the document's request carries the
-`loaderId` as its `requestId`, which is what makes a client's `goto` answer a response object. What is not
-there: the `Fetch` **response** stage and with it the `IO` domain, because `FetchObserver.OnResponse` is a
-notification an observer cannot answer, so a response-stage pause could only ever continue unchanged and a
-client that fulfilled from one would be ignored; the **WebSocket and EventSource** events, because the
-engine deliberately does not observe those two handshakes and a socket reported as a request that never
-finishes would also stop `networkIdle` firing; and `Network`'s **timing** document, because no phase of a
-request is measured and a document of zeros reads as a page that loaded instantly. A paused request holds
-the transport thread it is being sent on and never the page loop — the one exception is a `<script src>` a
-running script inserted, which blocks the loop by design.
+**The network domains are real, and what is still absent is absent with a reason rather than pending.**
+`Network` reports every request the page makes, and `Fetch` pauses one at the **request** stage or the
+**response** stage, all over the page's own request log, which is the engine's `FetchObserver`; the
+document's request carries the `loaderId` as its `requestId`, which is what makes a client's `goto` answer a
+response object. A page's `WebSocket` takes the four events the protocol gives a socket — its creation, both
+handshakes and its close — over the engine's own `WebSocketObserver`, and is deliberately *not* in the
+request log, because a socket stays open for as long as the page wants it and an entry would stop
+`networkIdle` firing. What is not there: `Fetch.getResponseBody` and `takeResponseBodyAsStream` and with
+them the `IO` domain, because a response-stage pause has the response's *headers* while its body is still on
+the socket, so handing a client bytes means buffering them first — a budget decision, and
+`Network.getResponseBody` is what answers a body here; the three `webSocketFrame*` events and
+`eventSourceMessageReceived`, because the socket observer is never told about a frame and a stream is
+observed as bytes rather than as the events they decode into; and `Network`'s **timing** document, because
+no phase of a request is measured and a document of zeros reads as a page that loaded instantly. A paused
+request holds the transport thread it is being sent on and never the page loop — the one exception is a
+`<script src>` a running script inserted, which blocks the loop by design.
 
 **`Emulation` is effective, and the question each command answers is *when*.** The viewport, the emulated
 media type and its Level 5 preference features, touch, focus, geolocation, the user agent and the hardware

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -1,4 +1,4 @@
-﻿# Migrating from Jint 4.16 to Jint 5
+# Migrating from Jint 4.16 to Jint 5
 
 Jint 5 is under development on `main`. This document is the running record of every change a
 4.16.x embedder has to react to; it is written for someone upgrading, so it says what broke and
@@ -5439,6 +5439,22 @@ only an observed socket pays.
 transport, so there is no hop to intercept and nothing to substitute; and it carries a `WebSocketId` rather
 than a `FetchRequestId`, because a socket counted as an outstanding request would leave a host waiting for a
 network that never goes quiet.
+
+### 4.130 `EventSource` resolves a relative URL against `BaseUrl` ([#3701](https://github.com/sebastienros/jint/issues/3701))
+
+`new EventSource('/events')` used to throw a `SyntaxError` on every engine, because the constructor parsed
+its URL with no base while `Request` and `WebSocket` both parsed theirs against
+`Options.WebApi.Fetch.BaseUrl`. It now reads that base too, which is the standard's *"relative to settings"*
+and what makes one relative URL mean the same thing to all three interfaces.
+
+```csharp
+options.WebApi.Fetch.BaseUrl = new Uri("https://example.org/pages/one.html");
+// new EventSource('../stream')  ->  https://example.org/stream
+```
+
+**An engine that sets no `BaseUrl` is unchanged**: with nothing to resolve against, a relative URL is still
+a `SyntaxError` rather than a request to a host nobody named. The only scripts affected are ones that were
+throwing.
 
 ## 5. New in v5
 

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5456,6 +5456,41 @@ options.WebApi.Fetch.BaseUrl = new Uri("https://example.org/pages/one.html");
 a `SyntaxError` rather than a request to a host nobody named. The only scripts affected are ones that were
 throwing.
 
+### 4.131 A `FetchObserver` can answer an authentication challenge ([#3828](https://github.com/sebastienros/jint/issues/3828))
+
+A `401` carrying a `WWW-Authenticate` used to be delivered and nothing else. `FetchObserver` grows a third
+ask beside `OnRequestAsync` and `OnResponseAsync`:
+
+```csharp
+public override ValueTask<FetchAuthDecision?> OnAuthRequiredAsync(
+    ObservedFetchAuthChallenge challenge,
+    CancellationToken cancellationToken)
+    => new(challenge.CanProvideCredentials
+        ? FetchAuthDecision.ProvideCredentials("ada", "l0velace")   // sends the hop again
+        : null);                                                    // delivers the 401
+```
+
+Nothing has to be done to migrate: the default answers `null`, and an engine whose observer does not override
+it behaves exactly as before.
+
+**Only `Basic` can be answered**, and `CanProvideCredentials` says so before the decision is made. `Digest`
+needs a nonce exchange and `Negotiate` and `NTLM` a handshake bound to the connection; a transport that hands
+the socket back after every response holds neither. Every scheme is still *reported*, because being asked is
+how an observer tells "unsupported" from "never challenged" — and credentials offered for one that cannot be
+answered are refused rather than quietly dropped.
+
+**One retry per request.** An observer has one credential to offer, so a challenge on the retry is delivered
+rather than asked about again. The retry is not a redirect and spends none of `MaxRedirects`, and the
+`Authorization` header it carries is dropped if a later redirect crosses to another origin, which is the Fetch
+Standard's own rule.
+
+**A `407` is not reported.** The proxy belongs to the `HttpClient` the host supplied, so a challenge's
+`Source` is always `Server`.
+
+Over the protocol this is `Fetch.enable`'s `handleAuthRequests`, the `Fetch.authRequired` event and
+`Fetch.continueWithAuth` — which both Puppeteer and Playwright send unconditionally whenever they intercept,
+and which used to be accepted and do nothing.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so

--- a/tools/devtools-protocol/manifest.json
+++ b/tools/devtools-protocol/manifest.json
@@ -158,9 +158,15 @@
   // a different reason than they used to be: the pause has the response's *headers* while its body is still
   // on the socket, so there are no bytes to hand a client without buffering them first, which is a budget
   // decision rather than a hook. Network.getResponseBody is what answers a body here.
-  // Fetch.continueWithAuth is absent for a smaller
-  // reason: nothing in this browser answers a 401 with credentials, so there is no challenge to be asked
-  // about and Fetch.authRequired is never sent.
+  //
+  // Fetch.authRequired and continueWithAuth are here now, over FetchObserver.OnAuthRequiredAsync: a 401
+  // carrying a WWW-Authenticate pauses when the client asked for handleAuthRequests, and continueWithAuth
+  // answers it. Only Basic can be answered - it is the one scheme whose answer is a function of the
+  // credentials alone, while Digest needs a nonce exchange and Negotiate and NTLM a handshake bound to the
+  // connection. Every other scheme is still reported, because being asked is how a client tells
+  // "unsupported" from "never challenged", and ProvideCredentials for one is refused with an error naming
+  // the scheme rather than accepted and dropped. A 407 is a proxy's and is not reported: the proxy belongs
+  // to the HttpClient the context was given, so the challenge's source is always Server.
   //
   // Network's four WebSocket events are here, over the engine's own WebSocketObserver: a socket's creation,
   // both of its handshakes and its close. webSocketFrameSent, webSocketFrameReceived and webSocketFrameError
@@ -292,6 +298,7 @@
     "Emulation.setVisibleSize",
     "Fetch.continueRequest",
     "Fetch.continueResponse",
+    "Fetch.continueWithAuth",
     "Fetch.disable",
     "Fetch.enable",
     "Fetch.failRequest",
@@ -422,6 +429,7 @@
     "Debugger.paused",
     "Debugger.resumed",
     "Debugger.scriptParsed",
+    "Fetch.authRequired",
     "Fetch.requestPaused",
     "Log.entryAdded",
     "Network.dataReceived",


### PR DESCRIPTION
Closes #3828's first-ranked gap. Stacks on #3833; only the last commit is this PR's.

**The only protocol gap that failed silently.** Both Puppeteer and Playwright send `Fetch.enable { handleAuthRequests: true }` unconditionally whenever they intercept — Playwright writes the flag literally in `crNetworkManager.ts`, Puppeteer likewise in `NetworkManager.ts` — and this browser accepted it and raised nothing. A `401` went to the page as an ordinary response, and the credentials a client had configured through `page.authenticate()` or `httpCredentials` were discarded with no error anywhere. Every other absent command answers `-32601`; this one answered "yes" and did nothing.

## The seam

`FetchObserver` grows a third ask beside `OnRequestAsync` and `OnResponseAsync`:

```csharp
public override ValueTask<FetchAuthDecision?> OnAuthRequiredAsync(
    ObservedFetchAuthChallenge challenge,
    CancellationToken cancellationToken)
    => new(challenge.CanProvideCredentials
        ? FetchAuthDecision.ProvideCredentials("ada", "l0velace")   // sends the hop again
        : null);                                                    // delivers the 401
```

**It is asked in `SendForStreamCoreAsync`, not `SendForStreamAsync`** — beside `OnRequestAsync` rather than `OnResponseAsync`. That is the same reasoning that made #3821 serve every lane instead of `fetch()` alone: a `401` on a document fetch, on a subresource and on an `XMLHttpRequest` is exactly the case this is for, and only `fetch()` takes the lane the final-response ask is asked in, so an ask placed there would have served the one caller that needed it least.

## Only `Basic` can be answered, and every scheme is still reported

`Basic` is the one scheme whose answer is a function of the credentials alone — one `Authorization` header, no state — while `Digest` needs a nonce exchange and `Negotiate` and `NTLM` a handshake bound to the connection, none of which a transport that hands the socket back after every response can hold.

Reporting only the answerable ones was the tempting narrow reading, and it recreates the same defect in a smaller place: a client that got no `authRequired` for a `Digest` challenge would learn nothing about why its credentials did nothing. So:

- the challenge is raised **whatever scheme it names**, which also keeps the protocol shape Chrome's;
- `ObservedFetchAuthChallenge.CanProvideCredentials` answers which kind it is **before** the observer decides;
- `Fetch.continueWithAuth` with `ProvideCredentials` for an unanswerable scheme is **refused with an error naming the scheme** — `Credentials cannot be provided for a 'Digest' challenge.` — and the `401` is then delivered.

**An ask that cannot be honoured must fail visibly, because an ask that silently does nothing is the defect this seam exists to remove.** That sentence is in the observer's own docs, in `Jint/WebApi/Fetch/AGENTS.md`, and in the domain's.

## The two bounds

**One retry per request**, not per hop (`authRetried`): an observer has one credential to offer, so a challenge on the retry is delivered rather than asked about again, and a loop is worse than a `401`. The retry is not a redirect and spends none of `MaxRedirects`.

**A `407` is not reported at all**, and `source` is always `Server`. The proxy belongs to the `HttpClient` the host supplied, and setting `Proxy-Authorization` under a handler that re-frames the request is not this engine's to do.

## Two things that were already right

**The cross-origin rule needed no new code.** `FetchTransport._crossOriginHeaderNames` already strips `authorization` when a redirect leaves the origin — [HTTP-redirect fetch](https://fetch.spec.whatwg.org/#http-redirect-fetch) step 13 — so the header this seam adds is dropped at exactly the right boundary. Stated in the PR and in the docs because the next reader will wonder.

**The precondition was checked rather than assumed.** `CreateSharedClient` sets no `HttpClientHandler.Credentials` and no `PreAuthenticate`, so a `401` really does arrive unhandled rather than being answered underneath us.

## The protocol half

`Fetch.enable`'s `handleAuthRequests`, the `Fetch.authRequired` event and `Fetch.continueWithAuth`, over a third pause map — one identifier space, three things it can name, which is the shape #3827 established for the response stage. `handleAuthRequests` is read as a flag rather than filtered by pattern, because a challenge is a property of a response and there is nothing for a URL pattern or a resource type to match on; that is the protocol's own shape too.

`Fetch.continueWithAuth` joins the four commands in `PageTarget.RunsOffThread`, for the reason they are all there: the challenge arrives on the hop's own response, with the page loop blocked on that fetch if a running script started it, and answering it looks one entry up in a `ConcurrentDictionary` and completes a `TaskCompletionSource` — no engine, no `JsValue`, no node.

## Tests, at both levels

**`WebApiFetchDocumentTests`** drives the engine seam from the embedder's side, against the real transport:

- a `Basic` challenge answered, with the retry's own `Authorization: Basic YWRhOmwwdmVsYWNl` read off the handler and the first attempt asserted to carry none;
- a declined challenge and an uninterested observer both delivering the `401`, with exactly one request sent;
- a `Digest` challenge reported as `answerable=False` and its credentials refused — one request, no invented header;
- a server that challenges twice getting exactly one retry and exactly one ask.

**`FetchDomainTests`** drives the protocol over a real page and a real origin:

- the challenge pausing with its `source`, `scheme`, `realm` and `origin`, `continueWithAuth` letting the navigation through, and the server's copy of both attempts asserted;
- `CancelAuth` delivering the `401` with nothing sent again;
- `ProvideCredentials` for `Digest` refused by name with `-32000`, and the request still released rather than left hanging on the error;
- no event at all for a client that did not send `handleAuthRequests`.

## Verification

Full solution builds clean. `Jint.Tests` 12323/12323 (net8.0, net10.0) and 8503/8503 (net472); `Jint.Tests.Browser` 1790/1790; `Jint.Tests.PublicInterface` 3627/3627 + 2889/2889 (net472), with the two `PublicApiTest` baselines updated for the three new preview members and `UndocumentedPublicApi` unchanged; `Jint.Tests.DevTools` 409/409, including the manifest and generated-protocol currency checks after regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpYdQ1XtE2cu585S25xkz
