### PR TITLE
Fix DOMStringMap dataset name conversion

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -23,7 +23,8 @@ here. Three consequences bind every change:
 - **Every AngleSharp behaviour that disagrees with the DOM standard is reported upstream and recorded below,
   never worked around silently.** A workaround in the binding hides a defect from the project that can fix it,
   and makes the next reader believe the standard says what AngleSharp does. The one thing a wrapper may do is
-  keep *its own* contracts coherent — the `dataset` name filter below is the worked example, and it says so.
+  implement Web IDL semantics AngleSharp's CLR surface does not represent — `DOMStringMap`'s property-name
+  conversion and named setter/deleter are the worked example, and the divergence register says so.
 - **No document or README sentence positions this as a rival DOM stack.** It is "AngleSharp + Jint".
 - **A seam that proves useful is offered, not hoarded.** The tree-aware event dispatcher the engine grew for
   this package (`Jint/WebApi/Events/EventDispatch.cs`) knows nothing about a node; it asks the target. The

--- a/Jint.Browser/Dom/AGENTS.md
+++ b/Jint.Browser/Dom/AGENTS.md
@@ -155,9 +155,10 @@ work around it — are the register in [`divergences.md`](divergences.md), which
 and so is not budgeted here. **Add a row there for every one you find**, and never work around a divergence
 silently; never open an issue on the AngleSharp repositories without being asked to.
 
-The `dataset` one has a visible consequence inside the binding, and the one place a workaround is legitimate:
-the generated `SupportedNames` filters out a `null` value, because the projection's three hooks must agree at
-the same instant or host-contract verification fails. That is keeping *our* contract, not mending AngleSharp's.
+The `dataset` one has a visible consequence inside the binding: AngleSharp exposes a CLR string map over raw
+attribute suffixes, while HTML and Web IDL expose a named-property object whose keys are converted. The
+`HTMLElement.dataset` getter hook therefore projects `DomStringMapAdapter` over the associated element; it owns
+the camelCase conversion, named setter validation and real attribute deletion that the CLR surface cannot state.
 
 ### DOM §7's XPath, and CSSOM's `CSS` are in the package file
 
@@ -218,4 +219,3 @@ declared — the sanctioned in-place slot replacement, and the only kind a shape
 `WebIdlPropertyAttributeTests` holds every emitted member to its kind's attributes, which are WebIDL's and not
 ECMAScript's: an operation is **enumerable**. The same rule `Jint/WebApi/AGENTS.md` states, checked the same
 way, and it is the mistake a generator makes by default.
-

