### PR TITLE
Implement file input transfers for Playwright

### DIFF
--- a/Jint.Browser/CustomElements/CustomElementCreation.cs
+++ b/Jint.Browser/CustomElements/CustomElementCreation.cs
@@ -65,6 +65,7 @@ internal static class CustomElementCreation
     internal static JsValue CloneNode(DomRealm realm, INode node, JsValue[] arguments)
     {
         var clone = node.Clone(DomConvert.OptionalBool(arguments, 0, true));
+        Dom.Files.FileTransferRealm.ResetCopiedInputs(clone);
         CustomElementRegistry.SubtreeCreated(realm, clone);
         return realm.WrapNodeValue(clone);
     }

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -203,6 +203,16 @@ internal class DomHostHooks
     internal virtual JsValue CloneNode(DomRealm realm, INode node, JsValue[] arguments)
         => CustomElements.CustomElementCreation.CloneNode(realm, node, arguments);
 
+    /// <summary>DOM's import steps do not copy a file input's selected files.</summary>
+    internal virtual JsValue ImportNode(DomRealm realm, IDocument document, JsValue[] arguments)
+    {
+        var imported = document.Import(
+            DomBindings.Argument<INode>(arguments, 0, "Document.importNode"),
+            DomConvert.OptionalBool(arguments, 1, true));
+        Files.FileTransferRealm.ResetCopiedInputs(imported);
+        return realm.WrapNodeValue(imported);
+    }
+
     // ------------------------------------------------------------------------------------------------
     // The members whose value the host has and AngleSharp does not. Every one of them used to be an own
     // property written onto the document wrapper, because a getter could not be hooked; they are accessors

--- a/Jint.Browser/Dom/Files/AngleSharpFileAdapter.cs
+++ b/Jint.Browser/Dom/Files/AngleSharpFileAdapter.cs
@@ -1,0 +1,81 @@
+using AngleSharp.Io.Dom;
+using Jint.WebApi.Files;
+
+namespace Jint.Browser.Dom.Files;
+
+/// <summary>
+/// Mirrors a selected File into AngleSharp's private input model so its value and constraint-validation
+/// algorithms see the same selection as the JavaScript FileList.
+/// </summary>
+internal sealed class AngleSharpFileAdapter : IFile
+{
+    private const long MinimumUnixMilliseconds = -62_135_596_800_000;
+    private const long MaximumUnixMilliseconds = 253_402_300_799_999;
+
+    private readonly JsFile _file;
+    private bool _closed;
+
+    internal AngleSharpFileAdapter(JsFile file)
+    {
+        _file = file;
+    }
+
+    public Stream Body => _closed ? Stream.Null : new MemoryStream(_file.Data.ToArray(), writable: false);
+
+    public bool IsClosed => _closed;
+
+    public int Length => (int) Math.Min(_file.Data.Length, int.MaxValue);
+
+    public string Type => _file.MediaType;
+
+    public DateTime LastModified
+        => DateTimeOffset.FromUnixTimeMilliseconds(
+            Math.Clamp(_file.LastModified, MinimumUnixMilliseconds, MaximumUnixMilliseconds)).UtcDateTime;
+
+    public string Name => _file.Name;
+
+    public void Close() => _closed = true;
+
+    public IBlob Slice(int start = 0, int end = int.MaxValue, string? contentType = null)
+    {
+        var length = _file.Data.Length;
+        var first = start < 0 ? Math.Max(length + start, 0) : Math.Min(start, length);
+        var last = end < 0 ? Math.Max(length + end, 0) : Math.Min(end, length);
+        var count = Math.Max(last - first, 0);
+        return new AngleSharpBlobAdapter(_file.Data.Slice(first, count), contentType ?? string.Empty);
+    }
+
+    public void Dispose() => Close();
+
+    private sealed class AngleSharpBlobAdapter : IBlob
+    {
+        private readonly ReadOnlyMemory<byte> _data;
+        private bool _closed;
+
+        internal AngleSharpBlobAdapter(ReadOnlyMemory<byte> data, string type)
+        {
+            _data = data;
+            Type = type;
+        }
+
+        public Stream Body => _closed ? Stream.Null : new MemoryStream(_data.ToArray(), writable: false);
+
+        public bool IsClosed => _closed;
+
+        public int Length => (int) Math.Min(_data.Length, int.MaxValue);
+
+        public string Type { get; }
+
+        public void Close() => _closed = true;
+
+        public IBlob Slice(int start = 0, int end = int.MaxValue, string? contentType = null)
+        {
+            var first = start < 0 ? Math.Max(_data.Length + start, 0) : Math.Min(start, _data.Length);
+            var last = end < 0 ? Math.Max(_data.Length + end, 0) : Math.Min(end, _data.Length);
+            var count = Math.Max(last - first, 0);
+            return new AngleSharpBlobAdapter(_data.Slice(first, count), contentType ?? string.Empty);
+        }
+
+        public void Dispose() => Close();
+    }
+}

--- a/Jint.Browser/Dom/Files/FileTransferInstaller.cs
+++ b/Jint.Browser/Dom/Files/FileTransferInstaller.cs
@@ -1,0 +1,96 @@
+using Jint.Browser.Dom.Collections;
+using Jint.Browser.Runtime;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Native.Symbol;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Browser.Dom.Files;
+
+/// <summary>The HTML drag data store interfaces used to move files into file inputs.</summary>
+internal static class FileTransferInstaller
+{
+    private static readonly JsObjectShape _fileList = new JsObjectShape.Builder()
+        .ToStringTag("FileList")
+        .PerRealmSlot("constructor", enumerable: false)
+        .PerRealmSlot(GlobalSymbolRegistry.Iterator, DomIterator.ArrayValues)
+        .Method("item", static (t, args) => JsFileList.Brand(t, "item").Item(args), length: 1)
+        .Build();
+
+    private static readonly JsObjectShape _dataTransfer = new JsObjectShape.Builder()
+        .ToStringTag("DataTransfer")
+        .PerRealmSlot("constructor", enumerable: false)
+        .Accessor("dropEffect",
+            static (t, _) => JsString.Create(JsDataTransfer.Brand(t, "dropEffect").DropEffect),
+            static (t, args) => JsDataTransfer.Brand(t, "dropEffect").SetDropEffect(args))
+        .Accessor("effectAllowed",
+            static (t, _) => JsString.Create(JsDataTransfer.Brand(t, "effectAllowed").EffectAllowed),
+            static (t, args) => JsDataTransfer.Brand(t, "effectAllowed").SetEffectAllowed(args))
+        .Accessor("files", static (t, _) => JsDataTransfer.Brand(t, "files").Files)
+        .Accessor("items", static (t, _) => JsDataTransfer.Brand(t, "items").Items)
+        .Accessor("types", static (t, _) => JsDataTransfer.Brand(t, "types").Types())
+        .Method("clearData", static (t, args) => JsDataTransfer.Brand(t, "clearData").ClearData(args))
+        .Method("getData", static (t, args) => JsDataTransfer.Brand(t, "getData").GetData(args), length: 1)
+        .Method("setData", static (t, args) => JsDataTransfer.Brand(t, "setData").SetData(args), length: 2)
+        .Method("setDragImage", static (t, args) => JsDataTransfer.Brand(t, "setDragImage").SetDragImage(args), length: 3)
+        .Build();
+
+    private static readonly JsObjectShape _dataTransferItemList = new JsObjectShape.Builder()
+        .ToStringTag("DataTransferItemList")
+        .PerRealmSlot("constructor", enumerable: false)
+        .Method("add", static (t, args) => JsDataTransferItemList.Brand(t, "add").Add(args), length: 1)
+        .Method("clear", static (t, _) => JsDataTransferItemList.Brand(t, "clear").Clear())
+        .Method("remove", static (t, args) => JsDataTransferItemList.Brand(t, "remove").Remove(args), length: 1)
+        .Build();
+
+    private static readonly JsObjectShape _dataTransferItem = new JsObjectShape.Builder()
+        .ToStringTag("DataTransferItem")
+        .PerRealmSlot("constructor", enumerable: false)
+        .Accessor("kind", static (t, _) => JsString.Create(JsDataTransferItem.Brand(t, "kind").Kind))
+        .Accessor("type", static (t, _) => JsString.Create(JsDataTransferItem.Brand(t, "type").MimeType))
+        .Method("getAsFile", static (t, _) => JsDataTransferItem.Brand(t, "getAsFile").GetAsFile())
+        .Method("getAsString", static (t, args) => JsDataTransferItem.Brand(t, "getAsString").GetAsString(args), length: 1)
+        .Build();
+
+    internal static JsObjectShape FileListShape => _fileList;
+
+    internal static JsObjectShape DataTransferShape => _dataTransfer;
+
+    internal static JsObjectShape DataTransferItemListShape => _dataTransferItemList;
+
+    internal static JsObjectShape DataTransferItemShape => _dataTransferItem;
+
+    /// <summary>Installs the four interface objects before the generated binding can claim <c>FileList</c>.</summary>
+    internal static void Install(PageRuntime runtime)
+    {
+        var engine = runtime.Engine;
+        Add(engine, "FileList", static realm => realm.FileListInterface);
+        Add(engine, "DataTransfer", static realm => realm.DataTransferInterface);
+        Add(engine, "DataTransferItemList", static realm => realm.DataTransferItemListInterface);
+        Add(engine, "DataTransferItem", static realm => realm.DataTransferItemInterface);
+    }
+
+    private static void Add(Engine engine, string name, Func<FileTransferRealm, JsValue> factory)
+        => engine.AddLazyGlobal(
+            name,
+            factory,
+            static (e, f) => f(FileTransferRealm.Of(e)),
+            PropertyFlag.NonEnumerable);
+
+    internal static ObjectInstance Instantiate(
+        Engine engine,
+        JsObjectShape shape,
+        string name,
+        int length,
+        Func<JsValue[], ObjectInstance>? construct,
+        out HostInterfaceObject interfaceObject)
+    {
+        var realm = engine._mainRealm;
+        var prototype = shape.Instantiate(engine, realm.Intrinsics.Object.PrototypeObject);
+        interfaceObject = new HostInterfaceObject(engine, realm, name, prototype, length, construct);
+        prototype.DefineOwnPropertyUnchecked(
+            "constructor",
+            new PropertyDescriptor(interfaceObject, PropertyFlag.NonEnumerable));
+        return prototype;
+    }
+}

