### PR TITLE
Report ResizeObserver changes when hidden elements become visible

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -141,15 +141,21 @@ and nothing belonging to an engine — a `JsValue`, an AngleSharp node — may b
 - **`IntersectionObserver` and `ResizeObserver` deliver as a *task*** — a zero-delay timer entry
   (`ObserverTask`) — because both belong to update-the-rendering and a microtask would run before the promises
   of the same turn. It also makes the delivery visible to `Page.WaitForIdleAsync`.
-- **Both are stubs, and the shape of the lie is the point.** Each observed target is reported exactly once,
-  fully intersecting or at its own size, and never again, because nothing here can change what a box is.
-  "Never intersecting" would stop every lazy list and reveal-on-scroll animation dead, and the initial resize
-  notification is the one a component uses to measure itself when it mounts. `root`, `rootMargin` and
+- **`IntersectionObserver` reports each target exactly once**, fully intersecting.
+  "Never intersecting" would stop every lazy list and reveal-on-scroll animation dead. `root`, `rootMargin` and
   `thresholds` are parsed, validated and reflected exactly as the specification says and change nothing.
   **The rectangles are real numbers now** — the flat box model gives every element a row, and an entry
   reports the target's own box through the same `Layout/DomRects` factory `getBoundingClientRect` answers
   from, so the two agree. They are still **plain objects, not `DOMRectReadOnly` instances**: the eight
   members are there and the interface object is not, and `Layout/DomRects` says what adding one would cost.
+- **`ResizeObserver` tracks changes in the flat model**, not just the initial size. A target mounted under
+  `display: none` must hear its later visible size, or a component that gates rendering on that measurement
+  stays empty forever. `ResizeObserverLane` checks at page-turn boundaries and in both nested pumps, shares
+  one layout per check/delivery, and schedules a task only for changed dimensions. No mutation observer is
+  installed: ancestor `classList`, CSSOM writes and viewport changes must work too. Idle wakes do not scan,
+  and a page with no resize observers allocates no lane. Entries retain measured sizes; the active list
+  retains observers only while they have targets. Callback-caused changes wait for another task rather than
+  running a depth-limited resize loop. All three box options still use the same synthetic dimensions.
 
 None of the five interface objects is generated, so they are hand-written `JsObjectShape`s behind
 `HostInterfaceObject`, and `Views/HostInterfaceDisciplineTests` holds them to the same two rules
@@ -277,7 +283,7 @@ never caches an engine, and a `JsValue` never leaves the page loop.
 
 ### The obstacle course, and what a red fixture means
 
-`Jint.Tests.Browser/Fixtures/` is eighteen offline pages built out of vendored libraries — TodoMVC on React,
+`Jint.Tests.Browser/Fixtures/` is nineteen offline pages built out of vendored libraries — TodoMVC on React,
 Vue 3, Preact and Svelte, React hydrating server markup, jQuery, htmx, Alpine, a `pushState` router, custom
 elements, an import map, `fetch`, a form that redirects, a cookie login, storage across navigations, both
 observers, dialogs — served over a real socket and driven through the public `Page` API. Four of them are

--- a/Jint.Browser/Observers/JsResizeObserver.cs
+++ b/Jint.Browser/Observers/JsResizeObserver.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using Jint.Browser.Dom;
+using Jint.Browser.Layout;
 using Jint.Browser.Runtime;
 using Jint.Native;
 using Jint.Native.Object;
@@ -8,32 +9,25 @@ using Jint.Runtime;
 namespace Jint.Browser.Observers;
 
 /// <summary>
-/// A <c>ResizeObserver</c> with no box to measure: every target it is given is reported once, at zero size.
+/// Reports changes to the sizes supplied by the page's flat box model.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>A stub, like <see cref="JsIntersectionObserver"/>, and for the same reason.</b>
-/// <a href="https://w3c.github.io/csswg-drafts/resize-observer/">Resize Observer</a> reports a box changing
-/// size, and there are no boxes. What matters to a page is the <em>initial</em> notification the specification
-/// requires — "observe() ... queues an initial observation" — because that is the one a component uses to
-/// measure itself when it mounts, and a component whose observer never fires never finishes mounting. So each
-/// observed target gets exactly one entry, delivered as a task after <c>observe()</c> returns, and nothing
-/// afterwards: with no layout, no size can change.
+/// The geometry is synthetic, but it changes when a target is shown, hidden, inserted or removed, when its
+/// rendered subtree changes, and when the viewport changes. Keeping the last reported size makes these
+/// changes observable without repeatedly reporting unchanged targets.
 /// </para>
 /// <para>
