### PR TITLE
Expose the global Image constructor in Jint.Browser

### DIFF
--- a/Jint.Browser/Dom/DomBindings.cs
+++ b/Jint.Browser/Dom/DomBindings.cs
@@ -8,8 +8,8 @@ using Jint.WebApi;
 namespace Jint.Browser.Dom;
 
 /// <summary>
-/// The two doors onto the DOM binding: install the interface objects on an engine, and move a value across
-/// the boundary in either direction.
+/// The two doors onto the DOM binding: install the interface objects and legacy factory functions on an
+/// engine, and move a value across the boundary in either direction.
 /// </summary>
 internal static class DomBindings
 {
@@ -68,6 +68,19 @@ internal static class DomBindings
             global.SetProperty(
                 definition.Name,
                 new LazyPropertyDescriptor<DomRealm>(realm, r => r.InterfaceObjectOf(captured), PropertyFlag.NonEnumerable));
+        }
+
+        foreach (var factory in DomConstructors.LegacyFactories)
+        {
+            if (global.HasOwnProperty(WebApiRegistration.NameOf(factory.Name)))
+            {
+                continue;
+            }
+
+            var captured = factory;
+            global.SetProperty(
+                factory.Name,
+                new LazyPropertyDescriptor<DomRealm>(realm, r => captured.Create(r), PropertyFlag.NonEnumerable));
         }
     }
 

--- a/Jint.Browser/Dom/DomConstructors.cs
+++ b/Jint.Browser/Dom/DomConstructors.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AngleSharp;
 using AngleSharp.Dom;
 using AngleSharp.Xml.Parser;
@@ -7,7 +8,7 @@ using Jint.Native.Object;
 namespace Jint.Browser.Dom;
 
 /// <summary>
-/// The generated interfaces a script may really call <c>new</c> on.
+/// The generated interfaces and legacy factory functions a script may really call <c>new</c> on.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -27,6 +28,12 @@ namespace Jint.Browser.Dom;
 /// interface at all — see <see cref="DomStaticRange"/>.
 /// </para>
 /// <para>
+/// HTML's <c>Image</c> is the other shape represented here: a
+/// <c>[LegacyFactoryFunction]</c> for the generated <c>HTMLImageElement</c> interface, rather than that
+/// interface's own constructor. It therefore gets its own global function while sharing the generated
+/// prototype and wrapper.
+/// </para>
+/// <para>
 /// <b>Every one of them says "the current global object's associated <c>Document</c>".</b> That is the page's
 /// when there is a page runtime behind the binding, and an empty XML document of this call's own when there
 /// is not — the same answer <c>DocumentFragment</c> already gave, for the same reason: a node nothing else