--- a/Jint.Browser/Dom/Files/FileTransferRealm.cs
+++ b/Jint.Browser/Dom/Files/FileTransferRealm.cs
@@ -1,0 +1,352 @@
+using System.Runtime.CompilerServices;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.WebApi.DomException;
+
+namespace Jint.Browser.Dom.Files;
+
+/// <summary>Per-engine interface objects and per-input selected-file state.</summary>
+internal sealed class FileTransferRealm
+{
+    private static readonly ConditionalWeakTable<Engine, FileTransferRealm> _realms = new();
+
+    private readonly Engine _engine;
+    private readonly ConditionalWeakTable<IHtmlInputElement, InputFileState> _inputFiles = new();
+    private ObjectInstance? _fileListPrototype;
+    private HostInterfaceObject? _fileListInterface;
+    private ObjectInstance? _dataTransferPrototype;
+    private HostInterfaceObject? _dataTransferInterface;
+    private ObjectInstance? _dataTransferItemListPrototype;
+    private HostInterfaceObject? _dataTransferItemListInterface;
+    private ObjectInstance? _dataTransferItemPrototype;
+    private HostInterfaceObject? _dataTransferItemInterface;
+
+    private FileTransferRealm(Engine engine)
+    {
+        _engine = engine;
+    }
+
+    internal static FileTransferRealm Of(Engine engine)
+        => _realms.GetValue(engine, static e => new FileTransferRealm(e));
+
+    internal HostInterfaceObject FileListInterface
+    {
+        get
+        {
+            if (_fileListInterface is null)
+            {
+                _fileListPrototype = FileTransferInstaller.Instantiate(
+                    _engine,
+                    FileTransferInstaller.FileListShape,
+                    "FileList",
+                    length: 0,
+                    construct: null,
+                    out var interfaceObject);
+                _fileListInterface = interfaceObject;
+            }
+
+            return _fileListInterface;
+        }
+    }
+
+    internal HostInterfaceObject DataTransferInterface
+    {
+        get
+        {
+            if (_dataTransferInterface is null)
+            {
+                _dataTransferPrototype = FileTransferInstaller.Instantiate(
+                    _engine,
+                    FileTransferInstaller.DataTransferShape,
+                    "DataTransfer",
+                    length: 0,
+                    _ => new JsDataTransfer(this, _dataTransferPrototype!),
+                    out var interfaceObject);
+                _dataTransferInterface = interfaceObject;
+            }
+
+            return _dataTransferInterface;
+        }
+    }
+
+    internal HostInterfaceObject DataTransferItemListInterface
+    {
+        get
+        {
+            if (_dataTransferItemListInterface is null)
+            {
+                _dataTransferItemListPrototype = FileTransferInstaller.Instantiate(
+                    _engine,
+                    FileTransferInstaller.DataTransferItemListShape,
+                    "DataTransferItemList",
+                    length: 0,
+                    construct: null,
+                    out var interfaceObject);
+                _dataTransferItemListInterface = interfaceObject;
+            }
+
+            return _dataTransferItemListInterface;
+        }
+    }
+
+    internal HostInterfaceObject DataTransferItemInterface
+    {
+        get
+        {
+            if (_dataTransferItemInterface is null)
+            {
+                _dataTransferItemPrototype = FileTransferInstaller.Instantiate(
+                    _engine,
+                    FileTransferInstaller.DataTransferItemShape,
+                    "DataTransferItem",
+                    length: 0,
+                    construct: null,
+                    out var interfaceObject);
+                _dataTransferItemInterface = interfaceObject;
+            }
+
+            return _dataTransferItemInterface;
+        }
+    }
+
+    internal JsFileList NewFileList()
+    {
+        _ = FileListInterface;
+        return new JsFileList(_engine, _fileListPrototype!);
+    }
+
+    internal JsDataTransferItemList NewItemList(JsDataTransfer owner, JsFileList files)
+    {
+        _ = DataTransferItemListInterface;
+        return new JsDataTransferItemList(this, _dataTransferItemListPrototype!, owner, files);
+    }
+
+    internal JsDataTransferItem NewFileItem(Jint.WebApi.Files.JsFile file)
+    {
+        _ = DataTransferItemInterface;
+        return new JsDataTransferItem(_engine, _dataTransferItemPrototype!, file);
+    }
+
+    internal JsDataTransferItem NewStringItem(string data, string type)
+    {
+        _ = DataTransferItemInterface;
+        return new JsDataTransferItem(_engine, _dataTransferItemPrototype!, data, type);
+    }
+
+    internal JsFileList? InputFiles(IHtmlInputElement input, bool create)
+    {
+        if (!IsFileInput(input))
+        {
+            ClearInput(input, preserveList: false);
+            return null;
+        }
+
+        if (_inputFiles.TryGetValue(input, out var state))
+        {
+            return state.Files;
+        }
+
+        if (!create)
+        {
+            return null;
+        }
+
+        return Attach(input, NewFileList());
+    }
+
+    internal void SetInputFiles(IHtmlInputElement input, JsFileList files)
+    {
+        if (!IsFileInput(input))
+        {
+            return;
+        }
+
+        Detach(input);
+        _ = Attach(input, files, external: true);
+    }
+
+    internal JsValue InputValue(IHtmlInputElement input)
+    {
+        if (IsFileInput(input))
+        {
+            var files = InputFiles(input, create: true)!;
+            return JsString.Create(files.Length == 0 ? string.Empty : @"C:\fakepath\" + files.Files[0].Name);
+        }
+
+        return JsString.Create(input.Value);
+    }
+
+    internal JsValue SetInputValue(IHtmlInputElement input, string value)
+    {
+        if (!IsFileInput(input))
+        {
+            input.Value = value;
+            return JsValue.Undefined;
+        }
+
+        if (value.Length != 0)
+        {
+            return DomFailures.Refuse(
+                _engine,
+                "HTMLInputElement.value",
+                DomExceptionNames.InvalidState,
+                "This input element accepts a filename, which may only be programmatically set to the empty string.");
+        }
+
+        ClearInput(input, preserveList: true);
+        input.Value = string.Empty;
+        return JsValue.Undefined;
+    }
+
+    internal JsValue SetInputType(IHtmlInputElement input, string type)
+    {
+        var wasFile = IsFileInput(input);
+        input.Type = type;
+        if (wasFile != IsFileInput(input))
+        {
+            ClearInput(input, preserveList: false);
+        }
+
+        return JsValue.Undefined;
+    }
+
+    internal void ResetForm(IHtmlFormElement form)
+    {
+        foreach (var element in form.Elements)
+        {
+            if (element is IHtmlInputElement input && IsFileInput(input))
+            {
+                ClearInput(input, preserveList: true);
+            }
+        }
+    }
+
+    internal static void ResetCopiedInputs(INode node)
+    {
+        if (node is IHtmlInputElement input)
+        {
+            ResetCopiedInput(input);
+        }
+
+        foreach (var descendant in node.Descendants<IHtmlInputElement>())
+        {
+            ResetCopiedInput(descendant);
+        }
+
+        static void ResetCopiedInput(IHtmlInputElement input)
+        {
+            if (IsFileInput(input))
+            {
+                input.Files?.Clear();
+                input.Value = string.Empty;
+            }
+        }
+    }
+
+    private JsFileList Attach(IHtmlInputElement input, JsFileList files, bool external = false)
+    {
+        var weakInput = new WeakReference<IHtmlInputElement>(input);
+        void Mirror()
+        {
+            if (weakInput.TryGetTarget(out var target))
+            {
+                MirrorToAngleSharp(target, files);
+            }
+            else
+            {
+                files.Changed -= Mirror;
+            }
+        }
+
+        var state = new InputFileState(files, Mirror, external);
+        _inputFiles.Add(input, state);
+        files.Changed += Mirror;
+        Mirror();
+        return files;
+    }
+
+    internal void AttributeChanged(IElement element, string name)
+    {
+        if (element is IHtmlInputElement input
+            && string.Equals(name, "type", StringComparison.OrdinalIgnoreCase)
+            && _inputFiles.TryGetValue(input, out _)
+            && !IsFileInput(input))
+        {
+            ClearInput(input, preserveList: false);
+        }
+    }
+
+    private void Detach(IHtmlInputElement input)
+    {
+        if (_inputFiles.TryGetValue(input, out var current))
+        {
+            current.Files.Changed -= current.Mirror;
+            _inputFiles.Remove(input);
+        }
+    }
+
+    private void ClearInput(IHtmlInputElement input, bool preserveList)
+    {
+        if (_inputFiles.TryGetValue(input, out var state))
+        {
+            if (state.External)
+            {
+                Detach(input);
+                input.Files?.Clear();
+                input.Value = string.Empty;
+                if (preserveList && IsFileInput(input))
+                {
+                    _ = Attach(input, NewFileList());
+                }
+            }
+            else
+            {
+                state.Files.Clear();
+                if (!preserveList)
+                {
+                    Detach(input);
+                }
+            }
+        }
+        else
+        {
+            input.Files?.Clear();
+        }
+    }
+
+    private static void MirrorToAngleSharp(IHtmlInputElement input, JsFileList files)
+    {
+        var target = input.Files;
+        if (target is null)
+        {
+            input.Value = string.Empty;
+            return;
+        }
+
+        target.Clear();
+        foreach (var file in files.Files)
+        {
+            target.Add(new AngleSharpFileAdapter(file));
+        }
+
+        input.Value = files.Length == 0 ? string.Empty : @"C:\fakepath\" + files.Files[0].Name;
+    }
+
+    private static bool IsFileInput(IHtmlInputElement input)
+        => string.Equals(input.Type, "file", StringComparison.OrdinalIgnoreCase);
+
+    private sealed record InputFileState(
+        JsFileList Files,
+        Action Mirror,
+        bool External);
+}
+
+/// <summary>Tracks file-upload state transitions for connected and disconnected inputs.</summary>
+internal sealed class FileInputAttributeObserver(Runtime.PageRuntime runtime) : IAttributeObserver
+{
+    /// <inheritdoc />
+    public void NotifyChange(IElement host, string name, string? value)
+        => FileTransferRealm.Of(runtime.Engine).AttributeChanged(host, name);
+}

--- a/Jint.Browser/Dom/Files/JsFileTransfer.cs
+++ b/Jint.Browser/Dom/Files/JsFileTransfer.cs
@@ -1,0 +1,553 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Files;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.Browser.Dom.Files;
+
+/// <summary>HTMLInputElement's selected files and DataTransfer's live file projection.</summary>
+internal sealed class JsFileList : ArrayLikeObject
+{
+    private readonly List<JsFile> _files = [];
+
+    internal JsFileList(Engine engine, ObjectInstance prototype) : base(engine)
+    {
+        Prototype = prototype;
+    }
+
+    public override uint Length => (uint) _files.Count;
+
+    public override bool TryGetIndex(uint index, out JsValue value)
+    {
+        if (index >= (uint) _files.Count)
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        value = _files[(int) index];
+        return true;
+    }
+
+    protected override bool HasIndex(uint index) => index < (uint) _files.Count;
+
+    internal IReadOnlyList<JsFile> Files => _files;
+
+    internal event Action? Changed;
+
+    internal void Add(JsFile file)
+    {
+        _files.Add(file);
+        Changed?.Invoke();
+    }
+
+    internal void Clear()
+    {
+        if (_files.Count != 0)
+        {
+            _files.Clear();
+            Changed?.Invoke();
+        }
+    }
+
+    internal JsValue Item(JsValue[] arguments)
+    {
+        var index = DomConvert.RequiredUInt32(arguments, 0, "FileList.item");
+        return TryGetIndex(index, out var value) ? value : JsValue.Null;
+    }
+
+    internal static JsFileList Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsFileList files)
+        {
+            return files;
+        }
+
+        IllegalInvocation(thisObject, "FileList", member);
+        return null!;
+    }
+
+    public override string ToString() => "[object FileList]";
+
+    internal static void IllegalInvocation(JsValue thisObject, string interfaceName, string member)
+    {
+        var message = "Failed to execute '" + member + "' on '" + interfaceName + "': Illegal invocation";
+        if (thisObject is ObjectInstance instance)
+        {
+            Throw.TypeError(instance.Engine.Realm, message);
+        }
+
+        Throw.TypeErrorNoEngine(message);
+    }
+}
+
+/// <summary>A read/write drag data store created by <c>new DataTransfer()</c>.</summary>
+internal sealed class JsDataTransfer : ObjectInstance
+{
+    private static readonly HashSet<string> _dropEffects = new(StringComparer.Ordinal)
+    {
+        "none", "copy", "link", "move",
+    };
+
+    private static readonly HashSet<string> _effectsAllowed = new(StringComparer.Ordinal)
+    {
+        "none", "copy", "copyLink", "copyMove", "link", "linkMove", "move", "all", "uninitialized",
+    };
+
+    private IElement? _dragImage;
+    private int _hotspotX;
+    private int _hotspotY;
+    private JsValue? _types;
+
+    internal JsDataTransfer(FileTransferRealm realm, ObjectInstance prototype) : base(prototype.Engine)
+    {
+        Prototype = prototype;
+        Files = realm.NewFileList();
+        Items = realm.NewItemList(this, Files);
+    }
+
+    internal string DropEffect { get; private set; } = "none";
+
+    internal string EffectAllowed { get; private set; } = "none";
+
+    internal JsFileList Files { get; }
+
+    internal JsDataTransferItemList Items { get; }
+
+    internal JsValue SetDropEffect(JsValue[] arguments)
+    {
+        var value = TypeConverter.ToString(arguments.At(0));
+        if (_dropEffects.Contains(value))
+        {
+            DropEffect = value;
+        }
+
+        return JsValue.Undefined;
+    }
+
+    internal JsValue SetEffectAllowed(JsValue[] arguments)
+    {
+        var value = TypeConverter.ToString(arguments.At(0));
+        if (_effectsAllowed.Contains(value))
+        {
+            EffectAllowed = value;
+        }
+
+        return JsValue.Undefined;
+    }
+
+    internal JsValue Types()
+    {
+        if (_types is not null)
+        {
+            return _types;
+        }
+
+        var types = new List<JsValue>();
+        foreach (var item in Items.Values)
+        {
+            if (item.IsStringItem && !types.Any(value => string.Equals(value.AsString(), item.MimeType, StringComparison.Ordinal)))
+            {
+                types.Add(JsString.Create(item.MimeType));
+            }
+        }
+
+        if (Items.Values.Any(static item => !item.IsStringItem))
+        {
+            types.Add(JsString.Create("Files"));
+        }
+
+        var result = Engine._mainRealm.Intrinsics.Array.ConstructFast(types);
+        result.SetIntegrityLevel(IntegrityLevel.Frozen);
+        return _types = result;
+    }
+
+    internal JsValue GetData(JsValue[] arguments)
+    {
+        var format = DomConvert.RequiredText(arguments, 0, "DataTransfer.getData");
+        var normalized = NormalizeToken(format);
+        var type = ExpandLegacyFormat(normalized);
+        var item = Items.Values.FirstOrDefault(candidate => candidate.IsStringItem && candidate.MimeType == type);
+        var data = item?.StringData ?? string.Empty;
+        return JsString.Create(normalized == "url" ? FirstUri(data) : data);
+    }
+
+    internal JsValue SetData(JsValue[] arguments)
+    {
+        var type = NormalizeFormat(DomConvert.RequiredText(arguments, 0, "DataTransfer.setData"));
+        var data = DomConvert.RequiredText(arguments, 1, "DataTransfer.setData");
+        Items.SetStringData(type, data);
+        return JsValue.Undefined;
+    }
+
+    internal JsValue ClearData(JsValue[] arguments)
+    {
+        var format = DomConvert.OptionalText(arguments, 0, null);
+        Items.ClearStringData(format is null ? null : NormalizeFormat(format));
+        return JsValue.Undefined;
+    }
+
+    internal JsValue SetDragImage(JsValue[] arguments)
+    {
+        _dragImage = DomBindings.Argument<IElement>(arguments, 0, "DataTransfer.setDragImage");
+        _hotspotX = DomConvert.RequiredInt32(arguments, 1, "DataTransfer.setDragImage");
+        _hotspotY = DomConvert.RequiredInt32(arguments, 2, "DataTransfer.setDragImage");
+        return JsValue.Undefined;
+    }
+
+    internal void InvalidateTypes() => _types = null;
+
+    internal static string NormalizeFormat(string format) => ExpandLegacyFormat(NormalizeToken(format));
+
+    private static string NormalizeToken(string format)
+    {
+        var start = 0;
+        while (start < format.Length && IsAsciiWhitespace(format[start]))
+        {
+            start++;
+        }
+
+        var end = format.Length;
+        while (end > start && IsAsciiWhitespace(format[end - 1]))
+        {
+            end--;
+        }
+
+        return UrlCharacters.AsciiLowercase(format[start..end]);
+    }
+
+    private static string ExpandLegacyFormat(string normalized)
+        => normalized switch
+        {
+            "text" => "text/plain",
+            "url" => "text/uri-list",
+            var value => value,
+        };
+
+    private static string FirstUri(string data)
+    {
+        foreach (var line in data.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!line.StartsWith('#'))
+            {
+                return line;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static bool IsAsciiWhitespace(char character) =>
+        character is '\t' or '\n' or '\f' or '\r' or ' ';
+
+    internal static string NormalizeItemType(string type) => UrlCharacters.AsciiLowercase(type);
+
+    internal static JsDataTransfer Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsDataTransfer transfer)
+        {
+            return transfer;
+        }
+
+        JsFileList.IllegalInvocation(thisObject, "DataTransfer", member);
+        return null!;
+    }
+
+    public override string ToString() => "[object DataTransfer]";
+}
+
+/// <summary>The live ordered item list owned by one DataTransfer.</summary>
+internal sealed class JsDataTransferItemList : ArrayLikeObject
+{
+    private readonly FileTransferRealm _realm;
+    private readonly JsDataTransfer _owner;
+    private readonly JsFileList _files;
+    private readonly List<JsDataTransferItem> _items = [];
+
+    internal JsDataTransferItemList(
+        FileTransferRealm realm,
+        ObjectInstance prototype,
+        JsDataTransfer owner,
+        JsFileList files)
+        : base(prototype.Engine)
+    {
+        _realm = realm;
+        _owner = owner;
+        _files = files;
+        Prototype = prototype;
+    }
+
+    public override uint Length => (uint) _items.Count;
+
+    public override bool TryGetIndex(uint index, out JsValue value)
+    {
+        if (index >= (uint) _items.Count)
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        value = _items[(int) index];
+        return true;
+    }
+
+    protected override bool HasIndex(uint index) => index < (uint) _items.Count;
+
+    internal IReadOnlyList<JsDataTransferItem> Values => _items;
+
+    internal JsValue Add(JsValue[] arguments)
+    {
+        JsDataTransferItem item;
+        if (arguments.Length == 1 && arguments[0] is JsFile file)
+        {
+            item = _realm.NewFileItem(file);
+        }
+        else if (arguments.Length >= 2)
+        {
+            var data = TypeConverter.ToString(arguments[0]);
+            var type = JsDataTransfer.NormalizeItemType(TypeConverter.ToString(arguments[1]));
+            if (_items.Any(candidate => candidate.IsStringItem && candidate.MimeType == type))
+            {
+                return DomFailures.Refuse(
+                    Engine,
+                    "DataTransferItemList.add",
+                    DomExceptionNames.NotSupported,
+                    "an item of type '" + type + "' already exists.");
+            }
+
+            item = _realm.NewStringItem(data, type);
+        }
+        else
+        {
+            Throw.TypeError(
+                Engine.Realm,
+                "Failed to execute 'add' on 'DataTransferItemList': the provided arguments match no overload.");
+            return JsValue.Undefined;
+        }
+
+        _items.Add(item);
+        RebuildFiles();
+        _owner.InvalidateTypes();
+        return item;
+    }
+
+    internal JsValue Clear()
+    {
+        if (_items.Count == 0)
+        {
+            return JsValue.Undefined;
+        }
+
+        foreach (var item in _items)
+        {
+            item.Disable();
+        }
+
+        _items.Clear();
+        _files.Clear();
+        _owner.InvalidateTypes();
+        return JsValue.Undefined;
+    }
+
+    internal JsValue Remove(JsValue[] arguments)
+    {
+        var index = DomConvert.RequiredUInt32(arguments, 0, "DataTransferItemList.remove");
+        if (index < (uint) _items.Count)
+        {
+            _items[(int) index].Disable();
+            _items.RemoveAt((int) index);
+            RebuildFiles();
+            _owner.InvalidateTypes();
+        }
+
+        return JsValue.Undefined;
+    }
+
+    internal void SetStringData(string type, string data)
+    {
+        var existing = _items.FirstOrDefault(item => item.IsStringItem && item.MimeType == type);
+        if (existing is not null)
+        {
+            existing.Disable();
+            _items.Remove(existing);
+        }
+
+        _items.Add(_realm.NewStringItem(data, type));
+        _owner.InvalidateTypes();
+    }
+
+    internal void ClearStringData(string? type)
+    {
+        var removed = false;
+        for (var index = _items.Count - 1; index >= 0; index--)
+        {
+            var item = _items[index];
+            if (item.IsStringItem && (type is null || item.MimeType == type))
+            {
+                item.Disable();
+                _items.RemoveAt(index);
+                removed = true;
+            }
+        }
+
+        if (removed)
+        {
+            _owner.InvalidateTypes();
+        }
+    }
+
+    private void RebuildFiles()
+    {
+        _files.Clear();
+        foreach (var item in _items)
+        {
+            if (item.File is { } file)
+            {
+                _files.Add(file);
+            }
+        }
+    }
+
+    internal static JsDataTransferItemList Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsDataTransferItemList items)
+        {
+            return items;
+        }
+
+        JsFileList.IllegalInvocation(thisObject, "DataTransferItemList", member);
+        return null!;
+    }
+
+    public override string ToString() => "[object DataTransferItemList]";
+}
+
+/// <summary>One string or file entry in a drag data store.</summary>
+internal sealed class JsDataTransferItem : ObjectInstance
+{
+    private bool _disabled;
+    private readonly JsFile? _file;
+    private readonly string _mimeType;
+    private string? _stringData;
+
+    internal JsDataTransferItem(Engine engine, ObjectInstance prototype, JsFile file) : base(engine)
+    {
+        Prototype = prototype;
+        _file = file;
+        _mimeType = file.MediaType;
+    }
+
+    internal JsDataTransferItem(Engine engine, ObjectInstance prototype, string data, string type) : base(engine)
+    {
+        Prototype = prototype;
+        _stringData = data;
+        _mimeType = type;
+    }
+
+    internal string Kind => _disabled ? string.Empty : IsStringItem ? "string" : "file";
+
+    internal string MimeType => _disabled ? string.Empty : _mimeType;
+
+    internal bool IsStringItem => _file is null;
+
+    internal JsFile? File => _disabled ? null : _file;
+
+    internal string? StringData => _disabled ? null : _stringData;
+
+    internal JsValue GetAsFile() => File ?? JsValue.Null;
+
+    internal JsValue GetAsString(JsValue[] arguments)
+    {
+        if (arguments.Length == 0)
+        {
+            Throw.TypeError(
+                Engine.Realm,
+                "Failed to execute 'getAsString' on 'DataTransferItem': 1 argument required, but only 0 present.");
+        }
+
+        var callbackValue = arguments.At(0);
+        if (callbackValue.IsNullOrUndefined())
+        {
+            return JsValue.Undefined;
+        }
+
+        if (callbackValue is not ICallable callback)
+        {
+            Throw.TypeError(Engine.Realm, "Failed to execute 'getAsString' on 'DataTransferItem': parameter 1 is not of type 'Function'.");
+            return JsValue.Undefined;
+        }
+
+        if (StringData is null)
+        {
+            return JsValue.Undefined;
+        }
+
+        var data = StringData;
+        Engine.Tasks.Post(() => callback.Call(JsValue.Undefined, JsString.Create(data)));
+        return JsValue.Undefined;
+    }
+
+    internal void Disable()
+    {
+        _disabled = true;
+        _stringData = null;
+    }
+
+    internal static JsDataTransferItem Brand(JsValue thisObject, string member)
+    {
+        if (thisObject is JsDataTransferItem item)
+        {
+            return item;
+        }
+
+        JsFileList.IllegalInvocation(thisObject, "DataTransferItem", member);
+        return null!;
+    }
+
+    public override string ToString() => "[object DataTransferItem]";
+}
+
+/// <summary>The generated HTMLInputElement.files accessor delegates here.</summary>
+internal static class FileTransferMembers
+{
+    internal static JsValue InputFiles(DomRealm realm, IHtmlInputElement input)
+        => FileTransferRealm.Of(realm.Engine).InputFiles(input, create: true) ?? JsValue.Null;
+
+    internal static JsValue SetInputFiles(DomRealm realm, IHtmlInputElement input, JsValue[] arguments)
+    {
+        var value = arguments.At(0);
+        if (value.IsNullOrUndefined())
+        {
+            return JsValue.Undefined;
+        }
+
+        if (value is not JsFileList files)
+        {
+            Throw.TypeError(realm.Engine.Realm, "Failed to set 'files' on 'HTMLInputElement': The provided value is not of type 'FileList'.");
+            return JsValue.Undefined;
+        }
+
+        FileTransferRealm.Of(realm.Engine).SetInputFiles(input, files);
+        return JsValue.Undefined;
+    }
+
+    internal static JsValue InputValue(DomRealm realm, IHtmlInputElement input)
+        => FileTransferRealm.Of(realm.Engine).InputValue(input);
+
+    internal static JsValue SetInputValue(DomRealm realm, IHtmlInputElement input, JsValue[] arguments)
+    {
+        var value = DomConvert.At(arguments, 0);
+        return FileTransferRealm.Of(realm.Engine).SetInputValue(
+            input,
+            value.IsNull() ? "" : TypeConverter.ToString(value));
+    }
+
+    internal static JsValue SetInputType(DomRealm realm, IHtmlInputElement input, JsValue[] arguments)
+        => FileTransferRealm.Of(realm.Engine).SetInputType(
+            input,
+            DomConvert.RequiredText(arguments, 0, "HTMLInputElement.type"));
+}

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -1020,7 +1020,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.importNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.importNode");
-                    return self.Realm.WrapNodeValue(self.Target.Import(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Document.importNode"), global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 1, true)));
+                    return self.Realm.Hooks.ImportNode(self.Realm, self.Target, args);
                 }),
                 length: 1)
             .Accessor("lastElementChild",

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -2173,7 +2173,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.files", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.files");
-                    return self.Realm.Wrap(self.Target.Files);
+                    return global::Jint.Browser.Dom.Files.FileTransferMembers.InputFiles(self.Realm, self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.files", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.files");
+                    return global::Jint.Browser.Dom.Files.FileTransferMembers.SetInputFiles(self.Realm, self.Target, args);
                 }))
             .Accessor("form",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.form", static (thisObj, args) =>
@@ -2485,7 +2490,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.type", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.type");
-                    self.Target.Type = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.type"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.Files.FileTransferMembers.SetInputType(self.Realm, self.Target, args);
                 }))
             .Accessor("validationMessage",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.validationMessage", static (thisObj, args) =>
@@ -2503,12 +2508,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.value");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Value);
+                    return global::Jint.Browser.Dom.Files.FileTransferMembers.InputValue(self.Realm, self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.value", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.value");
-                    self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.value"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.Files.FileTransferMembers.SetInputValue(self.Realm, self.Target, args);
                 }))
             .Accessor("valueAsDate",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.valueAsDate", static (thisObj, args) =>

--- a/Jint.Browser/Events/BrowserEventInterfaces.cs
+++ b/Jint.Browser/Events/BrowserEventInterfaces.cs
@@ -16,9 +16,9 @@ namespace Jint.Browser.Events;
 /// design doc §5, "one bus, Jint's".
 /// </para>
 /// <para>
-/// <b>Deliberately absent: <c>DragEvent</c>.</b> Drag and drop is a v1 non-goal (design doc §2), and an
-/// interface with no <c>DataTransfer</c> behind it would be a constructor for an event nothing can ever mean.
-/// <c>ClipboardEvent</c> is absent for the same reason. The legacy <c>initUIEvent</c>, <c>initMouseEvent</c>
+/// <b>Deliberately absent: <c>DragEvent</c>.</b> Drag and drop dispatch and its event-specific state remain
+/// a v1 non-goal (design doc §2), even though the transferable data store is available for file inputs.
+/// <c>ClipboardEvent</c> is absent because there is no clipboard model. The legacy <c>initUIEvent</c>, <c>initMouseEvent</c>
 /// and <c>initKeyboardEvent</c> initializers are absent too: they are the pre-constructor way of building an
 /// event through <c>document.createEvent</c>, which this package does not implement at all.
 /// </para>

--- a/Jint.Browser/Events/FormSubmission.cs
+++ b/Jint.Browser/Events/FormSubmission.cs
@@ -145,6 +145,7 @@ internal static class FormSubmission
         if (target.DispatchEvent(resetEvent))
         {
             form.Reset();
+            Dom.Files.FileTransferRealm.Of(realm.Engine).ResetForm(form);
         }
     }
 

