### PR TITLE
Propagate native errors during call argument evaluation

### DIFF
--- a/Jint.Tests/Runtime/CallArgumentAbruptCompletionTests.cs
+++ b/Jint.Tests/Runtime/CallArgumentAbruptCompletionTests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+public class CallArgumentAbruptCompletionTests
+{
+    [Test]
+    public void NestedNativeCallPropagatesUriErrorToCatch()
+    {
+        var result = new Engine().Evaluate(
+            """
+            try {
+                JSON.parse(decodeURIComponent("74px 0px -25%"));
+                "unexpected";
+            } catch (error) {
+                error.name;
+            }
+            """);
+
+        result.AsString().Should().Be("URIError");
+    }
+
+    [TestCase("decodeURIComponent(value)", "\"%\"", "URIError")]
+    [TestCase("String.fromCodePoint(value)", "-1", "RangeError")]
+    public void GenericArgumentEvaluationStopsBeforeCallingTheNativeFunction(
+        string expression,
+        string input,
+        string expectedError)
+    {
+        var result = new Engine().Evaluate(
+            $$"""
+            const values = [];
+            let laterArguments = 0;
+            function invoke(value) {
+                try {
+                    values.push({{expression}}, laterArguments++, "last");
+                    return "unexpected";
+                } catch (error) {
+                    return error.name;
+                }
+            }
+            const error = invoke({{input}});
+            error + "|" + laterArguments + "|" + values.length;
+            """);
+
+        result.AsString().Should().Be(expectedError + "|0|0");
+    }
+
+    [Test]
+    public void WarmFastCallDoesNotInvokeTheNativeFunctionAfterAnArgumentThrows()
+    {
+        var result = new Engine().Evaluate(
+            """
+            const values = [];
+            function append(value) {
+                return values.push(decodeURIComponent(value));
+            }
+            append("first");
+            append("second");
+            let caught = "";
+            try {
+                append("%");
+            } catch (error) {
+                caught = error.name;
+            }
+            caught + "|" + values.join(",");
+            """);
+
+        result.AsString().Should().Be("URIError|first,second");
+    }
+
+    [Test]
+    public void WarmRegisterCallDoesNotInvokeTheScriptFunctionAfterAnArgumentThrows()
+    {
+        var result = new Engine().Evaluate(
+            """
+            let calls = 0;
+            function target(value) {
+                calls++;
+            }
+            function invoke(value) {
+                return target(decodeURIComponent(value));
+            }
+            invoke("first");
+            invoke("second");
+            let caught = "";
+            try {
+                invoke("%");
+            } catch (error) {
+                caught = error.name;
+            }
+            caught + "|" + calls;
+            """);
+
+        result.AsString().Should().Be("URIError|2");
+    }
+
+    [Test]
+    public void SpreadArgumentEvaluationStopsBeforeCallingTheNativeFunction()
+    {
+        var result = new Engine().Evaluate(
+            """
+            const values = [];
+            let laterArguments = 0;
+            function invoke(value) {
+                try {
+                    values.push(...[decodeURIComponent(value), laterArguments++]);
+                    return "unexpected";
+                } catch (error) {
+                    return error.name;
+                }
+            }
+            const error = invoke("%");
+            error + "|" + laterArguments + "|" + values.length;
+            """);
+
+        result.AsString().Should().Be("URIError|0|0");
+    }
+}