-/// The <c>box</c> option is read and ignored: the three box sizes an entry carries are the same zeros, so
-/// choosing between them would be a distinction without a difference. The flat-box model (campaign item C4)
-/// is what makes them different numbers.
+/// All three box sizes use the same flat dimensions; padding, borders and device-pixel scaling are not
+/// modeled. Entries retain their measured dimensions rather than consulting the current DOM on each read.
 /// </para>
 /// </remarks>
 internal sealed class JsResizeObserver : ObjectInstance
 {
     private readonly PageRuntime _runtime;
     private readonly ICallable _callback;
-    private readonly List<INode> _targets = [];
-    private readonly List<JsResizeObserverEntry> _queue = [];
+    private readonly List<Observation> _targets = [];
     private readonly ObjectInstance _entryPrototype;
-    private bool _scheduled;
 
     internal JsResizeObserver(PageRuntime runtime, ObjectInstance prototype, ObjectInstance entryPrototype, ICallable callback)
         : base(runtime.Engine)
@@ -56,14 +50,13 @@ internal sealed class JsResizeObserver : ObjectInstance
     {
         var target = Target(arguments, "observe");
 
-        if (_targets.Contains(target))
+        if (_targets.Exists(observation => ReferenceEquals(observation.Target, target)))
         {
             return JsValue.Undefined;
         }
 
-        _targets.Add(target);
-        _queue.Add(new JsResizeObserverEntry(_runtime, _entryPrototype, target));
-        Schedule();
+        _targets.Add(new Observation(target));
+        _runtime.ResizeObservers.Enlist(this);
         return JsValue.Undefined;
     }
 
@@ -71,8 +64,11 @@ internal sealed class JsResizeObserver : ObjectInstance
     internal JsValue Unobserve(JsValue[] arguments)
     {
         var target = Target(arguments, "unobserve");
-        _targets.Remove(target);
-        _queue.RemoveAll(entry => ReferenceEquals(entry.Node, target));
+        _targets.RemoveAll(observation => ReferenceEquals(observation.Target, target));
+        if (_targets.Count == 0)
+        {
+            _runtime.ResizeObservers.Withdraw(this);
+        }
         return JsValue.Undefined;
     }
 
@@ -80,41 +76,57 @@ internal sealed class JsResizeObserver : ObjectInstance
     internal JsValue Disconnect()
     {
         _targets.Clear();
-        _queue.Clear();
+        _runtime.ResizeObservers.Withdraw(this);
         return JsValue.Undefined;
     }
 
-    private void Schedule()
+    /// <summary>https://drafts.csswg.org/resize-observer/#dom-resizeobservation-isactive.</summary>
+    internal bool HasChanges(FlatLayout layout)
     {
-        if (_scheduled)
+        foreach (var observation in _targets)
         {
-            return;
+            var box = layout.ClientBoxOf(observation.Target) ?? FlatBox.Empty;
+            if (observation.Width != box.Width || observation.Height != box.Height)
+            {
+                return true;
+            }
         }
 
-        _scheduled = true;
-        ObserverTask.Post(_runtime, Deliver);
+        return false;
     }
 
-    private void Deliver()
+    /// <summary>https://drafts.csswg.org/resize-observer/#broadcast-resize-notifications-h.</summary>
+    internal void Deliver(FlatLayout layout)
     {
-        _scheduled = false;
+        List<JsValue>? entries = null;
+        foreach (var observation in _targets)
+        {
+            var box = layout.ClientBoxOf(observation.Target) ?? FlatBox.Empty;
+            if (observation.Width == box.Width && observation.Height == box.Height)
+            {
+                continue;
+            }
 
-        if (_queue.Count == 0)
+            observation.Width = box.Width;
+            observation.Height = box.Height;
+            (entries ??= []).Add(new JsResizeObserverEntry(_runtime, _entryPrototype, observation.Target, box));
+        }
+
+        if (entries is null)
         {
             return;
         }
-
-        var values = new JsValue[_queue.Count];
-        for (var i = 0; i < _queue.Count; i++)
-        {
-            values[i] = _queue[i];
-        }
-
-        _queue.Clear();
 
         try
         {
-            _callback.Call(this, [_runtime.Engine._mainRealm.Intrinsics.Array.ConstructFast(values), this]);
+            try
+            {
+                _callback.Call(this, [_runtime.Engine._mainRealm.Intrinsics.Array.ConstructFast(entries.ToArray()), this]);
+            }
+            finally
+            {
+                _runtime.Engine.CleanUpAfterRunningScript();
+            }
         }
         catch (JavaScriptException exception)
         {
@@ -125,7 +137,7 @@ internal sealed class JsResizeObserver : ObjectInstance
         }
     }
 
-    private INode Target(JsValue[] arguments, string member)
+    private IElement Target(JsValue[] arguments, string member)
     {
         if (arguments.At(0) is IDomWrapper { DomTarget: IElement element })
         {
@@ -137,6 +149,15 @@ internal sealed class JsResizeObserver : ObjectInstance
             "Failed to execute '" + member + "' on 'ResizeObserver': parameter 1 is not of type 'Element'.");
         return null!;
     }
+
+    private sealed class Observation(IElement target)
+    {
+        internal IElement Target { get; } = target;
+
+        // https://drafts.csswg.org/resize-observer/#dom-resizeobservation-resizeobservation-target-options
+        internal double Width { get; set; } = -1;
+        internal double Height { get; set; } = -1;
+    }
 }
 
 /// <summary>
