### PR TITLE
Fix accessible names from associated labels

### DIFF
--- a/Jint.Browser/Accessibility/AccessibleName.cs
+++ b/Jint.Browser/Accessibility/AccessibleName.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using Jint.Browser.Dom;
 
 namespace Jint.Browser.Accessibility;
 
@@ -104,8 +105,8 @@ internal sealed class AccessibleName
 
         try
         {
-            // Step 2A. A hidden node contributes nothing unless it is the direct target of the reference
-            // that reached it, which is what makes an off-screen <span id="label" hidden> a legal label.
+            // Step 2A. A hidden node contributes nothing unless it is the direct target of the ARIA or
+            // native host-language reference that reached it.
             if (!referenced && _visibility.ReasonFor(element) != AxIgnoredReason.None)
             {
                 return string.Empty;
@@ -309,27 +310,14 @@ internal sealed class AccessibleName
     private string LabelElements(IElement element, Context context)
     {
         var builder = new StringBuilder();
-
-        var id = element.Id;
-        var document = element.Owner;
-        if (!string.IsNullOrEmpty(id) && document is not null)
+        if (element is not IHtmlElement control)
         {
-            foreach (var candidate in document.QuerySelectorAll("label[for]"))
-            {
-                if (string.Equals(candidate.GetAttribute("for"), id, StringComparison.Ordinal))
-                {
-                    Append(builder, FromElement(candidate, AriaRoles.Generic, context, referenced: false, descendant: true));
-                }
-            }
+            return string.Empty;
         }
 
-        for (var ancestor = element.ParentElement; ancestor is not null; ancestor = ancestor.ParentElement)
+        foreach (var label in HtmlLabelAssociation.LabelsFor(control))
         {
-            if (string.Equals(ancestor.LocalName, "label", StringComparison.Ordinal) && !ancestor.HasAttribute("for"))
-            {
-                Append(builder, FromElement(ancestor, AriaRoles.Generic, context, referenced: false, descendant: true));
-                break;
-            }
+            Append(builder, FromElement(label, AriaRoles.Generic, context, referenced: true, descendant: true));
         }
 
         return Flatten(builder.ToString());

--- a/Jint.Browser/Dom/Collections/DomLabelNodeList.cs
+++ b/Jint.Browser/Dom/Collections/DomLabelNodeList.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using AngleSharp;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace Jint.Browser.Dom.Collections;
+
+/// <summary>The live <c>NodeList</c> returned by a labelable element's <c>labels</c> attribute.</summary>
+internal sealed class DomLabelNodeList : INodeList
+{
+    private readonly IHtmlElement _control;
+
+    internal DomLabelNodeList(IHtmlElement control) => _control = control;
+
+    public int Length => HtmlLabelAssociation.LabelsFor(_control).Count;
+
+    public INode this[int index]
+    {
+        get
+        {
+            var labels = HtmlLabelAssociation.LabelsFor(_control);
+            return (uint) index < (uint) labels.Count ? labels[index] : null!;
+        }
+    }
+
+    public IEnumerator<INode> GetEnumerator()
+    {
+        foreach (var label in HtmlLabelAssociation.LabelsFor(_control))
+        {
+            yield return label;
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public void ToHtml(TextWriter writer, IMarkupFormatter formatter)
+    {
+        foreach (var label in HtmlLabelAssociation.LabelsFor(_control))
+        {
+            label.ToHtml(writer, formatter);
+        }
+    }
+}

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -121,6 +121,14 @@ internal class DomHostHooks
     internal virtual JsValue Dataset(DomRealm realm, IHtmlElement element)
         => realm.WrapStringMap(element, element.Dataset);
 
+    /// <summary>https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels</summary>
+    internal virtual JsValue Labels(DomRealm realm, IHtmlElement element)
+        => HtmlLabelAssociation.IsLabelable(element) ? realm.WrapLabels(element) : JsValue.Null;
+
+    /// <summary>https://html.spec.whatwg.org/multipage/forms.html#dom-label-control</summary>
+    internal virtual JsValue LabelControl(DomRealm realm, IHtmlLabelElement label)
+        => realm.WrapNodeValue(HtmlLabelAssociation.ControlFor(label));
+
     /// <summary>https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-insertadjacenthtml</summary>
     /// <remarks>
     /// <para>

--- a/Jint.Browser/Dom/DomRealm.cs
+++ b/Jint.Browser/Dom/DomRealm.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
 using Jint.Browser.Dom.Collections;
 using Jint.Native;
 using Jint.Native.Object;
@@ -261,6 +262,13 @@ internal sealed class DomRealm
 
         var target = new DomStaticNodeList(nodes);
         return Cache(nodes, new DomCollectionObject(this, DomInterfaces.NodeList, target, DomAccessorNodeList.Instance));
+    }
+
+    /// <summary>Projects the live <c>NodeList</c> of labels associated with a labelable element.</summary>
+    internal JsValue WrapLabels(IHtmlElement control)
+    {
+        var labels = new DomLabelNodeList(control);
+        return Cache(labels, new DomCollectionObject(this, DomInterfaces.NodeList, labels, DomAccessorNodeList.Instance));
     }
 
     /// <summary>Projects an element's <c>dataset</c> through HTML's name conversion algorithms.</summary>

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -1138,7 +1138,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlButtonElement>(thisObj, "HTMLButtonElement.labels");
-                    return self.Realm.Wrap(self.Target.Labels);
+                    return self.Realm.Hooks.Labels(self.Realm, self.Target);
                 }))
             .Accessor("name",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLButtonElement.name", static (thisObj, args) =>
@@ -2267,7 +2267,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.labels");
-                    return self.Realm.Wrap(self.Target.Labels);
+                    return self.Realm.Hooks.Labels(self.Realm, self.Target);
                 }))
             .Accessor("list",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.list", static (thisObj, args) =>
@@ -2695,7 +2695,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLLabelElement.control", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlLabelElement>(thisObj, "HTMLLabelElement.control");
-                    return self.Realm.WrapNodeValue(self.Target.Control);
+                    return self.Realm.Hooks.LabelControl(self.Realm, self.Target);
                 }))
             .Accessor("form",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLLabelElement.form", static (thisObj, args) =>
@@ -3140,7 +3140,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMeterElement>(thisObj, "HTMLMeterElement.labels");
-                    return self.Realm.Wrap(self.Target.Labels);
+                    return self.Realm.Hooks.Labels(self.Realm, self.Target);
                 }))
             .Accessor("low",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMeterElement.low", static (thisObj, args) =>
@@ -3603,7 +3603,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlOutputElement>(thisObj, "HTMLOutputElement.labels");
-                    return self.Realm.Wrap(self.Target.Labels);
+                    return self.Realm.Hooks.Labels(self.Realm, self.Target);
                 }))
             .Accessor("name",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLOutputElement.name", static (thisObj, args) =>
@@ -3719,7 +3719,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLProgressElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlProgressElement>(thisObj, "HTMLProgressElement.labels");
-                    return self.Realm.Wrap(self.Target.Labels);
+                    return self.Realm.Hooks.Labels(self.Realm, self.Target);
                 }))
             .Accessor("max",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLProgressElement.max", static (thisObj, args) =>
@@ -3948,7 +3948,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlSelectElement>(thisObj, "HTMLSelectElement.labels");
-                    return self.Realm.Wrap(self.Target.Labels);
+                    return self.Realm.Hooks.Labels(self.Realm, self.Target);
                 }))
             .Accessor("length",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLSelectElement.length", static (thisObj, args) =>
@@ -4607,7 +4607,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.labels", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTextAreaElement>(thisObj, "HTMLTextAreaElement.labels");
-                    return self.Realm.Wrap(self.Target.Labels);
+                    return self.Realm.Hooks.Labels(self.Realm, self.Target);
                 }))
             .Accessor("maxLength",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLTextAreaElement.maxLength", static (thisObj, args) =>

--- a/Jint.Browser/Dom/HtmlLabelAssociation.cs
+++ b/Jint.Browser/Dom/HtmlLabelAssociation.cs
@@ -1,0 +1,148 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>HTML's association between a <c>label</c> and its labeled control.</summary>
+internal static class HtmlLabelAssociation
+{
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/forms.html#labeled-control — the control a label labels.
+    /// </summary>
+    internal static IHtmlElement? ControlFor(IHtmlLabelElement label)
+    {
+        if (label.HasAttribute("for"))
+        {
+            var id = label.GetAttribute("for") ?? string.Empty;
+            return id.Length > 0 && FirstElementWithId(RootOf(label), id) is IHtmlElement html && IsLabelable(html)
+                ? html
+                : null;
+        }
+
+        return FirstLabelableDescendant(label);
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels — the labels whose labeled control is
+    /// <paramref name="control"/>, in tree order.
+    /// </summary>
+    internal static List<IHtmlLabelElement> LabelsFor(IHtmlElement control)
+    {
+        var labels = new List<IHtmlLabelElement>();
+        if (!IsLabelable(control))
+        {
+            return labels;
+        }
+
+        var root = RootOf(control);
+        var id = control.HasAttribute("id") ? control.Id ?? string.Empty : string.Empty;
+        var isFirstWithId = id.Length > 0 && ReferenceEquals(FirstElementWithId(root, id), control);
+
+        foreach (var node in InclusiveDescendants(root))
+        {
+            if (node is not IHtmlLabelElement label)
+            {
+                continue;
+            }
+
+            if (label.HasAttribute("for"))
+            {
+                if (isFirstWithId && string.Equals(label.GetAttribute("for"), id, StringComparison.Ordinal))
+                {
+                    labels.Add(label);
+                }
+            }
+            else if (IsAncestorOf(label, control) && ReferenceEquals(FirstLabelableDescendant(label), control))
+            {
+                labels.Add(label);
+            }
+        }
+
+        return labels;
+    }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/forms.html#category-label — the seven labelable element kinds.
+    /// A hidden input is the one exception the list carries with it.
+    /// </summary>
+    internal static bool IsLabelable(IHtmlElement element) => element switch
+    {
+        IHtmlInputElement input => !string.Equals(input.Type, "hidden", StringComparison.OrdinalIgnoreCase),
+        IHtmlButtonElement or IHtmlSelectElement or IHtmlTextAreaElement => true,
+        _ => element.LocalName is "meter" or "output" or "progress",
+    };
+
+    private static IElement? FirstElementWithId(INode root, string id)
+    {
+        foreach (var node in InclusiveDescendants(root))
+        {
+            if (node is IElement candidate
+                && candidate.HasAttribute("id")
+                && string.Equals(candidate.Id, id, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static IHtmlElement? FirstLabelableDescendant(INode root)
+    {
+        foreach (var node in Descendants(root))
+        {
+            if (node is IHtmlElement candidate && IsLabelable(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsAncestorOf(INode ancestor, INode node)
+    {
+        for (var parent = node.Parent; parent is not null; parent = parent.Parent)
+        {
+            if (ReferenceEquals(parent, ancestor))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static INode RootOf(INode node)
+    {
+        while (node.Parent is { } parent)
+        {
+            node = parent;
+        }
+
+        return node;
+    }
+
+    private static IEnumerable<INode> InclusiveDescendants(INode root)
+    {
+        yield return root;
+
+        foreach (var descendant in Descendants(root))
+        {
+            yield return descendant;
+        }
+    }
+
+    private static IEnumerable<INode> Descendants(INode root)
+    {
+        foreach (var child in root.ChildNodes)
+        {
+            yield return child;
+
+            foreach (var descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/Jint.Browser/Dom/divergences.md
+++ b/Jint.Browser/Dom/divergences.md
@@ -39,8 +39,8 @@ here:
 | the computed style is writable | CSSOM's computed flag makes every write a `NoModificationAllowedError` | an ordinary writable declaration, and a detached one, so a write neither throws nor changes anything readable — see `Dom/Views/ReadOnlyStyleDeclaration` |
 | `el.click()` on a checkbox, radio, `<summary>` or `<a href>` | the element's activation behaviour runs | `DoClick` dispatches on AngleSharp's own bus and runs **no activation behaviour at all**, with or without a browsing context: nothing toggles, opens or navigates |
 | `document.activeElement` | the focused element, or the body | `null` for the life of every document — nothing in AngleSharp ever assigns it, `DoFocus()` included |
-| `input.labels` | the `<label>`s whose `for` names the control | an empty collection |
-| `label.control` | the labeled control: the `for` target, or the first labelable **descendant** | `null` for a control the label contains, which is the commoner spelling; `Events/ActivationBehaviors` computes it instead so a click inside a wrapping label reaches its checkbox |
+| `input.labels` | every `<label>` whose labeled control is the input, in tree order | an empty collection. No longer reached directly: `HtmlLabelAssociation` supplies the live `NodeList` shared by the bindings and accessible-name computation |
+| `label.control` | the labeled control: the `for` target, or the first labelable **descendant** | `null` for a control the label contains, which is the commoner spelling. No longer reached directly: `HtmlLabelAssociation` supplies the binding and label activation |
 | `select.selectedIndex` with no `selected` option | 0 — the selectedness-setting algorithm picks the first option of a non-`multiple`, display-size-1 select | −1 |
 | `input.value = …` | the cursor moves to the end and the selection is dropped | `SelectionStart`/`SelectionEnd` are left where they were, so they can point past the end of the new value |
 | `input.setSelectionRange` on a `type=checkbox` | `InvalidStateError` — the type does not support selection | answers, so the type test has to be the caller's |

--- a/Jint.Browser/Events/ActivationBehaviors.cs
+++ b/Jint.Browser/Events/ActivationBehaviors.cs
@@ -260,7 +260,7 @@ internal static class ActivationBehaviors
     /// </remarks>
     private static void RunLabel(DomNodeObject wrapper, IHtmlLabelElement label, JsEvent ev)
     {
-        if (LabeledControl(label) is not { } control)
+        if (HtmlLabelAssociation.ControlFor(label) is not { } control)
         {
             return;
         }
@@ -440,46 +440,6 @@ internal static class ActivationBehaviors
         "audio" or "video" => element.HasAttribute("controls"),
         "img" or "object" => element.HasAttribute("usemap"),
         _ => false,
-    };
-
-    /// <summary>
-    /// https://html.spec.whatwg.org/multipage/forms.html#labeled-control — the control a <c>&lt;label&gt;</c>
-    /// labels: the element its <c>for</c> attribute names, and otherwise the first labelable descendant.
-    /// </summary>
-    /// <remarks>
-    /// Computed rather than read off AngleSharp, whose <c>IHtmlLabelElement.Control</c> answers
-    /// <see langword="null"/> for a control the label <i>contains</i> — which is the commoner of the two
-    /// spellings and the one <c>&lt;label&gt;&lt;input type=checkbox&gt;&lt;span&gt;text&lt;/span&gt;&lt;/label&gt;</c>
-    /// uses. It is recorded as an AngleSharp divergence in <c>Jint.Browser/Dom/AGENTS.md</c> beside
-    /// <c>input.labels</c>, which is the same gap seen from the other end.
-    /// </remarks>
-    private static IHtmlElement? LabeledControl(IHtmlLabelElement label)
-    {
-        if (label.GetAttribute("for") is { Length: > 0 } id)
-        {
-            return label.Owner?.GetElementById(id) is IHtmlElement named && IsLabelable(named) ? named : null;
-        }
-
-        foreach (var descendant in label.QuerySelectorAll("button, input, meter, output, progress, select, textarea"))
-        {
-            if (descendant is IHtmlElement candidate && IsLabelable(candidate))
-            {
-                return candidate;
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// https://html.spec.whatwg.org/multipage/forms.html#category-label — the seven labelable element kinds.
-    /// A hidden input is the one exception the list carries with it.
-    /// </summary>
-    private static bool IsLabelable(IHtmlElement element) => element switch
-    {
-        IHtmlInputElement input => !IsType(input, "hidden"),
-        IHtmlButtonElement or IHtmlSelectElement or IHtmlTextAreaElement => true,
-        _ => element.LocalName is "meter" or "output" or "progress",
     };
 
     /// <summary>

--- a/Jint.Tests.Browser/Accessibility/AccessibleNameTests.cs
+++ b/Jint.Tests.Browser/Accessibility/AccessibleNameTests.cs
@@ -26,8 +26,13 @@ public sealed class AccessibleNameTests
         yield return Case("<label for=t>Full name</label><input id=t>", "Full name");
         yield return Case("<label>Full name <input id=t></label>", "Full name");
         yield return Case("<label for=t>A</label><label for=t>B</label><input id=t>", "A B");
+        yield return Case("<label for=t hidden>Hidden</label><label for=t>Visible</label><input id=t>", "Hidden Visible");
+        yield return Case("<label for=t aria-hidden=true>Hidden</label><label for=t>Visible</label><input id=t>", "Hidden Visible");
+        yield return Case("<label for=t style='display:none'>Hidden</label><label for=t>Visible</label><input id=t>", "Hidden Visible");
         yield return Case("<input id=t placeholder='Search the docs'>", "Search the docs");
         yield return Case("<label for=t>Query</label><input id=t placeholder='Search'>", "Query");
+        yield return Case("<label for=t>Native</label><input id=t aria-label='ARIA label'>", "ARIA label");
+        yield return Case("<span id=a hidden>Referenced</span><label for=t>Native</label><input id=t aria-labelledby=a aria-label='ARIA label'>", "Referenced");
         yield return Case("<input id=t type=submit>", "Submit");
         yield return Case("<input id=t type=submit value='Send it'>", "Send it");
         yield return Case("<input id=t type=reset>", "Reset");

--- a/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
+++ b/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
@@ -116,6 +116,44 @@ public class PlaywrightCourseTests
         await page.CloseAsync();
     }
 
+    /// <summary>Role locators derive textbox names from HTML's label association.</summary>
+    [Test]
+    public async Task PlaywrightGetByRoleUsesAssociatedLabels()
+    {
+        await using var lane = await ClientLane.OpenAsync(server => server.MapHtml(
+            "/associated-labels/index.html",
+            """
+            <!doctype html>
+            <html><body>
+            <label for="explicit">Explicit</label><input id="explicit">
+            <label>Wrapped <input id="wrapped"></label>
+            <label for="multiple">First</label>
+            <label for="multiple" hidden>Hidden</label>
+            <label for="multiple">Second</label>
+            <input id="multiple">
+            <label for="aria">Native</label><input id="aria" aria-label="ARIA">
+            <span id="referenced" hidden>Referenced</span>
+            <label for="labelledby">Native</label>
+            <input id="labelledby" aria-label="ARIA" aria-labelledby="referenced">
+            </body></html>
+            """));
+        var page = await lane.NewPageAsync("associated-labels");
+
+        (await page.GetByRole(AriaRole.Textbox).CountAsync()).Should().Be(5);
+        (await NamedTextboxCount("Explicit")).Should().Be(1);
+        (await NamedTextboxCount("Wrapped")).Should().Be(1);
+        (await NamedTextboxCount("First Hidden Second")).Should().Be(1);
+        (await NamedTextboxCount("ARIA")).Should().Be(1);
+        (await NamedTextboxCount("Referenced")).Should().Be(1);
+
+        await page.CloseAsync();
+
+        async Task<int> NamedTextboxCount(string name)
+            => await page.GetByRole(
+                AriaRole.Textbox,
+                new PageGetByRoleOptions { Name = name, Exact = true }).CountAsync();
+    }
+
     /// <summary>The router, and the emulated colour scheme the page reads through <c>matchMedia</c>.</summary>
     [Test]
     public async Task PlaywrightMovesThroughTheRouterAndEmulatesTheColourScheme()

--- a/Jint.Tests.Browser/Dom/LabelAssociationTests.cs
+++ b/Jint.Tests.Browser/Dom/LabelAssociationTests.cs
@@ -1,0 +1,78 @@
+namespace Jint.Tests.Browser.Dom;
+
+/// <summary>HTML's shared association between labels and labelable form controls.</summary>
+public sealed class LabelAssociationTests
+{
+    private const string Page = """
+        <!doctype html>
+        <html><body>
+        <label id="first" for="named">First</label>
+        <label id="hidden" for="named" hidden>Hidden</label>
+        <input id="named">
+        <label id="second" for="named">Second</label>
+        <label id="wrapped">Wrapped <input id="inside"></label>
+        <label id="empty" for="">Not wrapped <input id="not-associated"></label>
+        </body></html>
+        """;
+
+    [Test]
+    public void LabelsReturnsExplicitAndWrappingLabelsInTreeOrder()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            (function () {
+              const explicit = Array.from(document.getElementById('named').labels, x => x.id).join(',');
+              const wrapped = Array.from(document.getElementById('inside').labels, x => x.id).join(',');
+              const empty = document.getElementById('not-associated').labels.length;
+              return [explicit, wrapped, empty].join('|');
+            })()
+            """).Should().Be("first,hidden,second|wrapped|0");
+    }
+
+    [Test]
+    public void LabelControlUsesForOrTheFirstLabelableDescendant()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            (function () {
+              return [
+                document.getElementById('first').control.id,
+                document.getElementById('wrapped').control.id,
+                String(document.getElementById('empty').control),
+              ].join('|');
+            })()
+            """).Should().Be("named|inside|null");
+    }
+
+    [Test]
+    public void LabelsIsALiveNodeList()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            (function () {
+              const input = document.getElementById('named');
+              const labels = input.labels;
+              const before = labels.length;
+              document.getElementById('second').htmlFor = 'inside';
+              return [before, labels.length, labels.item(1).id].join('|');
+            })()
+            """).Should().Be("3|2|hidden");
+    }
+
+    [Test]
+    public void AHiddenInputHasNoLabelsNodeList()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Text("""
+            (function () {
+              const input = document.createElement('input');
+              input.type = 'hidden';
+              return String(input.labels);
+            })()
+            """).Should().Be("null");
+    }
+}

--- a/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
+++ b/Jint.Tests.Browser/Events/ActivationBehaviorTests.cs
@@ -518,8 +518,8 @@ public sealed class ActivationBehaviorTests
     /// </summary>
     /// <remarks>
     /// The containing spelling is the one AngleSharp cannot answer — its <c>IHtmlLabelElement.Control</c> is
-    /// <see langword="null"/> for a control the label wraps — so the labeled control is computed here, and
-    /// this is what holds it to the two spellings and to the labelable-element list.
+    /// <see langword="null"/> for a control the label wraps — so the shared label-association algorithm
+    /// supplies it, and this holds activation to the same answer the DOM and accessibility paths use.
     /// </remarks>
     [Test]
     public async Task ClickingInsideALabelForwardsToTheControlItLabels()

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -1365,6 +1365,62 @@
       "reason": "HTML 3.2.6 maps DOMStringMap property names between camelCase and data-* attribute names and defines its own SyntaxError and InvalidCharacterError checks. AngleSharp's IStringMap instead accepts raw attribute suffixes, rejects uppercase ASCII, and leaves a removed attribute behind with a null value, so the binding supplies the standards-shaped map over the associated element."
     },
     {
+      "interface": "HTMLButtonElement",
+      "member": "labels",
+      "half": "getter",
+      "hook": "Labels",
+      "reason": "HTML 4.10.6 gives every labelable element a live NodeList of the labels whose labeled control it is. AngleSharp returns an empty collection for explicit for/id associations, so the shared HTML association algorithm supplies the value."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "labels",
+      "half": "getter",
+      "hook": "Labels",
+      "reason": "The input half of the labelable-element labels attribute, and the association Playwright's accessible-name computation reads."
+    },
+    {
+      "interface": "HTMLMeterElement",
+      "member": "labels",
+      "half": "getter",
+      "hook": "Labels",
+      "reason": "The meter half of the labelable-element labels attribute."
+    },
+    {
+      "interface": "HTMLOutputElement",
+      "member": "labels",
+      "half": "getter",
+      "hook": "Labels",
+      "reason": "The output half of the labelable-element labels attribute."
+    },
+    {
+      "interface": "HTMLProgressElement",
+      "member": "labels",
+      "half": "getter",
+      "hook": "Labels",
+      "reason": "The progress half of the labelable-element labels attribute."
+    },
+    {
+      "interface": "HTMLSelectElement",
+      "member": "labels",
+      "half": "getter",
+      "hook": "Labels",
+      "reason": "The select half of the labelable-element labels attribute."
+    },
+    {
+      "interface": "HTMLTextAreaElement",
+      "member": "labels",
+      "half": "getter",
+      "hook": "Labels",
+      "reason": "The textarea half of the labelable-element labels attribute."
+    },
+    {
+      "interface": "HTMLLabelElement",
+      "member": "control",
+      "half": "getter",
+      "hook": "LabelControl",
+      "reason": "HTML 4.10.4 resolves a label's explicit for target or first labelable descendant. AngleSharp returns null for the wrapping-label form, so the shared HTML association algorithm supplies the value."
+    },
+    {
       "interface": "Document",
       "member": "currentScript",
       "half": "getter",


### PR DESCRIPTION
## Summary

Derive accessible names from associated HTML labels.

## Details

Playwright's injected role selector reads script-visible DOM APIs, but AngleSharp's native `labels` and `control` behavior does not cover all HTML label associations. This caused `GetByRole(AriaRole.Textbox, new() { Name = ... })` to miss textboxes named by associated labels.

This change adds a shared, standards-aligned label-association path used by DOM `labels`/`label.control`, accessible-name computation, and label activation. It supports explicit `for`/`id` labels, wrapping labels, multiple labels in tree order, hidden native label references, live label collections, and hidden-input nullability while preserving `aria-labelledby` and `aria-label` precedence. Generated bindings are wired through generator overrides rather than edited by hand.

## Linked issue

Fixes: #3850

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

Validated the full `Jint.Tests.Browser` suite on .NET 8 and .NET 10, including host-contract verification. The real Playwright-over-CDP regression passes on both frameworks, the standalone reproduction now finds the named textbox, and generated-binding staleness checks pass.

## Breaking change?

No.