--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -306,22 +306,24 @@ public class DateTests
     [Test]
     public void FormattingTheFirstInstantOfYear10000DoesNotThrowAClrException()
     {
+        var engine = new Engine(options => options.TimeZone = TimeZoneInfo.Utc);
+
         // How many digits the expanded year gets is a separate defect; what this asserts is that a
         // string comes back at all.
-        _engine.Evaluate("new Date(253402300800000).toISOString()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
-        _engine.Evaluate("new Date(253402300800000).toJSON()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
-        _engine.Evaluate("JSON.stringify({ d: new Date(253402300800000) })").AsString().Should().EndWith("10000-01-01T00:00:00.000Z\"}");
-        _engine.Evaluate("new Date(253402300800000).getUTCFullYear()").AsNumber().Should().Be(10000);
+        engine.Evaluate("new Date(253402300800000).toISOString()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
+        engine.Evaluate("new Date(253402300800000).toJSON()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
+        engine.Evaluate("JSON.stringify({ d: new Date(253402300800000) })").AsString().Should().EndWith("10000-01-01T00:00:00.000Z\"}");
+        engine.Evaluate("new Date(253402300800000).getUTCFullYear()").AsNumber().Should().Be(10000);
 
         // toUTCString reached the same value through DateTimeOffset.FromUnixTimeMilliseconds, whose own
-        // message names 253402300799999 as the largest it accepts. toString renders in local time, so
-        // only the year is worth asserting there.
-        _engine.Evaluate("new Date(253402300800000).toUTCString()").AsString().Should().Be("Sat, 01 Jan 10000 00:00:00 GMT");
-        _engine.Evaluate("new Date(253402300800000).toString()").AsString().Should().Contain("10000");
+        // message names 253402300799999 as the largest it accepts. toString renders in the configured
+        // local time zone, so use UTC above to keep this boundary instant in year 10000 on every host.
+        engine.Evaluate("new Date(253402300800000).toUTCString()").AsString().Should().Be("Sat, 01 Jan 10000 00:00:00 GMT");
+        engine.Evaluate("new Date(253402300800000).toString()").AsString().Should().Contain("10000");
 
         // The escape itself: a CLR exception is invisible to script, so this used to throw out of
         // Evaluate rather than run the catch clause or return a value.
-        _engine.Evaluate("(function () { try { return new Date(253402300800000).toISOString(); } catch (e) { return 'caught'; } })()")
+        engine.Evaluate("(function () { try { return new Date(253402300800000).toISOString(); } catch (e) { return 'caught'; } })()")
             .AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
     }
 

--- a/Jint/Engine.GlobalSnapshot.cs
+++ b/Jint/Engine.GlobalSnapshot.cs
@@ -321,7 +321,6 @@ public partial class Engine
         AbandonHostStreamBridges();
 #endif
 
-        _error = null;
         _lastSyntaxElement = null;
 
         // RegExp legacy statics: every successful match writes them, so RegExp.$1 in the next

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -53,14 +53,14 @@ public sealed partial class Engine : IDisposable
 
     private readonly ExecutionContextStack _executionContexts;
 
-    // Invariant for engine-level ambient mutable fields (e.g. _error, _lastSyntaxElement): they must
+    // Invariant for engine-level ambient mutable fields (e.g. _lastSyntaxElement): they must
     // not hold an in-flight result across a call that can re-enter the engine (anything that may run
     // RunAvailableContinuations, or a CLR callback that calls Evaluate/Execute/Invoke). Either
     // save-and-restore around the re-entrant region, or carry the value out-of-band rather than in a
     // field. A script's completion value used to live here as a field and was clobbered by a
     // re-entrant drain (https://github.com/sebastienros/jint/issues/2492); it is now returned from
-    // ScriptEvaluation as a per-frame local. _error and _lastSyntaxElement are safe because they are
-    // produced and consumed synchronously with no re-entrant drain in between.
+    // ScriptEvaluation as a per-frame local. _lastSyntaxElement is safe because it is produced and
+    // consumed synchronously with no re-entrant drain in between.
 
     /// <summary>
     /// The context threaded through every statement and expression handler. Per <em>engine</em>, not
@@ -1227,8 +1227,6 @@ public sealed partial class Engine : IDisposable
     // set by DebugHandler.Evaluate around watch/breakpoint-condition expression evaluation so the
     // host-boundary constraint checks can exempt it (see CheckAmortizedConstraintsAtHostBoundary)
     internal bool _debuggerEvaluating;
-    internal ErrorDispatchInfo? _error;
-
     // Per-engine cache of interpreter function definitions — hoisted declarations, class methods,
     // class field initializers and static blocks — keyed on the stable AST node. The definition
     // owns the lazily-built body handler tree — and through it every per-node inline cache — so
@@ -5201,9 +5199,11 @@ public sealed partial class Engine : IDisposable
         return result;
     }
 
-    internal void SignalError(ErrorDispatchInfo error)
+    [DoesNotReturn]
+    internal void ThrowError(ErrorDispatchInfo error)
     {
-        _error = error;
+        var location = GetLastSyntaxElement()?.Location ?? default;
+        throw new JavaScriptException(error.ErrorConstructor, error.Message).SetJavaScriptLocation(in location);
     }
 
     internal void RegisterTypeReference(TypeReference reference)

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -404,7 +404,7 @@ public sealed partial class GlobalObject : ObjectInstance
 
 uriError:
         builder.Dispose();
-        _engine.SignalError(UriError);
+        _engine.ThrowError(UriError);
         return JsEmpty.Instance;
     }
 
@@ -594,7 +594,7 @@ uriError:
 
 uriError:
         builder.Dispose();
-        _engine.SignalError(UriError);
+        _engine.ThrowError(UriError);
         return JsEmpty.Instance;
     }
 

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -130,7 +130,7 @@ internal sealed partial class StringConstructor : Constructor
         return JsString.Create(result.ToString());
 
 rangeError:
-        _engine.SignalError(Throw.CreateRangeError(_realm, "Invalid code point " + codePoint));
+        _engine.ThrowError(Throw.CreateRangeError(_realm, "Invalid code point " + codePoint));
         return JsEmpty.Instance;
     }
 

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -202,10 +202,10 @@ internal sealed class EvaluationContext
 
     /// <summary>
     /// Establishes <paramref name="node"/> as the node an error would be reported against. This is