@@ -145,11 +166,13 @@ internal sealed class JsResizeObserver : ObjectInstance
 internal sealed class JsResizeObserverEntry : ObjectInstance
 {
     private readonly PageRuntime _runtime;
+    private readonly FlatBox _box;
 
-    internal JsResizeObserverEntry(PageRuntime runtime, ObjectInstance prototype, INode node)
+    internal JsResizeObserverEntry(PageRuntime runtime, ObjectInstance prototype, INode node, FlatBox box)
         : base(runtime.Engine)
     {
         _runtime = runtime;
+        _box = new FlatBox(0, 0, box.Width, box.Height);
         Node = node;
         Prototype = prototype;
     }
@@ -164,25 +187,10 @@ internal sealed class JsResizeObserverEntry : ObjectInstance
     /// https://drafts.csswg.org/resize-observer/#dom-resizeobserverentry-contentrect — the target's own
     /// size, at the origin of its own padding box, which is where a content rectangle is measured from.
     /// </summary>
-    internal JsValue Rect()
-    {
-        var box = Box();
-        return Layout.DomRects.Of(Engine, new Layout.FlatBox(0, 0, box.Width, box.Height));
-    }
+    internal JsValue Rect() => DomRects.Of(Engine, _box);
 
     /// <summary>A fresh one-element array holding the target's own size.</summary>
-    internal JsValue BoxSizes()
-    {
-        var box = Box();
-        return ObserverGeometry.BoxSizes(Engine, box.Width, box.Height);
-    }
-
-    /// <summary>The target's box, or the empty one when it has none.</summary>
-    private Layout.FlatBox Box()
-    {
-        var box = Node is IElement element ? _runtime.Layout.Current().ClientBoxOf(element) : null;
-        return box ?? Layout.FlatBox.Empty;
-    }
+    internal JsValue BoxSizes() => ObserverGeometry.BoxSizes(Engine, _box.Width, _box.Height);
 
     /// <inheritdoc />
     public override string ToString() => "[object ResizeObserverEntry]";

--- a/Jint.Browser/Observers/ResizeObserverLane.cs
+++ b/Jint.Browser/Observers/ResizeObserverLane.cs
@@ -1,0 +1,73 @@
+using Jint.Browser.Runtime;
+
+namespace Jint.Browser.Observers;
+
+/// <summary>Observes flat-box changes at page-turn boundaries and delivers them in a later rendering task.</summary>
+/// <remarks>
+/// The active list keeps observers alive only while they observe targets, as
+/// https://drafts.csswg.org/resize-observer/#lifetime requires. No mutation observer is installed: CSSOM
+/// writes and viewport changes need no DOM mutation, so a mutation-only signal would miss size changes.
+/// Unlike a layout engine's depth-limited rendering loop, callback-caused changes wait for the next task.
+/// </remarks>
+internal sealed class ResizeObserverLane(PageRuntime runtime)
+{
+    private readonly List<JsResizeObserver> _observers = [];
+    private bool _scheduled;
+
+    internal void Enlist(JsResizeObserver observer)
+    {
+        if (!_observers.Contains(observer))
+        {
+            _observers.Add(observer);
+        }
+
+        Schedule();
+    }
+
+    internal void Withdraw(JsResizeObserver observer) => _observers.Remove(observer);
+
+    internal void CheckForChanges()
+    {
+        if (_scheduled || _observers.Count == 0)
+        {
+            return;
+        }
+
+        var layout = runtime.Layout.Current();
+        foreach (var observer in _observers)
+        {
+            if (observer.HasChanges(layout))
+            {
+                Schedule();
+                return;
+            }
+        }
+    }
+
+    private void Schedule()
+    {
+        if (_scheduled)
+        {
+            return;
+        }
+
+        ObserverTask.Post(runtime, Deliver);
+        _scheduled = true;
+    }
+
+    private void Deliver()
+    {
+        _scheduled = false;
+        if (_observers.Count == 0)
+        {
+            return;
+        }
+
+        var batch = _observers.ToArray();
+        var layout = runtime.Layout.Current();
+        foreach (var observer in batch)
+        {
+            observer.Deliver(layout);
+        }
+    }
+}

--- a/Jint.Browser/Page.cs
+++ b/Jint.Browser/Page.cs
@@ -740,6 +740,7 @@ public sealed partial class Page : IAsyncDisposable
                 using (budget?.BeginTurn() ?? default)
                 {
                     engine.Tasks.ProcessTasks();
+                    PageRuntime.Find(engine)?.UpdateRendering();
                 }
             }
             catch (Exception exception) when (PageBudget.IsBudgetFailure(exception))