--- a/Jint.Browser/Events/LegacyEventCreation.cs
+++ b/Jint.Browser/Events/LegacyEventCreation.cs
@@ -31,7 +31,7 @@ namespace Jint.Browser.Events;
 /// <para>
 /// <b>An alias naming an interface this package does not have is a <c>NotSupportedError</c>, which is what the
 /// standard says for an alias it does not list at all.</b> Five of the table's rows name interfaces that do
-/// not exist here — <c>DragEvent</c> and <c>ClipboardEvent</c> need a <c>DataTransfer</c>,
+/// not exist here — <c>DragEvent</c> needs drag dispatch, <c>ClipboardEvent</c> a clipboard,
 /// <c>StorageEvent</c> a storage area's change notification, <c>TouchEvent</c> a touch input, and the two
 /// device-orientation events a sensor — and answering with a plain <c>Event</c> under those names would be a
 /// lie a page cannot detect. A browser without the interface refuses in the same way.

--- a/Jint.Browser/Runtime/BrowserEngineFactory.cs
+++ b/Jint.Browser/Runtime/BrowserEngineFactory.cs
@@ -173,6 +173,7 @@ internal static class BrowserEngineFactory
         runtime.Cancellation = cancellation;
         runtime.Modules = ReferenceEquals(engine.Options.Modules.ModuleLoader, modules) ? modules : null;
 