-    /// the whole of the per-node ceremony: abrupt completions travel out of band (as a
-    /// <see cref="JavaScriptException"/> or through <see cref="Engine._error"/>) and a break or
-    /// continue label travels on the <see cref="Completion"/> it belongs to, so there is no
-    /// completion state on the context left to reset.
+    /// the whole of the per-node ceremony: abrupt completions travel out of band as a
+    /// <see cref="JavaScriptException"/>, and a break or continue label travels on the
+    /// <see cref="Completion"/> it belongs to, so there is no completion state on the context left
+    /// to reset.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void PrepareFor(Node node) => LastSyntaxElement = node;

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -162,12 +162,6 @@ internal sealed class JintStatementList
                     {
                         c = pair.Statement.Execute(context);
                     }
-
-                    if (context.Engine._error is not null)
-                    {
-                        c = HandleError(context.Engine, pair.Statement);
-                        break;
-                    }
                 }
                 else
                 {
@@ -325,26 +319,6 @@ internal sealed class JintStatementList
         }
 
         return completion;
-    }
-
-    internal static Completion HandleError(Engine engine, JintStatement? s)
-    {
-        var error = engine._error!;
-        engine._error = null;
-        var completion = CreateThrowCompletion(error.ErrorConstructor, error.Message, engine._lastSyntaxElement ?? s!._statement);
-
-        if (engine._isDebugMode)
-        {
-            engine.Debugger.OnExceptionThrown(completion.Value, completion.Location);
-        }
-
-        return completion;
-    }
-
-    private static Completion CreateThrowCompletion(ErrorConstructor errorConstructor, string? message, Node s)
-    {
-        var error = errorConstructor.Construct(message);
-        return new Completion(CompletionType.Throw, error, s);
     }
 
     private static Completion CreateThrowCompletion(ErrorConstructor errorConstructor, Exception e, Node s)

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -338,8 +338,7 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
     /// <summary>
     /// Tight-loop entry; see <see cref="JintStatement.ExecuteDiscarded"/>. Valid only for blocks
     /// without lexical declarations (enforced by the enclosing loop's shape predicate), so no block
-    /// environment is created or attached. A statement after a deferred error must not run, so the
-    /// engine error slot is polled between statements; the caller polls after the last one.
+    /// environment is created or attached.
     /// </summary>
     internal void ExecuteDiscardedContents(EvaluationContext context)
     {
@@ -360,10 +359,6 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         for (var i = 0; i < count; i++)
         {
             list.GetStatement(i).ExecuteDiscarded(context);
-            if (context.Engine._error is not null)
-            {
-                return;
-            }
         }
     }
 