@@ -41,6 +48,12 @@ namespace Jint.Browser.Dom;
 /// </remarks>
 internal static class DomConstructors
 {
+    /// <summary>The legacy factory functions installed beside the generated interface objects.</summary>
+    internal static readonly DomLegacyFactoryDefinition[] LegacyFactories =
+    [
+        new("Image", DomInterfaces.HTMLImageElement, 0, ConstructImage),
+    ];
+
     /// <summary>
     /// Builds the instance for a <c>new</c> on <paramref name="definition"/>, or answers
     /// <see langword="false"/> for an interface WebIDL gives no constructor.
@@ -91,6 +104,28 @@ internal static class DomConstructors
 
         instance = null!;
         return false;
+    }
+
+    /// <summary>https://html.spec.whatwg.org/multipage/embedded-content.html#dom-image.</summary>
+    private static DomNodeObject ConstructImage(DomRealm realm, JsValue[] arguments)
+    {
+        var image = NodeDocument(realm).CreateElement(NamespaceNames.HtmlUri, "img");
+
+        if (arguments.Length > 0)
+        {
+            image.SetAttribute(
+                "width",
+                DomConvert.RequiredUInt32(arguments, 0, "Image").ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (arguments.Length > 1)
+        {
+            image.SetAttribute(
+                "height",
+                DomConvert.RequiredUInt32(arguments, 1, "Image").ToString(CultureInfo.InvariantCulture));
+        }
+
+        return realm.WrapNode(image);
     }
 
     /// <summary>The current global object's associated <c>Document</c>, or an empty one when there is none.</summary>

--- a/Jint.Browser/Dom/DomLegacyFactoryFunction.cs
+++ b/Jint.Browser/Dom/DomLegacyFactoryFunction.cs
@@ -1,0 +1,59 @@
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>
+/// A WebIDL legacy factory function such as HTML's <c>Image</c>: a constructor with the generated
+/// interface's prototype, but a different global name and constructor algorithm.
+/// </summary>
+internal sealed class DomLegacyFactoryFunction : Constructor
+{
+    private readonly DomRealm _domRealm;
+    private readonly DomLegacyFactoryDefinition _definition;
+
+    internal DomLegacyFactoryFunction(DomRealm realm, DomLegacyFactoryDefinition definition)
+        : base(realm.Engine, realm.PrincipalRealm, new JsString(definition.Name))
+    {
+        _domRealm = realm;
+        _definition = definition;
+        _prototype = realm.PrincipalRealm.Intrinsics.Function.PrototypeObject;
+        _length = new PropertyDescriptor(JsNumber.Create(definition.Length), PropertyFlag.Configurable);
+
+        // https://webidl.spec.whatwg.org/#legacy-factory-functions — the legacy factory's prototype is the
+        // original interface prototype, with { writable: false, enumerable: false, configurable: false }.
+        _prototypeDescriptor = new PropertyDescriptor(
+            realm.PrototypeOf(definition.Interface),
+            PropertyFlag.AllForbidden);
+    }
+
+    /// <inheritdoc />
+    public override ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
+    {
+        var instance = _definition.Construct(_domRealm, arguments);
+
+        // WebIDL internally creates the implementing object with NewTarget. The direct `new Image()` path
+        // already has the generated interface prototype; a derived constructor supplies its own instead.
+        if (!ReferenceEquals(newTarget, this) && newTarget is ObjectInstance constructor)
+        {
+            instance.Prototype = constructor.Get("prototype") as ObjectInstance
+                ?? _domRealm.PrototypeOf(_definition.Interface);
+        }
+
+        return instance;
+    }
+
+    public override string ToString() => "function " + _definition.Name + "() { [native code] }";
+}
+
+/// <summary>One hand-written <c>[LegacyFactoryFunction]</c> the AngleSharp metadata cannot express.</summary>
+internal readonly record struct DomLegacyFactoryDefinition(
+    string Name,
+    DomInterfaceDefinition Interface,
+    int Length,
+    Func<DomRealm, JsValue[], ObjectInstance> Construct)
+{
+    internal DomLegacyFactoryFunction Create(DomRealm realm) => new(realm, this);
+}

--- a/Jint.Tests.Browser/Dom/DomConstructorTests.cs
+++ b/Jint.Tests.Browser/Dom/DomConstructorTests.cs
@@ -17,6 +17,149 @@ public sealed class DomConstructorTests
         """;
 
     /// <summary>
+    /// https://html.spec.whatwg.org/multipage/embedded-content.html#dom-image and
+    /// https://webidl.spec.whatwg.org/#legacy-factory-functions: <c>Image</c> is the legacy factory function
+    /// for <c>HTMLImageElement</c>, with that interface's prototype rather than a prototype of its own.
+    /// </summary>
+    [Test]
+    public async Task ImageIsTheHtmlImageElementLegacyFactoryFunction()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<!doctype html><body></body>");
+
+        (await page.EvaluateAsync<string>("""
+            const image = new Image();
+            class DerivedImage extends Image {}
+            const derived = new DerivedImage();
+            const globalDescriptor = Object.getOwnPropertyDescriptor(window, 'Image');
+            const prototypeDescriptor = Object.getOwnPropertyDescriptor(Image, 'prototype');
+            let callError;
+            try { Image(); } catch (error) { callError = error.name; }
+            [
+              typeof Image,
+              Image.name,
+              Image.length,
+              Image.prototype === HTMLImageElement.prototype,
+              Image.prototype.constructor === HTMLImageElement,
+              Object.getPrototypeOf(image) === HTMLImageElement.prototype,
+              image instanceof HTMLImageElement,
+              image.tagName,
+              Object.prototype.toString.call(image),
+              Object.getPrototypeOf(derived) === DerivedImage.prototype,
+              derived instanceof DerivedImage,
+              derived instanceof HTMLImageElement,
+              callError,
+              globalDescriptor.writable,
+              globalDescriptor.enumerable,
+              globalDescriptor.configurable,
+              prototypeDescriptor.writable,
+              prototypeDescriptor.enumerable,
+              prototypeDescriptor.configurable,
+            ].join('|')
+            """)).Should().Be(
+            "function|Image|0|true|true|true|true|IMG|[object HTMLImageElement]|true|true|true|TypeError|true|false|true|false|false|false");
+    }
+
+    /// <summary>
+    /// The two arguments are optional, and only arguments that were supplied create the corresponding
+    /// content attributes.
+    /// </summary>
+    [Test]
+    public async Task ImageAppliesOnlyTheDimensionsThatWereSupplied()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<!doctype html><body></body>");
+
+        (await page.EvaluateAsync<string>("""
+            const omitted = new Image();
+            const widthOnly = new Image(320);
+            const sized = new Image(320, 200);
+            [
+              omitted.width,
+              omitted.height,
+              omitted.hasAttribute('width'),
+              omitted.hasAttribute('height'),
+              widthOnly.width,
+              widthOnly.height,
+              widthOnly.getAttribute('width'),
+              widthOnly.hasAttribute('height'),
+              sized.width,
+              sized.height,
+              sized.getAttribute('width'),
+              sized.getAttribute('height'),
+            ].join('|')
+            """)).Should().Be("0|0|false|false|320|0|320|false|320|200|320|200");
+    }
+
+    /// <summary>
+    /// WebIDL converts each supplied argument to <c>unsigned long</c> before HTML writes the attribute.
+    /// </summary>
+    [Test]
+    public async Task ImageDimensionsUseUnsignedLongConversion()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<!doctype html><body></body>");
+
+        (await page.EvaluateAsync<string>("""
+            const wrapped = new Image(-1, 4294967297);
+            const converted = new Image('12.9', NaN);
+            const explicitUndefined = new Image(undefined, 9);
+            const object = new Image({ valueOf() { return 17; } }, 4);
+            const errorNames = [];
+            for (const value of [Symbol('width'), 1n]) {
+              try { new Image(value); }
+              catch (error) { errorNames.push(error.name); }
+            }
+            [
+              wrapped.getAttribute('width'),
+              wrapped.getAttribute('height'),
+              converted.getAttribute('width'),
+              converted.getAttribute('height'),
+              explicitUndefined.getAttribute('width'),
+              explicitUndefined.getAttribute('height'),
+              object.getAttribute('width'),
+              object.getAttribute('height'),
+              ...errorNames,
+            ].join('|')
+            """)).Should().Be("4294967295|1|12|0|0|9|17|4|TypeError|TypeError");
+    }
+
+    /// <summary>
+    /// Image fetching is intentionally outside this headless browser's rendering-free model, but the
+    /// constructed element still reflects <c>src</c> and participates in the normal DOM event path.
+    /// </summary>
+    [Test]
+    public async Task ImageSupportsSourceReflectionAndLoadEvents()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<!doctype html><body></body>");
+
+        (await page.EvaluateAsync<string>("""
+            const image = new Image();
+            let loads = 0;
+            image.addEventListener('load', () => loads++);
+            image.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+            const beforeDispatch = loads;
+            image.dispatchEvent(new Event('load'));
+            [
+              image.getAttribute('src'),
+              image.src,
+              beforeDispatch,
+              loads,
+            ].join('|')
+            """)).Should().Be(
+            "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==|data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==|0|1");
+    }
+
+    /// <summary>
     /// https://dom.spec.whatwg.org/#dom-comment-comment and
     /// https://dom.spec.whatwg.org/#dom-text-text: <c>constructor(optional DOMString data = "")</c>, whose
     /// node document is the current global object's associated <c>Document</c>.


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

Expose the standard global `Image` constructor in Jint.Browser.

## Details

`Jint.Browser` already generates the `HTMLImageElement` interface and prototype, but did not expose HTML's `[LegacyFactoryFunction=Image(...)]`, causing applications that use `new Image()` to fail with `ReferenceError`.

This adds a reusable DOM legacy-factory function integrated with the existing manual `DomConstructors` and lazy `DomBindings` installation path. `new Image(width?, height?)` creates an HTML `img` in the current document, applies WebIDL `unsigned long` conversion to supplied dimensions, shares `HTMLImageElement.prototype`, and honors `newTarget` for derived constructors. Existing source reflection and DOM load-event behavior remain unchanged; image fetching is still intentionally unsupported by the rendering-free browser model.

## Linked issue

Fixes: #3847

## Test plan

- [ ] Added or updated unit tests in `Jint.Tests` (N/A: focused coverage was added in `Jint.Tests.Browser`)
- [ ] Ran `dotnet test --configuration Release` locally (N/A: ran the smallest targeted Release suites instead)
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions (N/A)
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` (N/A)
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark` (N/A)

Targeted validation:

- [x] `DomConstructorTests` on `net8.0` and `net10.0` (30 passed per framework)
- [x] `DomConstructorTests` with host-contract verification on `net8.0` and `net10.0` (30 passed per framework)
- [x] `DomBindingsStalenessTests` on `net10.0` (3 passed)

## Breaking change?

No.