+        Dom.Files.FileTransferInstaller.Install(runtime);
         DomBindings.Install(engine);
         runtime.Dom.MaxNodes = options.MaxDomNodes;
         runtime.Dom.ScriptingEnabled = runtime.ScriptingEnabled;

--- a/Jint.Browser/Runtime/FormSubmitter.cs
+++ b/Jint.Browser/Runtime/FormSubmitter.cs
@@ -246,6 +246,17 @@ internal static class FormSubmitter
                         return;
                     }
 
+                    var selectedFiles = Dom.Files.FileTransferRealm.Of(runtime.Engine).InputFiles(input, create: false);
+                    if (selectedFiles is { Length: > 0 })
+                    {
+                        foreach (var file in selectedFiles.Files)
+                        {
+                            entries.Add(new FormDataEntry(name!, file));
+                        }
+
+                        return;
+                    }
+
                     // "If there are no selected files, then append an entry with an empty File object" —
                     // which is what makes a server see the field at all.
                     entries.Add(new FormDataEntry(name!, EmptyFile(runtime)));

--- a/Jint.Browser/Runtime/Parsing/ParserDriver.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserDriver.cs
@@ -92,8 +92,9 @@ internal sealed class ParserDriver : IDisposable
         // WithDefaultLoader: every byte a document pulls goes through the page's own network position.
         // The render device is what the cascade resolves a relative length and an `@media` rule against;
         // without one AngleSharp.Css raises rather than answering for `width: 100%` (see PageRenderDevice).