@@ -373,10 +368,6 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         try
         {
             blockValue = _singleStatement!.Execute(context);
-            if (context.Engine._error is not null)
-            {
-                blockValue = JintStatementList.HandleError(context.Engine, _singleStatement);
-            }
         }
         // The filter is what keeps a single-statement block out of the unwind of an exception it could
         // only rethrow; see JintStatementList.ShouldCatch for why that matters at recursion depth.

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -127,7 +127,7 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
     /// <summary>
     /// The bare per-iteration loop for structurally-Normal bodies — the do-while twin of
     /// <see cref="JintWhileStatement"/>'s tight lane (body first, then test); see there for the
-    /// deferred-error and amortized-constraint reasoning.
+    /// amortized-constraint reasoning.
     /// </summary>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private Completion TightDoWhileBody(EvaluationContext context)
@@ -135,7 +135,6 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
         var test = _test;
         var single = _tightSingleStatement;
         var list = _tightBodyList;
-        var engine = context.Engine;
 
         // See JintForStatement.TightForBody: a non-single body costs the generic lane one extra
         // statement-counter charge per iteration (the block, or the bare EmptyStatement body).
@@ -153,10 +152,6 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
             if (single is not null)
             {
                 single.ExecuteDiscarded(context);
-                if (engine._error is not null)
-                {
-                    return JintStatementList.HandleError(engine, single);
-                }
             }
             else if (list is not null)
             {
@@ -164,10 +159,6 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
                 {
                     var statement = list.GetStatement(i);
                     statement.ExecuteDiscarded(context);
-                    if (engine._error is not null)
-                    {
-                        return JintStatementList.HandleError(engine, statement);
-                    }
                 }
             }
         } while (test.GetBooleanValue(context));

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -769,12 +769,10 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     /// <summary>
     /// The bare test → body-statements → update cycle. Exceptions propagate to the enclosing
     /// statement list exactly as on the generic path (ForBodyEvaluation catches nothing); the
-    /// loop's Normal completion value is dead by the caller's gate, so Undefined stands in.
-    /// Deferred errors surface as Engine._error instead of a .NET throw; the statement list
-    /// converts them per statement, and so must the tight loop. Under flattening the pooled
-    /// loop environment carries the body's slots: their TDZ is re-established per iteration
-    /// before the body statements run, mirroring the generic flattened arm — skipped when the
-    /// block scan proved every slot initializes before any use (leftovers are unobservable).
+    /// loop's Normal completion value is dead by the caller's gate, so Undefined stands in. Under
+    /// flattening the pooled loop environment carries the body's slots: their TDZ is re-established
+    /// per iteration before the body statements run, mirroring the generic flattened arm — skipped
+    /// when the block scan proved every slot initializes before any use (leftovers are unobservable).
     /// Amortized constraints stay live through the context's shared countdown, driven once per
     /// iteration (a tripped constraint throws and propagates like any other exception); exact
     /// constraints and debug mode never reach this lane by the caller's gate.
@@ -814,10 +812,6 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
             if (single is not null)
             {
                 single.ExecuteDiscarded(context);
-                if (engine._error is not null)
-                {
-                    return JintStatementList.HandleError(engine, single);
-                }
             }
             else if (list is not null)
             {
@@ -825,10 +819,6 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 {
                     var statement = list.GetStatement(i);
                     statement.ExecuteDiscarded(context);
-                    if (engine._error is not null)
-                    {
-                        return JintStatementList.HandleError(engine, statement);
-                    }
                 }
             }
 

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -80,7 +80,6 @@ internal sealed class JintIfStatement : JintStatement<IfStatement>
     /// Tight-loop entry. The enclosing loop's shape predicate guarantees neither branch is a
     /// FunctionDeclaration (no AnnexB handling) and the frame cannot suspend (no resume probes);
     /// the branch statements are themselves tight, so no Completion needs materializing.