--- a/Jint.Browser/Runtime/PageLoop.cs
+++ b/Jint.Browser/Runtime/PageLoop.cs
@@ -405,6 +405,9 @@ internal sealed class PageLoop : IDisposable
                 return;
             }
 
+            // An empty drain cannot resize anything. Leave work that arrives after this check queued for
+            // the next iteration rather than doing a layout walk on every idle wake.
+            var hasScheduledWork = tasks.TimeUntilNextScheduledWork is { Ticks: <= 0 };
             try
             {
                 // One drain is one turn: every timer callback, microtask, promise reaction and animation
@@ -414,11 +417,14 @@ internal sealed class PageLoop : IDisposable
 
                 try
                 {
-                    tasks.ProcessTasks();
+                    if (hasScheduledWork)
+                    {
+                        tasks.ProcessTasks();
+                    }
                 }
                 finally
                 {
-                    EndLoopTurn();
+                    EndLoopTurn(updateRendering: hasScheduledWork);
                 }
             }
             catch (Exception exception)
@@ -503,18 +509,23 @@ internal sealed class PageLoop : IDisposable
     /// it survives what watches them too.
     /// </para>
     /// </remarks>
-    private void EndLoopTurn()
+    private void EndLoopTurn(bool updateRendering = true)
     {
         EndTurn();
 
-        if (_onTurnEnd is not { } onTurnEnd || _engine is not { } engine)
+        if (_engine is not { } engine)
         {
             return;
         }
 
         try
         {
-            onTurnEnd(engine);
+            if (updateRendering)
+            {
+                PageRuntime.Find(engine)?.UpdateRendering();
+            }
+
+            _onTurnEnd?.Invoke(engine);
         }
         catch (Exception exception)
         {

--- a/Jint.Browser/Runtime/PageRuntime.cs
+++ b/Jint.Browser/Runtime/PageRuntime.cs
@@ -31,6 +31,7 @@ internal sealed class PageRuntime
     private readonly long _started;
     private IDocument? _document;
     private Observers.ObserverRealm? _observers;
+    private Observers.ResizeObserverLane? _resizeObservers;
     private CustomElements.CustomElementRegistry? _customElements;
     private Dom.Views.ViewRealm? _views;
     private List<JsMediaQueryList>? _mediaQueryLists;
@@ -178,6 +179,10 @@ internal sealed class PageRuntime
 
     /// <summary>The observer interface objects of this engine, built on first use.</summary>
     internal Observers.ObserverRealm Observers => _observers ??= new Observers.ObserverRealm(this);
+
+    internal Observers.ResizeObserverLane ResizeObservers => _resizeObservers ??= new Observers.ResizeObserverLane(this);
+
+    internal void UpdateRendering() => _resizeObservers?.CheckForChanges();
 
     /// <summary>
     /// This document's <c>CustomElementRegistry</c> — <c>window.customElements</c> — built on first use.

--- a/Jint.Browser/Runtime/Parsing/ParserBaton.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserBaton.cs
@@ -322,6 +322,7 @@ internal sealed class ParserBaton : IDisposable
             using (_budget.BeginTurn())
             {
                 _tasks.ProcessTasks();
+                PageRuntime.Find(_engine)?.UpdateRendering();
             }
         }
         catch (Exception exception)

--- a/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
+++ b/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
@@ -116,6 +116,30 @@ public class PlaywrightCourseTests
         await page.CloseAsync();
     }
 
+    [Test]
+    public async Task PlaywrightCreatesAFolderInATreeMountedWhileHidden()
+    {
+        await using var lane = await ClientLane.OpenAsync();
+        var page = await lane.NewPageAsync("vue-folder-tree");
+        await page.WaitForFunctionAsync("() => resizeHeights.length === 1 && resizeHeights[0] === 0");
+
+        await page.Locator("#load").ClickAsync();
+        await page.Locator("#children").WaitForAsync();
+        await page.Locator("#create").ClickAsync();
+        await page.Locator(".folder-name").Nth(1).WaitForAsync();
+        (await page.Locator(".folder-name").AllTextContentsAsync()).Should().Equal("Files", "TestFolder");
+
+        foreach (var context in lane.Pages.Contexts)
+        {
+            foreach (var hostPage in context.Pages)
+            {
+                hostPage.Errors.Should().BeEmpty();
+            }
+        }
+
+        await page.CloseAsync();
+    }
+
     /// <summary>The router, and the emulated colour scheme the page reads through <c>matchMedia</c>.</summary>
     [Test]
     public async Task PlaywrightMovesThroughTheRouterAndEmulatesTheColourScheme()