-        // The attribute observer is the last of them, and it is what a custom element's
-        // `attributeChangedCallback` is answered from: it is called for every element of this document,
+        // The attribute observers are the last of them: one answers a custom element's
+        // `attributeChangedCallback`, and one keeps file-input state aligned with type mutations. They run
+        // for every element of this document,
         // attached or not, where a mutation record needs the element to be under the observed document
         // and `el.setAttribute` before insertion is the commonest thing a component does. `.With` adds a
         // service rather than replacing one, so AngleSharp's own observer keeps working.
@@ -101,7 +102,8 @@ internal sealed class ParserDriver : IDisposable
             .WithCss()
             .With(new PageResourceLoader(this))
             .With<AngleSharp.Css.IRenderDevice>(_ => new PageRenderDevice(_runtime))
-            .With<AngleSharp.Dom.IAttributeObserver>(_ => new CustomElements.CustomElementAttributeObserver(_runtime));
+            .With<AngleSharp.Dom.IAttributeObserver>(_ => new CustomElements.CustomElementAttributeObserver(_runtime))
+            .With<AngleSharp.Dom.IAttributeObserver>(_ => new Dom.Files.FileInputAttributeObserver(_runtime));
 
         // https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setScriptExecutionDisabled
         // — the scripting service is simply not registered, which is how AngleSharp is told a document has

