### PR TITLE
Reuse CSS cascades within each flat-layout query

### DIFF
--- a/Jint.Benchmark/BrowserLayoutBenchmark.cs
+++ b/Jint.Benchmark/BrowserLayoutBenchmark.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Browser;
+using Jint.Tests.Browser.Layout;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// A nested admin form with inherited theme tokens and grouped CSS selectors. Engine construction and HTML
+/// parsing are excluded; this row owns one page and warms only its own geometry query.
+/// </summary>
+[MemoryDiagnoser]
+public class BrowserLayoutBenchmark
+{
+    private Browser.Browser _browser = null!;
+    private Page _page = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _browser = new Browser.Browser();
+        _page = await _browser.NewPageAsync();
+        await _page.SetContentAsync(AdminSettingsDocument.Create());
+    }
+
+    [Benchmark]
+    public Task<double> QuerySaveButton()
+        => _page.EvaluateAsync<double>("document.querySelector('.btn.save').getBoundingClientRect().top");
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _browser.DisposeAsync();
+}

--- a/Jint.Benchmark/Jint.Benchmark.csproj
+++ b/Jint.Benchmark/Jint.Benchmark.csproj
@@ -28,6 +28,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
+    <ProjectReference Include="..\Jint.Browser\Jint.Browser.csproj" />
+    <!-- The same script-free nested form drives the CDP regression and the layout benchmark. -->
+    <Compile Include="..\Jint.Tests.Browser\Layout\AdminSettingsDocument.cs" Link="AdminSettingsDocument.cs" />
     <!-- For InteropGeneratedAccessorBenchmarks. No <NoWarn>CS0436</NoWarn> accompanies it and none is
          needed: this analyzer emits no post-initialization source, so nothing it produces collides with the
          Jint internals this assembly can already see. -->

--- a/Jint.Browser/Accessibility/ElementVisibility.cs
+++ b/Jint.Browser/Accessibility/ElementVisibility.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Css.Dom;
 using AngleSharp.Dom;
+using Jint.Browser.Dom.Views;
 
 namespace Jint.Browser.Accessibility;
 
@@ -20,6 +21,9 @@ internal sealed class ElementVisibility
 
     internal ElementVisibility(bool useComputedStyle) => _useComputedStyle = useComputedStyle;
 
+    internal CssCascade.Traversal? CreateTraversal(IDocument? document)
+        => _useComputedStyle && _cascadeAvailable ? CssCascade.Traversal.For(document) : null;
+
     /// <summary>
     /// Whether the CSS cascade answered at least once, so a caller can say which source a verdict came from.
     /// </summary>
@@ -32,7 +36,7 @@ internal sealed class ElementVisibility
     /// Ancestors are not consulted: the tree walk carries an inherited verdict down, which is both cheaper
     /// than walking up per node and the only way <c>hiddenRoot</c> can name the ancestor that did it.
     /// </remarks>
-    internal AxIgnoredReason ReasonFor(IElement element) => ReasonFor(element, ariaHiddenCounts: true);
+    internal AxIgnoredReason ReasonFor(IElement element) => ReasonFor(element, ariaHiddenCounts: true, traversal: null);
 
     /// <summary>
     /// Returns the reason <paramref name="element"/> is not rendered, or <see cref="AxIgnoredReason.None"/>.
@@ -42,9 +46,10 @@ internal sealed class ElementVisibility
     /// changes nothing about the rendering. It is what the text and markdown extractors ask, because a
     /// decorative marker is still text on the page.
     /// </remarks>
-    internal AxIgnoredReason RenderingReasonFor(IElement element) => ReasonFor(element, ariaHiddenCounts: false);
+    internal AxIgnoredReason RenderingReasonFor(IElement element, CssCascade.Traversal? traversal = null)
+        => ReasonFor(element, ariaHiddenCounts: false, traversal);
 