--- a/Jint.Tests.Browser/Fixtures/README.md
+++ b/Jint.Tests.Browser/Fixtures/README.md
@@ -46,6 +46,7 @@ React does not) would otherwise read a draft it had already cleared.
 | --- | --- | --- |
 | `todomvc-react` | React 18 with a scheduler and synthetic events: controlled input, keyed list, hash-routed filters | passes |
 | `todomvc-vue` | Vue 3 compiling the document's **own** markup: `v-model`, `v-for`, `:class`, `@keydown.enter`, mustaches | passes |
+| `vue-folder-tree` | A Vue tree mounted while hidden, revealed after fetch, with child rendering gated by `ResizeObserver` height; async folder insertion and shallow root replacement | passes |
 | `todomvc-preact` | Preact hooks writing to the DOM directly, with no scheduler between them | passes |
 | `todomvc-svelte` | Svelte 5 compiled ahead of time: no framework runtime is loaded, only the component's own output | passes |
 | `ssr-hydration` | React `hydrateRoot` over server-rendered markup — the nodes are adopted, not replaced, and `onRecoverableError` stays empty | passes |
@@ -89,7 +90,7 @@ Each directory under `vendor/` holds the library's published bundle and its own 
 | Library | Version | Source | Licence | Used by |
 | --- | --- | --- | --- | --- |
 | React | 18.3.1 | `unpkg.com/react@18.3.1/umd/react.production.min.js`, `react-dom@18.3.1/umd/react-dom.production.min.js` | MIT | `todomvc-react`, `ssr-hydration` |
-| Vue | 3.5.22 | `unpkg.com/vue@3.5.22/dist/vue.global.prod.js` | MIT | `todomvc-vue` |
+| Vue | 3.5.22 | `unpkg.com/vue@3.5.22/dist/vue.global.prod.js` | MIT | `todomvc-vue`, `vue-folder-tree` |
 | Preact | 10.29.8 | `unpkg.com/preact@10.29.8/dist/preact.umd.js`, `preact@10.29.8/hooks/dist/hooks.umd.js` | MIT | `todomvc-preact` |
 | Svelte | 5.57.0 | compiled into `todomvc-svelte/todomvc.bundle.js`; only the licence is under `vendor/` | MIT | `todomvc-svelte` |
 | jQuery | 3.7.1 | `unpkg.com/jquery@3.7.1/dist/jquery.min.js` | MIT | `jquery` |

--- a/Jint.Tests.Browser/Fixtures/VueTreeFixtureTests.cs
+++ b/Jint.Tests.Browser/Fixtures/VueTreeFixtureTests.cs
@@ -1,0 +1,23 @@
+namespace Jint.Tests.Browser.Fixtures;
+
+public class VueTreeFixtureTests
+{
+    [Test]
+    public async Task ATreeMountedWhileHiddenRendersFoldersAfterLoading()
+    {
+        await using var course = await FixtureCourse.OpenAsync("vue-folder-tree");
+        await course.UntilAsync("resizeHeights.length", "1");
+        (await course.Page.EvaluateAsync<double>("resizeHeights[0]")).Should().Be(0);
+
+        await course.ClickAsync("#load");
+        await course.UntilAsync("document.querySelector('#status').textContent", "Ready");
+        await course.UntilAsync("document.querySelectorAll('#children').length", "1");
+        await course.ClickAsync("#create");
+        await course.UntilAsync("document.querySelectorAll('.folder-name').length", "2");
+
+        (await course.TextsAsync(".folder-name")).Should().Be("Files|TestFolder");
+        course.Server.Received.Should().ContainSingle(request =>
+            request.Path == "/vue-folder-tree/created.json" && request.Method == "POST");
+        course.ShouldHaveReportedNothing();
+    }
+}

--- a/Jint.Tests.Browser/Fixtures/vue-folder-tree/created.json
+++ b/Jint.Tests.Browser/Fixtures/vue-folder-tree/created.json
@@ -1,0 +1,1 @@
+{"name":"TestFolder","directoryPath":"TestFolder","filePath":null,"isDirectory":true,"hasChildren":false}