-    /// A deferred error signalled by the test must suppress the branch — the caller converts it.
     /// </summary>
     internal override void ExecuteDiscarded(EvaluationContext context)
     {
@@ -88,20 +87,10 @@ internal sealed class JintIfStatement : JintStatement<IfStatement>
 
         if (_test.GetBooleanValue(context))
         {
-            if (context.Engine._error is not null)
-            {
-                return;
-            }
-
             _statementConsequent.ExecuteDiscarded(context);
         }
         else
         {
-            if (context.Engine._error is not null)
-            {
-                return;
-            }
-
             _alternate?.ExecuteDiscarded(context);
         }
     }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -45,9 +45,8 @@ internal abstract class JintStatement
     /// prove it dead. Callers guarantee a non-suspendable frame, no exact constraint/debug checks
     /// (amortized constraints stay live via the caller's own countdown-driven cadence), dead
     /// completion values, and a statement shape vetted by <see cref="JintForStatement"/>'s tight-body
-    /// predicate (no break/continue/return/labels, so only Normal completions can occur). Deferred
-    /// errors surface via <see cref="Engine._error"/>, which the caller polls after each statement.
-    /// The base implementation falls back to the full <see cref="Execute"/> ceremony.
+    /// predicate (no break/continue/return/labels, so only Normal completions can occur). The base
+    /// implementation falls back to the full <see cref="Execute"/> ceremony.
     /// <para>
     /// Overrides must call <see cref="EvaluationContext.ChargeStatement"/> first: it stands in for the
     /// statement-counting constraint that <see cref="Execute"/> would have charged here, and its cadence

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -128,12 +128,10 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
     }
 
     /// <summary>
-    /// The bare per-iteration loop for structurally-Normal bodies: test, discarded body
-    /// statements, deferred-error polls — nothing else. The loop's Normal completion value is
-    /// dead by the caller's gate, so Undefined stands in. Deferred errors surface as
-    /// Engine._error and convert per statement, exactly as JintStatementList would. Amortized
-    /// constraints are driven once per iteration through the context's shared countdown; exact
-    /// constraints and debug mode never reach this lane by the caller's gate.
+    /// The bare per-iteration loop for structurally-Normal bodies: test and discarded body
+    /// statements. The loop's Normal completion value is dead by the caller's gate, so Undefined
+    /// stands in. Amortized constraints are driven once per iteration through the context's shared
+    /// countdown; exact constraints and debug mode never reach this lane by the caller's gate.
     /// </summary>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private Completion TightWhileBody(EvaluationContext context)
@@ -141,7 +139,6 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
         var test = _test;
         var single = _tightSingleStatement;
         var list = _tightBodyList;
-        var engine = context.Engine;
 
         // See JintForStatement.TightForBody: a non-single body costs the generic lane one extra
         // statement-counter charge per iteration (the block, or the bare EmptyStatement body).
@@ -159,10 +156,6 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
             if (single is not null)
             {
                 single.ExecuteDiscarded(context);
-                if (engine._error is not null)
-                {
-                    return JintStatementList.HandleError(engine, single);
-                }
             }
             else if (list is not null)
             {
@@ -170,10 +163,6 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
                 {
                     var statement = list.GetStatement(i);
                     statement.ExecuteDiscarded(context);
-                    if (engine._error is not null)
-                    {
-                        return JintStatementList.HandleError(engine, statement);
-                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Propagate deferred native errors immediately during expression evaluation.

## Details

Native URI and range errors previously stored an ambient engine error and returned an empty sentinel. When such an error occurred inside a call argument, the enclosing expression continued evaluating and could invoke the outer function before the statement boundary converted the stored error into an abrupt completion. In the reported case, `JSON.parse` received the sentinel from `decodeURIComponent` and entered a process-fatal coercion recursion.

This change raises the cached error descriptor immediately as a located `JavaScriptException`, removes the obsolete statement-boundary and tight-loop polling, and adds focused coverage for generic, spread, warmed native fast-call, and warmed script register-call argument paths. It also makes the existing year-10000 date test explicitly use UTC so its boundary assertion is independent of the host time zone.

## Linked issue

Fixes: #3843

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

The full core and Test262 suites pass on net8.0 and net10.0. The timezone-independent date test also passes under both `America/Los_Angeles` and `Pacific/Auckland`.

## Breaking change?

No.