--- a/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
+++ b/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Jint.Browser;
 using Jint.DevTools;
 using Jint.Tests.Browser.Fixtures;
@@ -339,6 +340,67 @@ public class PlaywrightCourseTests
         // And the box the check reads is a real one, computed against the viewport rather than refused.
         (await page.EvaluateAsync<string>(
             "() => getComputedStyle(document.getElementById('SiteName')).width")).Should().Be("1280px");
+
+        await page.CloseAsync();
+    }
+
+    /// <summary>Issue #3844: Playwright's standard DataTransfer path can select in-memory files.</summary>
+    [Test]
+    public async Task PlaywrightCanSetMultipleInputFiles()
+    {
+        await using var lane = await ClientLane.OpenAsync(server => server.MapHtml(
+            "/file-input/index.html",
+            """
+            <form>
+              <input id="upload" type="file" multiple>
+            </form>
+            <script>
+              window.fileEvents = [];
+              for (const type of ['input', 'change']) {
+                document.body.addEventListener(type, event => {
+                  window.fileEvents.push(type + ':' + event.target.id + ':' + event.bubbles);
+                });
+              }
+            </script>
+            """));
+        var page = await lane.NewPageAsync("file-input");
+
+        await page.Locator("#upload").SetInputFilesAsync(
+        [
+            new FilePayload
+            {
+                Name = "hello.txt",
+                MimeType = "text/plain",
+                Buffer = Encoding.UTF8.GetBytes("hello from Playwright"),
+            },
+            new FilePayload
+            {
+                Name = "data.json",
+                MimeType = "application/json",
+                Buffer = Encoding.UTF8.GetBytes("{\"answer\":42}"),
+            },
+        ]);
+
+        var result = await page.EvaluateAsync<string>(
+            """
+            async () => {
+              const files = document.getElementById('upload').files;
+              const details = await Promise.all(Array.from(files, async file =>
+                [file.name, file.type, await file.text()].join('|')));
+              return [
+                files instanceof FileList,
+                files.length,
+                files.item(0) === files[0],
+                files.item(2) === null,
+                details.join(';'),
+                window.fileEvents.join(',')
+              ].join('#');
+            }
+            """);
+
+        result.Should().Be(
+            "true#2#true#true#hello.txt|text/plain|hello from Playwright;"
+            + "data.json|application/json|{\"answer\":42}#input:upload:true,change:upload:true");
 
         await page.CloseAsync();
     }

--- a/Jint.Tests.Browser/Events/UiEventTests.cs
+++ b/Jint.Tests.Browser/Events/UiEventTests.cs
@@ -354,9 +354,8 @@ public sealed class UiEventTests
     }
 
     /// <summary>
-    /// <c>DragEvent</c> is a stated v1 non-goal: drag and drop has no <c>DataTransfer</c> behind it, so an
-    /// interface object would be a constructor for an event nothing can mean. Feature detection has to be
-    /// honest about it.
+    /// <c>DragEvent</c> is a stated v1 non-goal: the transferable data store used by file inputs exists, but
+    /// drag dispatch and event-specific state do not. Feature detection has to be honest about it.
     /// </summary>
     [Test]
     public async Task DragEventIsAbsentSoFeatureDetectionIsHonest()