--- a/Jint.Tests.Browser/Fixtures/vue-folder-tree/index.html
+++ b/Jint.Tests.Browser/Fixtures/vue-folder-tree/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Vue folder tree</title></head>
+<body>
+  <div id="app">
+    <button id="load" @click="load">Load library</button>
+    <button id="create" @click="createDirectory" :disabled="loading">Create folder</button>
+    <output id="status">{{ loading ? 'Loading' : 'Ready' }}</output>
+    <div v-show="!loading">
+      <nav ref="navigation">
+        <ul id="folder-tree">
+          <li><span class="folder-name">{{ root.name }}</span></li>
+          <li v-if="scrollerHeight > 0">
+            <ul id="children" :style="{ height: scrollerHeight + 'px' }">
+              <li v-for="child in children" :key="child.directoryPath">
+                <span class="folder-name">{{ child.name }}</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+  <script src="/vendor/vue-3.5.22/vue.global.prod.js"></script>
+  <script>
+    window.resizeHeights = [];
+    const { createApp, ref, computed, onMounted, onBeforeUnmount } = Vue;
+    createApp({
+      setup() {
+        const loading = ref(true);
+        const root = ref({ name: 'Files', directoryPath: '', hasChildren: false, children: [] });
+        const navigation = ref();
+        const scrollerHeight = ref(0);
+        const children = computed(() => root.value.hasChildren ? root.value.children : []);
+        const observer = new ResizeObserver(entries => {
+          const height = entries[0].contentRect.height;
+          resizeHeights.push(height);
+          scrollerHeight.value = Math.max(0, height - 40);
+        });
+        onMounted(() => observer.observe(navigation.value));
+        onBeforeUnmount(() => observer.disconnect());
+        async function load() {
+          root.value = await (await fetch('/vue-folder-tree/tree.json')).json();
+          loading.value = false;
+        }
+        async function createDirectory() {
+          const folder = await (await fetch('/vue-folder-tree/created.json?path=&name=TestFolder', { method: 'POST' })).json();
+          const parent = root.value;
+          parent.children.push({ ...folder, children: [] });
+          parent.hasChildren = true;
+          root.value = { ...root.value };
+        }
+        return { loading, root, navigation, scrollerHeight, children, load, createDirectory };
+      }
+    }).mount('#app');
+  </script>
+</body>
+</html>

--- a/Jint.Tests.Browser/Fixtures/vue-folder-tree/tree.json
+++ b/Jint.Tests.Browser/Fixtures/vue-folder-tree/tree.json
@@ -1,0 +1,1 @@
+{"name":"Files","directoryPath":"","hasChildren":false,"children":[]}