--- a/Jint.Browser/Dom/Collections/DomStringMapAdapter.cs
+++ b/Jint.Browser/Dom/Collections/DomStringMapAdapter.cs
@@ -1,0 +1,181 @@
+using System.Collections;
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Dom.Collections;
+
+/// <summary>
+/// Adapts an element's <c>data-*</c> attributes to HTML's <c>DOMStringMap</c> naming algorithms.
+/// </summary>
+internal sealed class DomStringMapAdapter : IStringMap
+{
+    private const string Prefix = "data-";
+    private const string Member = "DOMStringMap";
+
+    private readonly DomRealm _realm;
+    private readonly IElement _element;
+
+    internal DomStringMapAdapter(DomRealm realm, IElement element)
+    {
+        _realm = realm;
+        _element = element;
+    }
+
+    public string? this[string name]
+    {
+        get
+        {
+            if (ContainsDashLowercase(name))
+            {
+                return null;
+            }
+
+            var attributeName = ToAttributeName(name);
+            return DomNames.IsValidAttributeLocalName(attributeName)
+                ? _element.GetAttribute(attributeName)
+                : null;
+        }
+        set
+        {
+            // https://html.spec.whatwg.org/multipage/dom.html#dom-domstringmap-setitem
+            if (ContainsDashLowercase(name))
+            {
+                DomFailures.Refuse(
+                    _realm.Engine,
+                    Member,
+                    Jint.WebApi.DomException.DomExceptionNames.Syntax,
+                    "the property name '" + name + "' contains a hyphen followed by a lowercase ASCII letter.");
+            }
+
+            var attributeName = ToAttributeName(name);
+            if (!DomNames.IsValidAttributeLocalName(attributeName))
+            {
+                DomFailures.Refuse(
+                    _realm.Engine,
+                    Member,
+                    Jint.WebApi.DomException.DomExceptionNames.InvalidCharacter,
+                    "the property name '" + name + "' does not produce a valid attribute name.");
+            }
+
+            _element.SetAttribute(attributeName, value ?? "");
+        }
+    }
+
+    public void Remove(string name)
+    {
+        // https://html.spec.whatwg.org/multipage/dom.html#dom-domstringmap-removeitem
+        _element.RemoveAttribute(ToAttributeName(name));
+    }
+
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+    {
+        // https://html.spec.whatwg.org/multipage/dom.html#concept-domstringmap-pairs
+        foreach (var attribute in _element.Attributes)
+        {
+            if (attribute.NamespaceUri is not null
+                || !attribute.Name.StartsWith(Prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var suffix = attribute.Name.AsSpan(Prefix.Length);
+            if (ContainsAsciiUppercase(suffix))
+            {
+                continue;
+            }
+
+            yield return new KeyValuePair<string, string>(ToPropertyName(suffix), attribute.Value);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private static string ToAttributeName(string name)
+    {
+        var uppercaseCount = 0;
+        foreach (var character in name)
+        {
+            if (IsAsciiUppercase(character))
+            {
+                uppercaseCount++;
+            }
+        }
+
+        return string.Create(Prefix.Length + name.Length + uppercaseCount, name, static (result, source) =>
+        {
+            Prefix.AsSpan().CopyTo(result);
+            var write = Prefix.Length;
+            foreach (var character in source)
+            {
+                if (IsAsciiUppercase(character))
+                {
+                    result[write++] = '-';
+                    result[write++] = (char) (character + ('a' - 'A'));
+                }
+                else
+                {
+                    result[write++] = character;
+                }
+            }
+        });
+    }
+
+    private static string ToPropertyName(ReadOnlySpan<char> name)
+    {
+        var removedHyphens = 0;
+        for (var i = 0; i + 1 < name.Length; i++)
+        {
+            if (name[i] == '-' && IsAsciiLowercase(name[i + 1]))
+            {
+                removedHyphens++;
+                i++;
+            }
+        }
+
+        return string.Create(name.Length - removedHyphens, name.ToString(), static (result, source) =>
+        {
+            var write = 0;
+            for (var read = 0; read < source.Length; read++)
+            {
+                var character = source[read];
+                if (character == '-' && read + 1 < source.Length && IsAsciiLowercase(source[read + 1]))
+                {
+                    result[write++] = (char) (source[++read] - ('a' - 'A'));
+                }
+                else
+                {
+                    result[write++] = character;
+                }
+            }
+        });
+    }
+
+    private static bool ContainsDashLowercase(string name)
+    {
+        for (var i = 0; i + 1 < name.Length; i++)
+        {
+            if (name[i] == '-' && IsAsciiLowercase(name[i + 1]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsAsciiUppercase(ReadOnlySpan<char> value)
+    {
+        foreach (var character in value)
+        {
+            if (IsAsciiUppercase(character))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsAsciiUppercase(char value) => value is >= 'A' and <= 'Z';
+
+    private static bool IsAsciiLowercase(char value) => value is >= 'a' and <= 'z';
+}

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
 using Jint.Browser.Runtime;
 using Jint.Native;
 using Jint.Native.Object;
@@ -115,6 +116,10 @@ internal class DomHostHooks
         element.RemoveAttribute(name);
         Events.EventHandlerContentAttributes.AttributeChanged(realm, element, name);
     }
+
+    /// <summary>HTML's <c>DOMStringMap</c> view over an element's <c>data-*</c> attributes.</summary>
+    internal virtual JsValue Dataset(DomRealm realm, IHtmlElement element)
+        => realm.WrapStringMap(element, element.Dataset);
 
     /// <summary>https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-insertadjacenthtml</summary>
     /// <remarks>

--- a/Jint.Browser/Dom/DomRealm.cs
+++ b/Jint.Browser/Dom/DomRealm.cs
@@ -263,6 +263,18 @@ internal sealed class DomRealm
         return Cache(nodes, new DomCollectionObject(this, DomInterfaces.NodeList, target, DomAccessorNodeList.Instance));
     }
 
+    /// <summary>Projects an element's <c>dataset</c> through HTML's name conversion algorithms.</summary>
+    internal JsValue WrapStringMap(IElement element, IStringMap map)
+    {
+        if (_wrappers.TryGetValue(map, out var cached))
+        {
+            return cached;
+        }
+
+        var target = new DomStringMapAdapter(this, element);
+        return Cache(map, new DomNamedMapObject(this, DomInterfaces.DOMStringMap, target, DomAccessorDOMStringMap.Instance));
+    }
+
     private ObjectInstance Create(DomInterfaceDefinition definition, object value)
     {
         if (definition.WrapperKind == DomWrapperKind.Node)

--- a/Jint.Browser/Dom/Generated/DomCollectionAccessors.g.cs
+++ b/Jint.Browser/Dom/Generated/DomCollectionAccessors.g.cs
@@ -170,10 +170,8 @@ internal sealed class DomAccessorDOMStringMap : DomCollectionAccessor
         foreach (var entry in (global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<global::System.String, global::System.String>>) target)
         {
             // A null value is filtered out because the projection's three hooks have to agree at the
-            // same instant, and TryGetNamed reads null as an authoritative miss. AngleSharp's
-            // StringMap.Remove leaves the attribute in place with a null value rather than removing it
-            // (reported upstream), so without this a deleted dataset key would still enumerate while
-            // reading as undefined — the exact incoherence host-contract verification catches.
+            // same instant, and TryGetNamed reads null as an authoritative miss. Otherwise a key could
+            // enumerate while reading as undefined — the exact incoherence host verification catches.
             if (entry.Value is not null)
             {
                 names.Add(entry.Key);

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -90,7 +90,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.dataset", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlElement>(thisObj, "HTMLElement.dataset");
-                    return self.Realm.Wrap(self.Target.Dataset);
+                    return self.Realm.Hooks.Dataset(self.Realm, self.Target);
                 }))
             .Accessor("dir",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLElement.dir", static (thisObj, args) =>

--- a/Jint.Browser/Dom/divergences.md
+++ b/Jint.Browser/Dom/divergences.md
@@ -12,7 +12,7 @@ here:
 | What | The standard | AngleSharp |
 | --- | --- | --- |
 | `node.isConnected` | DOM §4.4: whether the node's shadow-including root is a document | `INode` has no member for it at all, so nothing is projected — and every client library asks a node handle this before it clicks it, so an absent member makes every element read as detached. Re-declared in `additions` |
-| `delete el.dataset.foo` | DOM §3.5's deleter removes the content attribute | `IStringMap.Remove` sets its value to `null` and leaves `data-foo` in place |
+| `el.dataset.fooBar` and `delete el.dataset.foo` | HTML §3.2.6 converts between property names and `data-*` attribute names, and the deleter removes the content attribute | `IStringMap` accepts raw attribute suffixes, rejects uppercase ASCII, and the pinned version's `Remove` sets the value to `null` without removing the attribute ([fixed upstream](https://github.com/AngleSharp/AngleSharp/issues/1303)). No longer reached directly: `DomStringMapAdapter` projects the associated element instead |
 | `el.querySelectorAll(…)` | DOM §4.2.6 returns a static `NodeList` | returns an `IHtmlCollection<IElement>`; `DomStaticNodeList` adapts it to the generated NodeList binding and omits HTMLCollection's named properties |
 | `el.style.color` | CSSOM serializes an opaque colour as `rgb(r, g, b)` | serializes every colour as `rgba(r, g, b, 1)` |
 | `el.children === el.children` | one `HTMLCollection` per element | a fresh collection per call, so the wrapper cache has nothing to key identity on |

--- a/Jint.Tests.Browser/DomBindingTests.cs
+++ b/Jint.Tests.Browser/DomBindingTests.cs
@@ -105,22 +105,38 @@ public sealed class DomBindingTests
     }
 
     [Test]
-    public void DatasetProjectsDataAttributes()
+    public void DatasetConvertsCamelCaseDataAttributeNames()
     {
         using var fixture = DomTestFixture.Create(Page);
 
         fixture.Text("document.querySelector('#a').dataset.foo").Should().Be("bar");
 
-        fixture.Evaluate("document.querySelector('#a').dataset.baz = 'qux'");
-        fixture.Text("document.querySelector('#a').getAttribute('data-baz')").Should().Be("qux");
-        fixture.Text("Object.keys(document.querySelector('#a').dataset).sort().join(',')").Should().Be("baz,foo");
+        fixture.Evaluate("document.querySelector('#a').setAttribute('data-password-rule', 'length')");
+        fixture.Text("document.querySelector('#a').dataset.passwordRule").Should().Be("length");
+        fixture.Text("Object.keys(document.querySelector('#a').dataset).sort().join(',')").Should().Be("foo,passwordRule");
 
-        // The JavaScript-visible half of the deleter. The content attribute itself survives, because
-        // AngleSharp's StringMap.Remove sets its value to null instead of removing it — reported upstream and
-        // recorded in Jint.Browser/AGENTS.md rather than worked around here.
-        fixture.Evaluate("delete document.querySelector('#a').dataset.foo");
-        fixture.Evaluate("document.querySelector('#a').dataset.foo").IsUndefined().Should().BeTrue();
-        fixture.Bool("'foo' in document.querySelector('#a').dataset").Should().BeFalse();
+        fixture.Evaluate("document.querySelector('#a').dataset.passwordRule = 'required'");
+        fixture.Text("document.querySelector('#a').getAttribute('data-password-rule')").Should().Be("required");
+
+        fixture.Evaluate("delete document.querySelector('#a').dataset.passwordRule");
+        fixture.Evaluate("document.querySelector('#a').dataset.passwordRule").IsUndefined().Should().BeTrue();
+        fixture.Bool("document.querySelector('#a').hasAttribute('data-password-rule')").Should().BeFalse();
+        fixture.Bool("'passwordRule' in document.querySelector('#a').dataset").Should().BeFalse();
+    }
+
+    [TestCase("foo-bar", "SyntaxError", 12)]
+    [TestCase("bad name", "InvalidCharacterError", 5)]
+    [TestCase("bad/name", "InvalidCharacterError", 5)]
+    public void DatasetRejectsInvalidPropertyNames(string property, string name, int code)
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text($$"""
+            (function () {
+              try { document.querySelector('#a').dataset['{{property}}'] = 'value'; return 'no throw'; }
+              catch (e) { return [e.name, e.code].join('/'); }
+            })()
+            """).Should().Be(name + "/" + code);
     }
 
     [Test]

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
@@ -1191,10 +1191,8 @@ internal sealed class ModelBuilder
             builder.Append("        var names = new global::System.Collections.Generic.List<string>();\n");
             builder.Append("        foreach (var entry in (").Append(CSharpNames.Render(pair)).Append(") target)\n        {\n");
             builder.Append("            // A null value is filtered out because the projection's three hooks have to agree at the\n");
-            builder.Append("            // same instant, and TryGetNamed reads null as an authoritative miss. AngleSharp's\n");
-            builder.Append("            // StringMap.Remove leaves the attribute in place with a null value rather than removing it\n");
-            builder.Append("            // (reported upstream), so without this a deleted dataset key would still enumerate while\n");
-            builder.Append("            // reading as undefined — the exact incoherence host-contract verification catches.\n");
+            builder.Append("            // same instant, and TryGetNamed reads null as an authoritative miss. Otherwise a key could\n");
+            builder.Append("            // enumerate while reading as undefined — the exact incoherence host verification catches.\n");
             builder.Append("            if (entry.Value is not null)\n            {\n                names.Add(entry.Key);\n            }\n        }\n\n        return names;\n    }\n\n");
         }
         else

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -1301,6 +1301,13 @@
   ],
   "hooks": [
     {
+      "interface": "HTMLElement",
+      "member": "dataset",
+      "half": "getter",
+      "hook": "Dataset",
+      "reason": "HTML 3.2.6 maps DOMStringMap property names between camelCase and data-* attribute names and defines its own SyntaxError and InvalidCharacterError checks. AngleSharp's IStringMap instead accepts raw attribute suffixes, rejects uppercase ASCII, and leaves a removed attribute behind with a null value, so the binding supplies the standards-shaped map over the associated element."
+    },
+    {
       "interface": "Document",
       "member": "currentScript",
       "half": "getter",


### PR DESCRIPTION
## Summary

Fix camelCase `dataset` property reads, writes, and deletes.

## Details

`DOMStringMap` property names now follow the HTML Standard's conversion between camelCase JavaScript keys and `data-*` attribute names. The binding also applies the specified `SyntaxError` and `InvalidCharacterError` behavior and removes attributes on delete.

The implementation preserves wrapper identity while adapting AngleSharp's raw `IStringMap` surface at the Web IDL projection boundary. Generated bindings route `HTMLElement.dataset` through that adapter.

## Linked issue

Fixes: #3840

## Test plan

- [ ] Added or updated unit tests in `Jint.Tests`
- [ ] Ran `dotnet test --configuration Release` locally
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`
- [x] Added focused read/write/delete and invalid-name tests in `Jint.Tests.Browser`
- [x] Ran the focused DOM binding and generated-binding staleness tests in Release
- [x] Ran the focused tests with `JINT_HOST_CONTRACT_VERIFICATION=1`
- [x] Reproduced and verified the issue's direct `Jint.Browser` sample

## Breaking change?

No.