-    private AxIgnoredReason ReasonFor(IElement element, bool ariaHiddenCounts)
+    private AxIgnoredReason ReasonFor(IElement element, bool ariaHiddenCounts, CssCascade.Traversal? traversal)
     {
         if (element.HasAttribute("hidden"))
         {
@@ -56,7 +61,7 @@ internal sealed class ElementVisibility
             return AxIgnoredReason.AriaHiddenElement;
         }
 
-        var (display, visibility) = Style(element);
+        var (display, visibility) = Style(element, traversal);
 
         if (string.Equals(display, "none", StringComparison.OrdinalIgnoreCase))
         {
@@ -76,11 +81,11 @@ internal sealed class ElementVisibility
     /// Reads the element's <c>display</c> and <c>visibility</c>, from the cascade when it is available and
     /// from the <c>style</c> content attribute when it is not.
     /// </summary>
-    internal (string? Display, string? Visibility) Style(IElement element)
+    internal (string? Display, string? Visibility) Style(IElement element, CssCascade.Traversal? traversal = null)
     {
         if (_useComputedStyle && _cascadeAvailable)
         {
-            if (Dom.Views.CssCascade.Of(element) is { } computed
+            if ((traversal is null ? CssCascade.Of(element) : traversal.Of(element)) is { } computed
                 && Dom.Views.CssCascade.ValueOf(computed, "display") is { } display
                 && Dom.Views.CssCascade.ValueOf(computed, "visibility") is { } visibility)
             {

--- a/Jint.Browser/Dom/Views/CssCascade.cs
+++ b/Jint.Browser/Dom/Views/CssCascade.cs
@@ -1,4 +1,8 @@
+using AngleSharp;
+using AngleSharp.Css;
 using AngleSharp.Css.Dom;
+using AngleSharp.Css.RenderTree;
+using AngleSharp.Css.Values;
 using AngleSharp.Dom;
 
 namespace Jint.Browser.Dom.Views;
@@ -75,6 +79,98 @@ internal static class CssCascade
         }
         catch (Exception exception) when (exception is ArgumentException or InvalidOperationException or NullReferenceException)
         {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// https://drafts.csswg.org/css-cascade/#inheritance - a cascade shared only by one synchronous tree
+    /// walk, never across DOM or CSSOM writes. Matching and inheritance remain AngleSharp's.
+    /// </summary>
+    internal sealed class Traversal(IStyleCollection styles)
+    {
+        private readonly Dictionary<IElement, ICssStyleDeclaration> _cascaded = new();
+        private readonly Stack<IElement> _pending = new();
+
+        internal static Traversal? For(IDocument? document)
+        {
+            if (document?.DefaultView is not { } window)
+            {
+                return null;
+            }
+
+            var device = document.Context.GetService<IRenderDevice>() ?? new DefaultRenderDevice();
+            return new Traversal(window.GetStyleCollection(device));
+        }
+
+        internal ICssStyleDeclaration? Of(IElement element)
+        {
+            try
+            {
+                // Keep the uncomputed cascade: inheriting a parent's resolved lengths or var() values
+                // would change what ComputeCurrentStyle answers for the child.
+                var current = element;
+                while (current is not null && !_cascaded.ContainsKey(current))
+                {
+                    _pending.Push(current);
+                    current = current.ParentElement;
+                }
+
+                var parent = current is null ? null : _cascaded[current];
+                while (_pending.TryPop(out current))
+                {
+                    parent = parent is null
+                        ? styles.ComputeExplicitStyle(current)
+                        : styles.ComputeCascadedStyle(current, parent);
+
+                    // AngleSharp's ancestor walk can resolve an explicit inherit past a parent that
+                    // declares nothing for a non-inherited property. Preserve that answer too.
+                    if (current.ParentElement is not null
+                        && parent.Any(static property => property.IsInherited && !property.CanBeInherited))
+                    {
+                        parent = styles.GetDeclarations(current);
+                    }
+
+                    _cascaded.Add(current, parent);
+                }
+
+                var cascade = _cascaded[element];
+                return cascade.Compute(new ComputeContext(styles.Device, element.Owner?.Context, cascade));
+            }
+            catch (Exception exception) when (exception is ArgumentException or InvalidOperationException or NullReferenceException)
+            {
+                return null;
+            }
+            finally
+            {
+                _pending.Clear();
+            }
+        }
+    }
+
+    /// <summary>The device and raw variables AngleSharp's own value computation resolves against.</summary>
+    private sealed class ComputeContext(
+        IRenderDevice device,
+        IBrowsingContext? context,
+        ICssStyleDeclaration properties) : ICssComputeContext
+    {
+        public IRenderDevice Device => device;
+        public IBrowsingContext? Context => context;
+        public IValueConverter? Converter => null;
+
+        public ICssValue? Resolve(string name)
+        {
+            if (name.StartsWith("--", StringComparison.Ordinal))
+            {
+                foreach (var property in properties)
+                {
+                    if (string.Equals(property.Name, name, StringComparison.Ordinal))
+                    {
+                        return property.RawValue;
+                    }
+                }
+            }
+
             return null;
         }
     }

--- a/Jint.Browser/Layout/FlatLayout.cs
+++ b/Jint.Browser/Layout/FlatLayout.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Jint.Browser.Accessibility;
+using Jint.Browser.Dom.Views;
 
 namespace Jint.Browser.Layout;
 
@@ -30,7 +31,8 @@ namespace Jint.Browser.Layout;
 /// <b>It is recomputed per query and never cached.</b> A cache would need an invalidation signal, and the
 /// only one available is an AngleSharp <c>MutationObserver</c> over the whole document — which would make
 /// every DOM mutation on every page pay for mutation records whether or not anything ever asks for a box.
-/// The walk is linear in the size of the document and touches no engine state.
+/// One walk shares a cascade so each element's selectors are matched once, not again for every descendant.
+/// The scope ends with the query, so mutations, focus and media changes need no invalidation machinery.
 /// </para>
 /// </remarks>
 internal sealed class FlatLayout
@@ -88,10 +90,11 @@ internal sealed class FlatLayout
         double scrollY)
     {
         var layout = new FlatLayout(viewportWidth, viewportHeight, scrollY);
+        var cascade = visibility.CreateTraversal(document);
 
-        if (document?.DocumentElement is { } root && IsRendered(root, visibility))
+        if (document?.DocumentElement is { } root && IsRendered(root, visibility, cascade))
         {
-            layout.Walk(root, visibility);
+            layout.Walk(root, visibility, cascade);
         }
 
         return layout;
@@ -120,7 +123,7 @@ internal sealed class FlatLayout
     /// hit test depends on.
     /// </para>
     /// </remarks>
-    internal static bool IsRendered(IElement element, ElementVisibility visibility)
+    internal static bool IsRendered(IElement element, ElementVisibility visibility, CssCascade.Traversal? cascade = null)
     {
         if (element is IHtmlHeadElement)
         {
@@ -141,7 +144,7 @@ internal sealed class FlatLayout
                 break;
         }
 
-        return visibility.RenderingReasonFor(element) == AxIgnoredReason.None;
+        return visibility.RenderingReasonFor(element, cascade) == AxIgnoredReason.None;
     }
 
     /// <summary>The ordinal of <paramref name="element"/>, or <c>-1</c> when it is not rendered.</summary>
@@ -218,7 +221,7 @@ internal sealed class FlatLayout
         return row >= 0 && row < _elements.Count ? _elements[(int) row] : null;
     }
 
-    private void Walk(IElement root, ElementVisibility visibility)
+    private void Walk(IElement root, ElementVisibility visibility, CssCascade.Traversal? cascade)
     {
         var stack = new Stack<(IElement Element, int Depth)>();
         stack.Push((root, 0));
@@ -233,7 +236,7 @@ internal sealed class FlatLayout
             for (var i = children.Length - 1; i >= 0; i--)
             {
                 var child = children[i];
-                if (IsRendered(child, visibility))
+                if (IsRendered(child, visibility, cascade))
                 {
                     stack.Push((child, depth + 1));
                 }

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -213,10 +213,15 @@ fall out of the row rule and every one of them is load-bearing:
   `visibility: hidden`, whose `visibility: visible` descendant CSS lets escape. A model whose boxes are rows
   cannot give a descendant a row inside a parent that has none, and the nesting is what the hit test rests on.
 
-**It is recomputed per query and never cached.** A cache needs an invalidation signal, and the only one
+**It is recomputed per query and never cached across queries.** A cache needs an invalidation signal, and the only one
 available is an AngleSharp `MutationObserver` over the whole document — which would make every DOM mutation on
-every page pay for mutation records whether or not anything ever asks for a box. The walk is linear in the
-size of the document and touches no engine state.
+every page pay for mutation records whether or not anything ever asks for a box. Within that synchronous
+walk, `CssCascade.Traversal` shares the style collection and raw parent cascades: calling
+`ComputeCurrentStyle` separately for every element rematches every ancestor, which made a nested admin form
+expensive at every step of Playwright's actionability checks. AngleSharp still owns matching, specificity,
+inheritance and value computation. Raw rather than computed declarations preserve child-relative `var()`
+resolution; unresolved explicit `inherit` takes AngleSharp's ancestor-walk fallback. Nothing survives the
+query, so even same-turn CSSOM writes, `classList`, control state and media changes need no invalidation.
 
 **The scroll is virtual, and it is the only state.** `Layout/PageLayout` holds a `scrollY` clamped to the
 document, and every viewport-relative answer subtracts it; `scrollX` is zero and stays zero, because every box
@@ -329,4 +334,3 @@ The baton between the parser thread and the page loop, which thread runs what, t
 costs, and how scripts, modules, import maps and style sheets load are
 [`Parsing/AGENTS.md`](Parsing/AGENTS.md). The one rule to carry across without opening it: exactly one
 holder touches the engine and the DOM at a time, and a fetch a *script* triggered never pumps.
-

--- a/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
+++ b/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Jint.Browser;
 using Jint.DevTools;
 using Jint.Tests.Browser.Fixtures;
+using Jint.Tests.Browser.Layout;
 using Jint.Tests.Browser.Navigation;
 using Microsoft.Playwright;
 using PageContextOptions = Jint.Browser.BrowserContextOptions;
@@ -189,6 +190,32 @@ public class PlaywrightCourseTests
         var redirected = lane.Server.Received.Single(request => request.Path == "/form-redirect/done.html");
         redirected.Method.Should().Be("GET");
         redirected.Body.Should().BeEmpty();
+
+        await page.CloseAsync();
+    }
+
+    [Test]
+    public async Task PlaywrightSavesANestedAdminFormWithoutRetryingThePost()
+    {
+        await using var lane = await ClientLane.OpenAsync(server => server.Map(
+            "/admin-settings/index.html",
+            request => LoopbackResponse.Html(AdminSettingsDocument.Create(saved: request.Method == "POST"))));
+        var page = await lane.NewPageAsync("admin-settings");
+
+        // No Force, extended timeout, explicit navigation wait or wait for the success marker.
+        await page.Locator(".btn.save").ClickAsync();
+
+        page.Url.Should().Be(lane.Url("admin-settings"));
+        (await page.EvaluateAsync<string>("() => document.querySelector('#saved')?.textContent ?? ''"))
+            .Should().Be("Settings saved");
+        lane.Server.Received.Count(request => request.Method == "POST").Should().Be(1);
+        foreach (var context in lane.Pages.Contexts)
+        {
+            foreach (var hostPage in context.Pages)
+            {
+                hostPage.Errors.Should().BeEmpty();
+            }
+        }
 
         await page.CloseAsync();
     }

--- a/Jint.Tests.Browser/Layout/AdminSettingsDocument.cs
+++ b/Jint.Tests.Browser/Layout/AdminSettingsDocument.cs
@@ -1,0 +1,78 @@
+#nullable enable
+
+using System.Text;
+
+namespace Jint.Tests.Browser.Layout;
+
+/// <summary>A script-free admin form: nested layout wrappers, inherited theme tokens and grouped selectors.</summary>
+/// <remarks>
+/// A reduction, not a captured Orchard response. The Save classes and wrapper patterns come from
+/// https://github.com/OrchardCMS/OrchardCore/tree/59dd4923007afb36220897b74524b608ee23e682/src/OrchardCore.Modules/OrchardCore.Settings/Views.
+/// The generated theme tokens and rules keep the depth-sensitive cascade workload offline and deterministic.
+/// </remarks>
+internal static class AdminSettingsDocument
+{
+    internal static string Create(bool saved = false, string? css = null)
+    {
+        var html = new StringBuilder("<!doctype html><html data-bs-theme='light'><head><style>");
+        if (css is not null)
+        {
+            html.Append(css);
+        }
+        else
+        {
+            html.Append(":root,[data-bs-theme=light]{");
+            for (var i = 0; i < 180; i++)
+            {
+                html.Append("--theme-").Append(i).Append(":").Append(i).Append("px;");
+            }
+
+            html.Append("color:#212529;font-family:sans-serif} ");
+            for (var i = 0; i < 200; i++)
+            {
+                html.Append(".unused-").Append(i).Append(",.admin-menu .item-").Append(i)
+                    .Append(":not(.active)>a{padding:0.5rem;color:var(--theme-0)} ");
+            }
+
+            html.Append("""
+                .form-control{display:block;width:100%;padding:.375rem .75rem}
+                .btn{display:inline-block;padding:.375rem .75rem;border:1px solid transparent}
+                .btn-primary{color:white;background-color:blue}
+                .d-none{display:none!important}
+                .navbar,.content,.card,.card-body,.mb-3{display:block}
+                """);
+        }
+
+        html.Append("""
+            </style></head><body class="the-admin"><div class="ta-wrapper">
+            <nav class="admin-menu"><ul>
+            """);
+        for (var i = 0; i < 40; i++)
+        {
+            html.Append("<li class='nav-item'><a><span><i></i>Menu</span></a></li>");
+        }
+
+        html.Append("""
+            </ul></nav><main><div class="content"><div class="content-body"><div class="card">
+            <div class="card-body"><form method="post"><div class="tab-content"><div class="tab-pane active">
+            """);
+        for (var i = 0; i < 70; i++)
+        {
+            html.Append("<div class='mb-3'><div class='row'><div class='col-sm-9'><label>Setting</label>")
+                .Append("<input class='form-control' name='setting").Append(i)
+                .Append("' value='value'><span class='hint'>Help</span></div></div></div>");
+        }
+
+        html.Append("""
+            </div></div><div class="edit-item-secondary"><div class="edit-item-actions">
+            <button type="submit" class="primaryAction btn btn-primary save">Save</button>
+            </div></div></form>
+            """);
+        if (saved)
+        {
+            html.Append("<p id='saved'>Settings saved</p>");
+        }
+
+        return html.Append("</div></div></div></div></main></div></body></html>").ToString();
+    }
+}

--- a/Jint.Tests.Browser/Layout/CascadeTraversalTests.cs
+++ b/Jint.Tests.Browser/Layout/CascadeTraversalTests.cs
@@ -1,0 +1,161 @@
+using System.Collections;
+using AngleSharp;
+using AngleSharp.Css;
+using AngleSharp.Css.Dom;
+using AngleSharp.Css.RenderTree;
+using AngleSharp.Dom;
+using Jint.Browser.Accessibility;
+using Jint.Browser.Dom.Views;
+using Jint.Browser.Layout;
+using Jint.Browser.Runtime;
+
+namespace Jint.Tests.Browser.Layout;
+
+public sealed class CascadeTraversalTests
+{
+    [Test]
+    public async Task TheAdminFormMatchesSelectorsOnlyOnceForEachElement()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(AdminSettingsDocument.Create());
+        var counts = await page.RunOnLoopAsync(engine =>
+        {
+            var document = PageRuntime.Find(engine)!.Document!;
+            var styles = new CountingStyles(document.DefaultView!.GetStyleCollection(document.Context.GetService<IRenderDevice>()!));
+            var traversal = new CssCascade.Traversal(styles);
+            var elements = document.All.ToArray();
+            foreach (var element in elements)
+            {
+                traversal.Of(element).Should().NotBeNull("the cascade for {0} must answer", element.LocalName);
+            }
+
+            var scopedMatches = styles.Matches;
+            styles.Matches = 0;
+            foreach (var element in elements)
+            {
+                styles.ComputeDeclarations(element);
+            }
+
+            return (Elements: elements.Length, Scoped: scopedMatches, Legacy: styles.Matches);
+        });
+        counts.Scoped.Should().Be(counts.Elements);
+        counts.Legacy.Should().BeGreaterThan(counts.Scoped * 8);
+        TestContext.Out.WriteLine($"Admin form: {counts.Elements} elements; {counts.Legacy} legacy selector passes, {counts.Scoped} scoped passes.");
+    }
+
+    [Test]
+    public async Task EachLayoutBuildsOneStyleCollectionAndDoesNotKeepItForTheNextQuery()
+    {
+        using var defaults = BrowsingContext.New(Configuration.Default.WithCss());
+        var provider = new CountingProvider(defaults.GetService<ICssDefaultStyleSheetProvider>()!);
+        using var context = BrowsingContext.New(Configuration.Default.WithCss().With(provider));
+        using var document = await context.OpenAsync(response => response.Content(
+            "<div><div><div><button>Save</button></div></div></div>"));
+        var visibility = new ElementVisibility(useComputedStyle: true);
+        provider.Reads = 0;
+
+        FlatLayout.Of(document, visibility, 1280, 720, 0).Count.Should().Be(6);
+        provider.Reads.Should().Be(1, "all elements in a layout share its style collection");
+        document.QuerySelector("button")!.SetAttribute("hidden", "");
+        FlatLayout.Of(document, visibility, 1280, 720, 0).Count.Should().Be(5);
+        provider.Reads.Should().Be(2, "the next query must read the sheets again");
+    }
+
+    [TestCase(8)]
+    [TestCase(32)]
+    public async Task SelectorsAreMatchedOncePerElementRatherThanOncePerAncestorPerElement(int depth)
+    {
+        using var context = BrowsingContext.New(Configuration.Default.WithCss());
+        // Bootstrap declares this inherited custom-property token at the root; it must not send every
+        // descendant back through the explicit-inherit compatibility fallback.
+        using var document = await context.OpenAsync(response => response.Content(
+            "<style>:root{--colour:red;--bs-heading-color:inherit} div{color:var(--colour)}</style>"
+            + string.Concat(Enumerable.Repeat("<div>", depth)) + "<button>Save</button>"
+            + string.Concat(Enumerable.Repeat("</div>", depth))));
+        var styles = new CountingStyles(document.DefaultView!.GetStyleCollection(new DefaultRenderDevice()));
+        var traversal = new CssCascade.Traversal(styles);
+        var elements = document.All.ToArray();
+
+        foreach (var element in elements)
+        {
+            traversal.Of(element).Should().NotBeNull();
+        }
+
+        styles.Matches.Should().Be(elements.Length);
+
+        // The old per-element API rematches every ancestor. Count work, not elapsed time.
+        styles.Matches = 0;
+        foreach (var element in elements)
+        {
+            styles.ComputeDeclarations(element);
+        }
+
+        styles.Matches.Should().Be(elements.Sum(element => 1 + element.GetAncestors().OfType<IElement>().Count()));
+        styles.Matches.Should().BeGreaterThan(elements.Length * 3);
+    }
+
+    [Test]
+    public async Task ReusingRawParentDeclarationsPreservesTheExistingComputedCascade()
+    {
+        using var context = BrowsingContext.New(Configuration.Default.WithCss());
+        using var document = await context.OpenAsync(response => response.Content(
+            """
+            <style>
+              :root { --colour: red; --extent: 10px; --heading-colour: inherit; color: green; font-size: 16px; text-align: inherit }
+              body { visibility: hidden; width: 40px }
+              .outer { --colour: blue; color: var(--colour); width: var(--extent); font-size: 2em }
+              .inner { --extent: 20px; visibility: visible; color: inherit; font-size: 1.5em }
+              .inner > span { width: inherit; display: inline !important }
+              span { display: none; color: purple }
+              @media (min-width: 1px) { button { display: block } }
+            </style>
+            <div class="outer"><div class="inner"><span style="color:orange">text</span><button>Save</button></div></div>
+            <p style="visibility:visible">sibling</p>
+            """));
+        var styles = document.DefaultView!.GetStyleCollection(new DefaultRenderDevice());
+        var traversal = new CssCascade.Traversal(styles);
+
+        // Start with a leaf too: callers need not have visited every ancestor first.
+        foreach (var element in document.All.Reverse())
+        {
+            var expected = styles.ComputeDeclarations(element);
+            var actual = traversal.Of(element);
+            actual.Should().NotBeNull();
+            actual!.Select(property => (property.Name, property.Value, property.IsImportant))
+                .Should().BeEquivalentTo(expected.Select(property => (property.Name, property.Value, property.IsImportant)));
+        }
+    }
+
+    private sealed class CountingStyles(IStyleCollection inner) : IStyleCollection
+    {
+        public IRenderDevice Device => inner.Device;
+        internal int Matches { get; set; }
+
+        public IEnumerator<ICssStyleRule> GetEnumerator()
+        {
+            Matches++;
+            return inner.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class CountingProvider(ICssDefaultStyleSheetProvider inner) : ICssDefaultStyleSheetProvider
+    {
+        internal int Reads { get; set; }
+
+        public ICssStyleSheet Default
+        {
+            get
+            {
+                Reads++;
+                return inner.Default;
+            }
+        }
+
+        public void SetDefault(ICssStyleSheet? sheet) => inner.SetDefault(sheet);
+        public void SetDefault(string source) => inner.SetDefault(source);
+        public void AppendDefault(string source) => inner.AppendDefault(source);
+    }
+}

--- a/Jint.Tests.Browser/Layout/FlatLayoutTests.cs
+++ b/Jint.Tests.Browser/Layout/FlatLayoutTests.cs
@@ -1,4 +1,5 @@
 using Jint.Browser;
+using Jint.Browser.Runtime;
 
 namespace Jint.Tests.Browser.Layout;
 
@@ -21,6 +22,95 @@ namespace Jint.Tests.Browser.Layout;
 public class FlatLayoutTests
 {
     private const int Row = 16;
+
+    [Test]
+    public async Task AFailedRootComputationDoesNotForgetThatTheCascadePreviouslyAnswered()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<style>.gone { display: none }</style><button class='gone' id='target'>Save</button>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const target = document.getElementById('target');
+              const before = target.getBoundingClientRect().height;
+              document.documentElement.style.width = '20ch';
+              return before + ',' + target.getBoundingClientRect().height;
+            })()
+            """)).Should().Be("0,0");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [TestCase("target.classList.add('gone')")]
+    [TestCase("target.style.display = 'none'")]
+    [TestCase("target.hidden = true")]
+    [TestCase("document.body.setAttribute('data-hide', '')")]
+    [TestCase("document.querySelector('style').textContent = '.target { display: none }'")]
+    [TestCase("document.styleSheets[0].insertRule('.target { display: none }', 0)")]
+    [TestCase("document.styleSheets[0].cssRules[0].selectorText = '.target'")]
+    [TestCase("document.getElementById('trigger').addEventListener('focus', () => target.style.display = 'none'); document.getElementById('trigger').focus()")]
+    [TestCase("document.getElementById('trigger').checked = true")]
+    [TestCase("document.getElementById('hidden-parent').appendChild(target)")]
+    public async Task ANewQuerySeesMutationsAndControlStateWithinTheSameTurn(string mutation)
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <style>
+              .unmatched { display: none }
+              .gone, [data-hide] .target, input:focus ~ .target, input:checked ~ .target { display: none }
+            </style>
+            <input id="trigger" type="checkbox"><button id="target" class="target">Save</button>
+            <div id="hidden-parent" hidden></div>
+            """);
+
+        (await page.EvaluateAsync<string>(
+            $$"""
+            (() => {
+              const target = document.getElementById('target');
+              const before = target.getBoundingClientRect().height;
+              {{mutation}};
+              return before + ',' + target.getBoundingClientRect().height;
+            })()
+            """)).Should().Be("16,0");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ANewQuerySeesRuleDeletionAndViewportChanges()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <style>
+              button { display: none }
+              @media (max-width: 600px) { button { display: none } }
+            </style>
+            <button id="target">Save</button>
+            """);
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const target = document.getElementById('target');
+              const before = target.getBoundingClientRect().height;
+              document.styleSheets[0].deleteRule(0);
+              return before + ',' + target.getBoundingClientRect().height;
+            })()
+            """)).Should().Be("0,16");
+
+        (await page.RunOnLoopAsync(engine =>
+        {
+            var runtime = PageRuntime.Find(engine)!;
+            var before = runtime.Layout.Current().Count;
+            runtime.SetViewport(new Viewport(400, 800));
+            return before - runtime.Layout.Current().Count;
+        })).Should().Be(1);
+        page.Errors.Should().BeEmpty();
+    }
 
     [Test]
     public async Task EveryRenderedElementOwnsOneRowAndAContainerSpansItsSubtree()


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

<!-- One short sentence (under 80 characters) describing the change. -->

Reuse CSS cascades within each flat-layout query to accelerate Playwright clicks.

## Details

<!--
- What changed and why
- Anything reviewers should pay extra attention to
- Notable implementation choices or trade-offs
-->

OrchardCore admin Save clicks over Playwright's CDP connection spent substantial time in CSS/layout work. Every element visited by `FlatLayout` independently computed its style, causing AngleSharp to rebuild style collections and rematch ancestor selectors repeatedly during actionability and geometry queries.

This shares one style collection and raw parent cascades within a synchronous layout traversal. AngleSharp still owns selector matching, specificity, inheritance, and value computation. Nothing is retained between queries, so same-turn DOM/CSSOM changes, focus-handler mutations, control state, and viewport changes remain fresh.

Two compatibility details matter: reuse raw declarations rather than computed values to preserve relative-length/custom-property behavior, and retain the legacy ancestor fallback for explicit `inherit` on non-inheritable properties. Bootstrap's inherited `--bs-heading-color: inherit` must not trigger that fallback. The document's existing cascade-availability history also survives individual computation failures.

The standalone reduction has no OrchardCore binary dependency and exercises an ordinary unforced CDP click submitting back to the same URL, exactly one POST, and an immediately readable success marker. Actual public CSS validation used all four admin stylesheets (451,706 bytes) from OrchardCMS/OrchardCore at `59dd4923007afb36220897b74524b608ee23e682`. No downloaded stylesheets are committed. The repro isolates the layout delay; it does not reproduce the original intermittent post-navigation retry, and this change does not alter CDP lifecycle behavior.

### Performance

Deterministic selector passes on the 598-element nested admin reduction fall from **7,193 to 598**. An integration regression also asserts one style collection per layout query and fresh collection creation on the next query.

Three alternating full-default-job BenchmarkDotNet pairs measured geometry queries:

| Pair | Before | After |
| --- | ---: | ---: |
| 1 | 69.681 ms | 13.651 ms |
| 2 | 66.634 ms | 13.687 ms |
| 3 | 68.795 ms | 13.298 ms |

Final-code confirmation: **13.431 ms**; allocations: **47.59 MB to 27.51 MB**. These are advisory shared-machine measurements, not performance gates; background CPU warnings occurred, and two baseline runs had minimum-iteration-time warnings.

Separately, diagnostic unforced clicks with the actual public CSS improved from **12.37 s to 1.52 s on net10**; the final net8 run took **1.81 s**. Both final runs completed with one POST and no page errors. Regression assertions use work counts and behavior, not machine-sensitive timing thresholds.

## Linked issue

<!-- Use "Fixes #1234" or "Closes #1234" so the issue is auto-closed on merge. For discussion-only changes use "Refs #1234". -->

N/A

## Test plan

- [ ] Added or updated unit tests in `Jint.Tests` - N/A; regression coverage is in `Jint.Tests.Browser`.
- [x] Ran `dotnet test --configuration Release` locally - targeted projects and filters on net8/net10, not the full solution or WPT corpus.
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions - N/A.
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` - N/A.
- [x] For perf changes: included before/after numbers from `Jint.Benchmark`.

| Final Release validation | net8.0 | net10.0 |
| --- | ---: | ---: |
| Relevant browser/CDP/direct-Playwright/DOM-staleness suite | 621 passed | 622 passed |
| Same suite with host-contract verification enabled | 621 passed | 622 passed |
| Protocol generation staleness and manifest tests | 11 passed | 11 passed |
| Agent instruction-file checks | 5 passed | 5 passed |
| Final targeted cascade-counter tests | 5 passed | 5 passed |

No failures or skips. Coverage includes raw-cascade parity, explicit inheritance, variables, relative lengths, importance, same-turn DOM/CSSOM changes, checked state, focus-handler mutations, reparenting, viewport changes, and cascade-failure history.

## Breaking change?

<!-- Yes / No. If yes, describe the public-API impact and any migration steps. -->

No. No public API or dependency changes; reuse is scoped to one layout query.