--- a/Jint.Tests.Browser/Observers/ResizeObserverTests.cs
+++ b/Jint.Tests.Browser/Observers/ResizeObserverTests.cs
@@ -1,0 +1,227 @@
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.Observers;
+
+using Browser = global::Jint.Browser.Browser;
+
+public class ResizeObserverTests
+{
+    [Test]
+    public async Task AHiddenTargetIsReportedWhenItsAncestorBecomesVisible()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <div id="parent" style="display:none"><div id="target"><span>Files</span></div></div>
+            <script>
+              window.sizes = [];
+              new ResizeObserver(entries => sizes.push(entries[0].contentRect.height))
+                .observe(document.getElementById('target'));
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("sizes.join(',')")).Should().Be("0");
+        await page.EvaluateAsync("document.getElementById('parent').style.display = ''");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("sizes.join(',')")).Should().Be("0,32");
+
+        await page.EvaluateAsync("document.getElementById('parent').style.display = 'none'");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("sizes.join(',')")).Should().Be("0,32,0");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task EntriesKeepTheirMeasuredSizeAcrossLaterMutations()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <div id="target"></div>
+            <script>
+              window.entries = [];
+              new ResizeObserver(batch => entries.push(batch[0]))
+                .observe(document.getElementById('target'));
+            </script>
+            """);
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        await page.EvaluateAsync("document.getElementById('target').appendChild(document.createElement('span'))");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>(
+            "entries.map(e => [e.contentRect.height, e.borderBoxSize[0].blockSize, e.contentBoxSize[0].blockSize, e.devicePixelContentBoxSize[0].blockSize].join(':')).join('|')"))
+            .Should().Be("16:16:16:16|32:32:32:32");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [TestCase("parent.classList.add('hidden')", "parent.classList.remove('hidden')")]
+    [TestCase("document.styleSheets[0].insertRule('#parent { display:none }', 0)", "document.styleSheets[0].deleteRule(0)")]
+    [TestCase("parent.remove()", "document.body.appendChild(parent)")]
+    public async Task ChangesWithoutAnObservedTargetMutationAreReported(string hide, string show)
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <style>.hidden { display:none }</style>
+            <div id="parent"><div id="target"></div></div>
+            <script>
+              const parent = document.getElementById('parent');
+              window.sizes = [];
+              new ResizeObserver(entries => sizes.push(entries[0].contentRect.height))
+                .observe(document.getElementById('target'));
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        await page.EvaluateAsync(hide);
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        await page.EvaluateAsync(show);
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("sizes.join(',')")).Should().Be("16,0,16");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ViewportChangesButNotPositionChangesResizeATarget()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <div id="target"></div>
+            <script>
+              window.sizes = [];
+              new ResizeObserver(entries => sizes.push(entries[0].contentRect.width))
+                .observe(document.getElementById('target'));
+            </script>
+            """);
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        await page.EvaluateAsync("document.body.prepend(document.createElement('div'))");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("sizes.join(',')")).Should().Be("1280");
+
+        await page.SetViewportAsync(new Viewport(640, 480));
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("sizes.join(',')")).Should().Be("1280,640");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task CallbackChangesAreDeliveredInALaterTaskAndThenBecomeIdle()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <div id="target"></div>
+            <script>
+              window.log = [];
+              new ResizeObserver(entries => {
+                const entry = entries[0];
+                log.push(entry.contentRect.height);
+                if (entry.contentRect.height === 16) {
+                  entry.target.appendChild(document.createElement('span'));
+                  log.push('snapshot:' + entry.contentRect.height);
+                  Promise.resolve().then(() => log.push('microtask'));
+                }
+              }).observe(document.getElementById('target'));
+              Promise.resolve().then(() => log.push('before'));
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("log.join(',')")).Should().Be("before,16,snapshot:16,microtask,32");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task UnobserveDisconnectAndReobserveControlFutureNotifications()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <div id="a"></div><div id="b"></div>
+            <script>
+              const a = document.getElementById('a'), b = document.getElementById('b');
+              window.log = [];
+              const observer = new ResizeObserver(entries => {
+                log.push(entries.map(e => e.target.id + ':' + e.contentRect.height).join(','));
+              });
+              observer.observe(a);
+              observer.observe(b);
+              observer.observe(a);
+            </script>
+            """);
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("log.join('|')")).Should().Be("a:16,b:16");
+
+        await page.EvaluateAsync(
+            "observer.unobserve(a); a.appendChild(document.createElement('span')); b.appendChild(document.createElement('span'))");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("log.join('|')")).Should().Be("a:16,b:16|b:32");
+
+        await page.EvaluateAsync("observer.disconnect(); b.appendChild(document.createElement('span'))");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("log.join('|')")).Should().Be("a:16,b:16|b:32");
+
+        await page.EvaluateAsync("observer.observe(a)");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("log.join('|')")).Should().Be("a:16,b:16|b:32|a:32");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task OneCallbackCanDisconnectAnotherBeforeItIsDelivered()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <div id="target"></div>
+            <script>
+              window.log = [];
+              const target = document.getElementById('target');
+              const first = new ResizeObserver(() => {
+                log.push('first');
+                second.disconnect();
+                Promise.resolve().then(() => log.push('microtask'));
+              });
+              const second = new ResizeObserver(() => log.push('second'));
+              const third = new ResizeObserver(() => log.push('third'));
+              first.observe(target);
+              second.observe(target);
+              third.observe(target);
+            </script>
+            """);
+
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("log.join(',')")).Should().Be("first,microtask,third");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ThrowingCallbacksDoNotStopOtherObserversOrFutureChanges()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <div id="target"></div>
+            <script>
+              const target = document.getElementById('target');
+              window.sizes = [];
+              new ResizeObserver(() => { throw new Error('resize failed'); }).observe(target);
+              new ResizeObserver(entries => sizes.push(entries[0].contentRect.height)).observe(target);
+            </script>
+            """);
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        await page.EvaluateAsync("target.appendChild(document.createElement('span'))");
+        (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
+        (await page.EvaluateAsync<string>("sizes.join(',')")).Should().Be("16,32");
+        page.Errors.Should().HaveCount(2).And.OnlyContain(error => error.Kind == PageErrorKind.UncaughtCallbackError);
+    }
+}

--- a/Jint.Tests.Browser/Observers/ViewportObserverTests.cs
+++ b/Jint.Tests.Browser/Observers/ViewportObserverTests.cs
@@ -7,8 +7,7 @@ namespace Jint.Tests.Browser.Observers;
 using Browser = global::Jint.Browser.Browser;
 
 /// <summary>
-/// <c>IntersectionObserver</c> and <c>ResizeObserver</c>: one notification per observed target, delivered as
-/// a task, with the geometry a page with no layout can honestly be told.
+/// <c>IntersectionObserver</c> and <c>ResizeObserver</c>: task delivery and the flat model's geometry.
 /// </summary>
 public sealed class ViewportObserverTests
 {
@@ -164,7 +163,7 @@ public sealed class ViewportObserverTests
     }
 
     [Test]
-    public async Task EveryResizeObservedTargetIsReportedOnce()
+    public async Task EveryResizeObservedTargetReceivesAnInitialNotification()
     {
         await using var browser = new Browser();
         var page = await browser.NewPageAsync();
@@ -226,7 +225,7 @@ public sealed class ViewportObserverTests
         await page.EvaluateAsync("window.log.length = 0");
         (await page.WaitForIdleAsync(TimeSpan.FromSeconds(5))).Should().BeTrue();
 
-        // Nothing is reported a second time: with no layout, no size can change.
+        // No dimensions changed, so an idle observer reports nothing more.
         (await page.EvaluateAsync<string>("window.log.join('|')")).Should().BeEmpty();
     }
 

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -458,8 +458,11 @@ planned. A blank last column means the section above describes what exists.
 | 10 | `Jint.Browser.Mcp`, the Model Context Protocol server, and `jint-browser mcp` serving it on stdio | [#3717](https://github.com/sebastienros/jint/pull/3717) | **`--http` did not ship** — the protocol's 2026-07-28 revision removed the session header from streamable HTTP, and the two ways to hold per-session state either need an `[Experimental]` handler or put an ASP.NET Core framework reference in a `dotnet tool`; and a `ref=` is the accessibility tree's own identifier rather than a `backendNodeId`, which belongs to a protocol target an MCP session has none of |
 
 Two decisions in the v1/not-v1 table of §2 turned out differently and are worth naming here rather than
-leaving a reader to compare tables. `IntersectionObserver` and `ResizeObserver` are no longer stubs, since
-§8's model gives them numbers to report. And `getComputedStyle` answers a *resolved* value for the ten
+leaving a reader to compare tables. §8's model gives both observers numbers to report.
+`IntersectionObserver` still reports each target once, fully intersecting. `ResizeObserver` also reports
+subsequent synthetic size changes, including hidden-to-visible transitions, from page-turn checkpoints;
+its entries preserve the measured size. Callback-induced changes are deferred to another task rather than
+processed through a depth-limited rendering loop. And `getComputedStyle` answers a *resolved* value for the ten
 properties an automation client reads to decide whether an element can be interacted with
 ([#3716](https://github.com/sebastienros/jint/pull/3716)) — the smallest exception to the standing decision
 against an initial-value table of our own, made because without it no supported client can drive a page.


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

<!-- One short sentence (under 80 characters) describing the change. -->

Report ResizeObserver size changes after hidden elements become visible.

## Details

<!--
- What changed and why
- Anything reviewers should pay extra attention to
- Notable implementation choices or trade-offs
-->

OrchardCore's Vue media app mounts its folder tree while the loading container is hidden. Jint's one-shot `ResizeObserver` reported height zero and never reported the later visible size. Folder creation succeeded and Vue updated its state, but the height-gated virtual scroller stayed unmounted, leaving only the "Files" root visible.

This change tracks each target's last reported flat-box dimensions, checks for changes at page-turn boundaries and in both nested pumps, and delivers changed targets asynchronously. Entries retain their measured dimensions instead of reading live geometry. Checks share a layout, require no mutation-observer subscription, and skip idle-loop layout scans; ancestor visibility, CSSOM and viewport changes are covered too.

The geometry remains synthetic. All three box options use the same dimensions, and callback-induced changes are deferred to another task rather than processed through a depth-limited rendering loop.

## Linked issue

<!-- Use "Fixes #1234" or "Closes #1234" so the issue is auto-closed on merge. For discussion-only changes use "Refs #1234". -->

N/A

## Test plan

- [ ] Added or updated unit tests in `Jint.Tests` - focused tests and fixtures are in `Jint.Tests.Browser` instead.
- [x] Ran `dotnet test --configuration Release` locally - targeted suites on both net8.0 and net10.0.
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions - N/A.
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` - N/A.
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark` - N/A; no benchmark claims.

Added 10 focused observer cases plus a minimal Vue folder-tree fixture driven through the public Page API and Microsoft.Playwright 1.62.0 over CDP.

| Validation | net8.0 | net10.0 |
| --- | --- | --- |
| Browser runtime, navigation, layout, observer, fixture, Playwright and binding-staleness matrix | 362 passed | 363 passed |
| Same matrix with `JINT_HOST_CONTRACT_VERIFICATION=1` | 362 passed | 363 passed |
| Instruction and spec-citation guardians | 8 passed | 8 passed |
| Exact Orchard `media2.js`, immediate and delayed initial API responses | 2 passed | 2 passed |

The exact-bundle reproduction failed before the fix with delayed responses: initial observed height 0, later actual height 240, no scroller and only "Files". Afterward it receives subsequent sizes and renders "Files" and "TestFolder". The downloaded full-bundle harness remains a local investigation artifact; the reduced offline Vue regression is committed. The full Orchard application suite was not run here.

## Breaking change?

<!-- Yes / No. If yes, describe the public-API impact and any migration steps. -->

No public API changes. Resize observers now receive subsequent size-change notifications as expected, rather than stopping after their initial notification.