--- a/Jint.Tests.Browser/Files/FileTransferTests.cs
+++ b/Jint.Tests.Browser/Files/FileTransferTests.cs
@@ -1,0 +1,332 @@
+namespace Jint.Tests.Browser.Files;
+
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>HTML's drag data store, FileList, and selected-file state.</summary>
+public sealed class FileTransferTests
+{
+    [Test]
+    public async Task FileItemsProjectIntoALiveFileListAndCanBeAssignedToAFileInput()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<input id='upload' type='file' multiple><input id='text'>");
+
+        await page.EvaluateAsync(
+            """
+            (async () => {
+              const first = new File(
+                [new Uint8Array([104, 101, 108, 108, 111])],
+                'greeting.txt',
+                { type: 'text/plain', lastModified: 123 });
+              const second = new File(['{"ok":true}'], 'data.json', { type: 'application/json', lastModified: 456 });
+              const transfer = new DataTransfer();
+              const firstItem = transfer.items.add(first);
+              transfer.items.add(second);
+              const input = document.getElementById('upload');
+              input.files = transfer.files;
+
+              const beforeRemoval = [
+                transfer.items instanceof DataTransferItemList,
+                transfer.files instanceof FileList,
+                input.files === transfer.files,
+                input.files.length,
+                input.files[0] === first,
+                input.files.item(1) === second,
+                input.files.item(2) === null,
+                [...input.files].map(file => file.name).join(','),
+                FileList.prototype[Symbol.iterator] === Array.prototype[Symbol.iterator],
+                firstItem.kind,
+                firstItem.type,
+                firstItem.getAsFile() === first,
+                first.name,
+                first.type,
+                first.lastModified,
+                await first.text(),
+                await second.text()
+              ].join('|');
+
+              transfer.items.remove(0);
+              const afterRemoval = [
+                transfer.items.length,
+                transfer.files.length,
+                transfer.files[0].name,
+                input.files.length
+              ].join(',');
+              transfer.items.clear();
+              const afterClear = [transfer.items.length, transfer.files.length, input.files.length].join(',');
+              window.transferResult = [beforeRemoval, afterRemoval, afterClear].join(';');
+            })()
+            """);
+        (await page.WaitForAsync("window.transferResult !== undefined", TimeSpan.FromSeconds(30))).Should().BeTrue();
+        var result = await page.EvaluateAsync<string>("window.transferResult");
+
+        result.Should().Be(
+            "true|true|true|2|true|true|true|greeting.txt,data.json|true|file|text/plain|true|"
+            + "greeting.txt|text/plain|123|hello|{\"ok\":true};1,1,data.json,1;0,0,0");
+    }
+
+    [Test]
+    public async Task StringItemsFollowTheDragDataStoreListRules()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<p>files</p>");
+
+        await page.EvaluateAsync(
+            """
+            (async () => {
+              const transfer = new DataTransfer();
+              const item = transfer.items.add('hello', 'TEXT/PLAIN');
+              transfer.setData('url', 'https://example.test/');
+              let duplicate;
+              try {
+                transfer.items.add('other', 'TEXT/PLAIN');
+                duplicate = 'no throw';
+              } catch (error) {
+                duplicate = error.name;
+              }
+              const callbackData = await new Promise(resolve => item.getAsString(resolve));
+              const noMatch = action => {
+                try { action(); return 'no throw'; } catch (error) { return error.name; }
+              };
+              const literalType = new DataTransfer().items.add('literal', 'TEXT').type;
+              const replacement = new DataTransfer();
+              replacement.setData('custom', 'one');
+              const replaced = replacement.items[0];
+              replacement.setData('other', 'middle');
+              replacement.setData('custom', 'two');
+              const clearUndefined = new DataTransfer();
+              clearUndefined.setData('text', 'gone');
+              clearUndefined.clearData(undefined);
+              const uri = new DataTransfer();
+              uri.setData(' URL ', '# comment\r\nhttps://first.test/\nhttps://second.test/');
+              const fileItem = uri.items.add(new File(['x'], 'x.txt'));
+              const disabledTransfer = new DataTransfer();
+              const removed = disabledTransfer.items.add('x', 'custom');
+              disabledTransfer.items.remove(0);
+              const sameTypes = transfer.types === transfer.types;
+              const overloads = [
+                noMatch(() => new DataTransfer().items.add()),
+                noMatch(() => new DataTransfer().items.add('one argument')),
+                new DataTransfer().items.add(new File(['x'], 'x.txt'), 'text/custom').kind,
+                noMatch(() => transfer.files.item()),
+                noMatch(() => new DataTransfer().items.remove()),
+                noMatch(() => transfer.getData()),
+                noMatch(() => transfer.setData()),
+                noMatch(() => item.getAsString()),
+                noMatch(() => fileItem.getAsString(1)),
+                noMatch(() => removed.getAsString(1)),
+                noMatch(() => item.getAsString(null))
+              ].join(',');
+              const beforeClear = [
+                transfer.items.length,
+                transfer.items[0] === item,
+                item.kind,
+                item.type,
+                item.getAsFile() === null,
+                callbackData,
+                transfer.getData('TEXT'),
+                transfer.getData('Url'),
+                transfer.types.join(','),
+                Object.isFrozen(transfer.types),
+                sameTypes,
+                duplicate,
+                literalType,
+                replacement.items[0] !== replaced,
+                replaced.kind === '',
+                replacement.types.join(','),
+                replacement.getData('custom'),
+                clearUndefined.items.length,
+                uri.getData(' url '),
+                overloads
+              ].join('|');
+
+              transfer.clearData('text');
+              const afterClearData = [
+                transfer.items.length,
+                transfer.types.join(','),
+                transfer.getData('text'),
+                item.kind,
+                item.type
+              ].join('|');
+              transfer.items.remove(0);
+              window.transferResult = [beforeClear, afterClearData, transfer.items.length].join(';');
+            })()
+            """);
+        (await page.WaitForAsync("window.transferResult !== undefined", TimeSpan.FromSeconds(30))).Should().BeTrue();
+        var result = await page.EvaluateAsync<string>("window.transferResult");
+
+        result.Should().Be(
+            "2|true|string|text/plain|true|hello|hello|https://example.test/|"
+            + "text/plain,text/uri-list|true|true|NotSupportedError|text|true|true|other,custom|two|0|https://first.test/|"
+            + "TypeError,TypeError,string,TypeError,TypeError,TypeError,TypeError,TypeError,TypeError,TypeError,no throw;"
+            + "1|text/uri-list|||;0");
+    }
+
+    [Test]
+    public async Task SelectedFilesParticipateInInputValueValidityAndReset()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            "<form id='form'><input id='upload' type='file' required><input id='text'></form>");
+
+        var result = await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const input = document.getElementById('upload');
+              const select = name => {
+                const transfer = new DataTransfer();
+                transfer.items.add(new File(['content'], name, { type: 'text/plain' }));
+                input.files = transfer.files;
+                return transfer.files;
+              };
+
+              const first = select('first.txt');
+              let nonEmpty;
+              try { input.value = 'not allowed'; nonEmpty = 'no throw'; } catch (error) { nonEmpty = error.name; }
+              const selected = [input.value, input.validity.valueMissing, input.checkValidity(), nonEmpty].join('|');
+
+              input.value = '';
+              const cleared = [
+                input.files !== first,
+                input.files.length,
+                first.length,
+                input.validity.valueMissing
+              ].join('|');
+
+              const second = select('second.txt');
+              document.getElementById('form').reset();
+              const reset = [
+                input.files !== second,
+                input.files.length,
+                second.length,
+                input.validity.valueMissing
+              ].join('|');
+
+              const third = select('third.txt');
+              input.type = 'text';
+              const textState = [input.files === null, input.value].join('|');
+              input.type = 'file';
+              const fileState = [
+                input.files !== third,
+                input.files.length,
+                third.length,
+                input.validity.valueMissing
+              ].join('|');
+
+              const fourth = select('fourth.txt');
+              input.setAttribute('type', 'text');
+              input.setAttribute('type', 'file');
+              const attributeState = [
+                input.files !== fourth,
+                input.files.length,
+                fourth.length,
+                input.validity.valueMissing
+              ].join('|');
+
+              const fifth = select('fifth.txt');
+              input.files = undefined;
+              const undefinedFiles = [input.files === fifth, input.files.length].join('|');
+              input.value = null;
+              const nullValue = [input.files !== fifth, input.files.length, fifth.length].join('|');
+
+              const transition = action => {
+                const source = select('source.txt');
+                action();
+                const away = input.files === null;
+                input.type = 'file';
+                return [away, input.files.length, source.length].join('|');
+              };
+              const mutationStates = [
+                transition(() => input.setAttributeNS(null, 'type', 'text')),
+                transition(() => input.removeAttributeNS(null, 'type')),
+                transition(() => {
+                  input.remove();
+                  input.getAttributeNode('type').value = 'text';
+                }),
+                transition(() => {
+                  const attribute = document.createAttribute('type');
+                  attribute.value = 'text';
+                  input.attributes.setNamedItem(attribute);
+                }),
+                transition(() => input.attributes.removeNamedItem('type')),
+                transition(() => input.toggleAttribute('type'))
+              ].join(',');
+
+              const cloneSource = select('clone.txt');
+              const clone = input.cloneNode();
+              const imported = document.importNode(input);
+              const copiedStates = [
+                clone.value,
+                clone.files.length,
+                clone.validity.valueMissing,
+                clone.checkValidity(),
+                imported.value,
+                imported.files.length,
+                imported.validity.valueMissing,
+                imported.checkValidity(),
+                cloneSource.length
+              ].join('|');
+
+              return [
+                selected,
+                cleared,
+                reset,
+                textState,
+                fileState,
+                attributeState,
+                undefinedFiles,
+                nullValue,
+                mutationStates,
+                copiedStates
+              ].join(';');
+            })()
+            """);
+
+        result.Should().Be(
+            @"C:\fakepath\first.txt|false|true|InvalidStateError;"
+            + "true|0|1|true;true|0|1|true;true|;true|0|1|true;true|0|1|true;"
+            + "true|1;true|0|1;"
+            + "true|0|1,true|0|1,true|0|1,true|0|1,true|0|1,true|0|1;"
+            + "|0|true|false||0|true|false|1");
+    }
+
+    [Test]
+    public async Task TransferInterfacesAndInputFilesHaveTheirWebIdlShape()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<input id='upload' type='file'><input id='text'>");
+
+        var result = await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const transfer = new DataTransfer();
+              let illegalConstructor;
+              let badAssignment;
+              try { new FileList(); } catch (error) { illegalConstructor = error.message; }
+              try { document.getElementById('upload').files = []; } catch (error) { badAssignment = error.name; }
+              const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'DataTransfer');
+              return [
+                transfer instanceof DataTransfer,
+                Object.prototype.toString.call(transfer),
+                Object.prototype.toString.call(transfer.items),
+                Object.prototype.toString.call(transfer.files),
+                DataTransfer.length,
+                illegalConstructor,
+                badAssignment,
+                document.getElementById('text').files === null,
+                descriptor.writable,
+                descriptor.enumerable,
+                descriptor.configurable
+              ].join('|');
+            })()
+            """);
+
+        result.Should().Be(
+            "true|[object DataTransfer]|[object DataTransferItemList]|[object FileList]|0|Illegal constructor|"
+            + "TypeError|true|true|false|true");
+    }
+}

--- a/Jint.Tests.Browser/Forms/FormTests.cs
+++ b/Jint.Tests.Browser/Forms/FormTests.cs
@@ -148,6 +148,33 @@ public sealed class FormTests
     }
 
     [Test]
+    public async Task AMultipartSubmissionCarriesTheSelectedFiles()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => WithEcho(server).MapHtml(
+            "/form.html",
+            "<form id='f' action='/echo' method='post' enctype='multipart/form-data'>"
+            + "<input type='file' name='upload' multiple></form>"));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+        await fixture.Page.EvaluateAsync(
+            """
+            const transfer = new DataTransfer();
+            transfer.items.add(new File(['alpha'], 'a.txt', { type: 'text/plain' }));
+            transfer.items.add(new File(['{"b":2}'], 'b.json', { type: 'application/json' }));
+            document.querySelector('input').files = transfer.files;
+            """);
+        await fixture.Page.SubmitFormAsync("#f");
+
+        var body = fixture.Server.Received.Single(request => request.Path == "/echo").Body;
+        body.Should().Contain("name=\"upload\"; filename=\"a.txt\"");
+        body.Should().Contain("Content-Type: text/plain");
+        body.Should().Contain("alpha");
+        body.Should().Contain("name=\"upload\"; filename=\"b.json\"");
+        body.Should().Contain("Content-Type: application/json");
+        body.Should().Contain("{\"b\":2}");
+    }
+
+    [Test]
     public async Task APostSubmissionCanBeTextPlain()
     {
         await using var fixture = await LoopbackPage.CreateAsync(server => WithEcho(server).MapHtml(

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -243,6 +243,21 @@
       "interface": "CharacterData",
       "member": "replaceData",
       "reason": "The offset and the count of the same conversion; see substringData."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "files",
+      "reason": "HTML's selected files are File API File objects held by a live FileList. AngleSharp exposes its own IFileList through a getter only, which cannot hold Jint's File instances and cannot accept the FileList produced by DataTransfer. Re-declared in additions so the getter and setter share the browser runtime's selected-file state."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "type",
+      "reason": "Changing into or out of the file-upload state empties the selected file list. Re-declared in additions so the selected-file sidecar follows that state transition."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "value",
+      "reason": "The file-upload state exposes a fake path for the selected filename, permits only the empty string to be assigned, and clears its selected files when that happens. Re-declared in additions while preserving AngleSharp's behavior for every other input state."
     }
   ],
   "additions": [
@@ -1294,6 +1309,48 @@
       "reason": "The other half of the skip above; see substringData."
     },
     {
+      "interface": "HTMLInputElement",
+      "member": "files",
+      "kind": "attribute",
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, \"HTMLInputElement.files\");",
+        "return global::Jint.Browser.Dom.Files.FileTransferMembers.InputFiles(self.Realm, self.Target);"
+      ],
+      "setter": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, \"HTMLInputElement.files\");",
+        "return global::Jint.Browser.Dom.Files.FileTransferMembers.SetInputFiles(self.Realm, self.Target, args);"
+      ],
+      "reason": "HTML §4.10.5.1.17 exposes the selected files as a nullable FileList and permits assigning another FileList. The binding's list carries Jint's standards-based File objects, so File.text(), FormData and fetch all observe the same bytes."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "type",
+      "kind": "attribute",
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, \"HTMLInputElement.type\");",
+        "return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Type);"
+      ],
+      "setter": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, \"HTMLInputElement.type\");",
+        "return global::Jint.Browser.Dom.Files.FileTransferMembers.SetInputType(self.Realm, self.Target, args);"
+      ],
+      "reason": "HTML §4.10.5.3.1 empties selected files when a type change moves into or out of the file-upload state."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "value",
+      "kind": "attribute",
+      "body": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, \"HTMLInputElement.value\");",
+        "return global::Jint.Browser.Dom.Files.FileTransferMembers.InputValue(self.Realm, self.Target);"
+      ],
+      "setter": [
+        "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, \"HTMLInputElement.value\");",
+        "return global::Jint.Browser.Dom.Files.FileTransferMembers.SetInputValue(self.Realm, self.Target, args);"
+      ],
+      "reason": "HTML §4.10.5.1.17 defines the file-upload state's filename value, fake path, and empty-string setter."
+    },
+    {
       "interface": "Element",
       "extend": "Jint.Browser.Dom.AriaReflection.ElementAria",
       "reason": "ARIA §10.1's ARIAMixin, which the standard puts on Element: `role` and forty-four `aria-*` IDL attributes, each an identically shaped accessor pair reflecting one content attribute. AngleSharp's IElement has no ARIA member at all, so the member closure yields none, and as member entries they would be ninety near-identical rows; the extend form exists for exactly this. The element-reflection half of the mixin is not here -- see Jint.Browser/Dom/AriaReflection.cs."
@@ -1386,6 +1443,14 @@
       "hook": "CloneNode",
       "returns": true,
       "reason": "The same AngleSharp call, and then the upgrade DOM's clone steps enqueue -- so the node the page is handed is the host's answer rather than AngleSharp's."
+    },
+    {
+      "interface": "Document",
+      "member": "importNode",
+      "half": "operation",
+      "hook": "ImportNode",
+      "returns": true,
+      "reason": "DOM's import steps leave a cloned file input with no selected files. AngleSharp copies its internal filename value, so the host clears copied file controls before exposing the imported tree."
     },
     {
       "interface": "Element",


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

Enable Playwright to assign files through the standard DataTransfer APIs.

## Details

- Adds standards-shaped `DataTransfer`, `DataTransferItemList`, `DataTransferItem`, and live `FileList` implementations using the existing Jint `File` objects.
- Integrates assigned files with input value, validity, reset and type-transition behavior, clone/import behavior, and multipart form submission.
- Preserves assigned `FileList` identity and liveness while detaching external lists when the input is cleared.
- Adds focused browser coverage and an unmodified Playwright-over-CDP regression for multiple files, metadata, contents, list APIs, and bubbling `input`/`change` events.

## Linked issue

Fixes: #3844

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

Additional validation: full `Jint.Tests.Browser` suites on net8.0 and net10.0, the gated Playwright regression on both frameworks, DOM binding staleness checks, and host-contract verification for `Jint.Tests`, `Jint.Tests.PublicInterface`, and the focused browser tests.

## Breaking change?

No.