### PR TITLE
Fix browser budgets at task and microtask-checkpoint boundaries

### DIFF
--- a/Jint.Browser/BrowserOptions.cs
+++ b/Jint.Browser/BrowserOptions.cs
@@ -103,21 +103,18 @@ public sealed class BrowserOptions
             : throw new ArgumentOutOfRangeException(nameof(value), value, "MaxRecordedEvents must be positive.");
     }
 
-    /// <summary>How long one turn of a page's loop may run before it is cut short; five seconds.</summary>
+    /// <summary>Gets or sets the time budget for one page task and its microtasks; defaults to five seconds.</summary>
     /// <remarks>
     /// <para>
-    /// A <b>turn</b> is one unit of work the page's thread does with the engine: one call posted by a
-    /// <see cref="Page"/> member, one <c>ProcessTasks</c> drain (which is every timer callback, microtask,
-    /// promise reaction and animation frame that was due), and one inline <c>&lt;script&gt;</c> run during a
-    /// parse. Each is bracketed with an <c>OperationDeadlineConstraint</c>, which is one of the two
-    /// constraints a per-entry reset never rewinds — a plain <c>Options.LimitExecutionTime</c> bounds
-    /// neither a pumped job chain nor a sequence of host calls, which is why this exists.
+    /// Each <see cref="Page"/> call, inline script, timer callback, rendering task, animation-frame batch
+    /// and protocol command receives its own budget. Its complete microtask checkpoint shares that budget:
+    /// recursive promise reactions cannot renew it. Separately queued tasks do not consume each other's
+    /// allowance, even when they run in the same pump.
     /// </para>
     /// <para>
-    /// A turn that runs out fails differently depending on which turn it was. A <see cref="Page"/> call
-    /// fails its own task with <see cref="TimeoutException"/>; a job chain and an inline script are recorded
-    /// as a <see cref="PageErrorKind.BudgetExceeded"/> entry in <see cref="Page.Errors"/> and the page goes
-    /// on — a page survives its scripts.
+    /// A <see cref="Page"/> call that exhausts its budget fails with <see cref="TimeoutException"/>.
+    /// A pumped task or inline script records <see cref="PageErrorKind.BudgetExceeded"/> in
+    /// <see cref="Page.Errors"/>; a protocol command reports failure to its client. The page continues.
     /// </para>
     /// <para>
     /// <see cref="Timeout.InfiniteTimeSpan"/>, zero and any negative value all mean no time bound at all,

--- a/Jint.Browser/Page.cs
+++ b/Jint.Browser/Page.cs
@@ -454,7 +454,7 @@ public sealed partial class Page : IAsyncDisposable
     /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
     public Task<bool> WaitForIdleAsync(TimeSpan timeout)
     {
-        // Not bracketed as one turn: the request is a pump, so it brackets each drain itself. Bracketing the
+        // Not bracketed as one turn: the engine brackets each task and its microtasks. Bracketing the
         // whole wait would charge every drain and every park to one turn's budget and fail a wait longer than
         // BrowserOptions.MaxTaskDuration for no reason at all.
         return _loop.PostAsync(engine => PumpUntilIdle(engine, timeout), bracketed: false);
@@ -595,7 +595,7 @@ public sealed partial class Page : IAsyncDisposable
     /// <para>
     /// The one thing on <see cref="Page"/> that is <b>not</b> a mailbox request: it is a volatile read of a
     /// number the loop publishes, safe from any thread and costing the loop nothing to be asked. A turn is a
-    /// bracketed mailbox request or a <c>ProcessTasks</c> drain — <see cref="PageLoop.Turns"/> is the
+    /// bracketed mailbox request or a single-task pump pass — <see cref="PageLoop.Turns"/> is the
     /// definition, including what a navigation and a pump each count as.
     /// </para>
     /// <para>
@@ -729,19 +729,13 @@ public sealed partial class Page : IAsyncDisposable
     {
         var started = Stopwatch.GetTimestamp();
         var closing = _loop.Closing;
-        var budget = PageRuntime.Find(engine)?.Budget;
 
         while (!closing.IsCancellationRequested)
         {
             try
             {
-                // One drain, one turn — the same bracket the page loop puts around its own drains, taken
-                // here because this request is the pump for as long as it holds the thread.
-                using (budget?.BeginTurn() ?? default)
-                {
-                    engine.Tasks.ProcessTasks();
-                    PageRuntime.Find(engine)?.UpdateRendering();
-                }
+                engine.Tasks.ProcessTask();
+                PageRuntime.Find(engine)?.UpdateRendering();
             }
             catch (Exception exception) when (PageBudget.IsBudgetFailure(exception))
             {

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -16,7 +16,7 @@
 ### The page loop, and the thread rule
 
 **One thread per page owns its engine and its DOM, and nothing else may touch either.** `Runtime/PageLoop`
-is that thread: it drains a mailbox of requests, calls `Tasks.ProcessTasks()`, and parks in
+is that thread: it drains a mailbox of requests, processes one engine task and its microtasks, and parks in
 `Tasks.WaitForScheduledWork` for the shorter of `BrowserOptions.PumpIdle` and
 `Tasks.TimeUntilNextScheduledWork`. The engine is built on it and disposed on it, because both are
 engine-owning operations, and a navigation replaces the engine from inside a mailbox request rather than from
@@ -65,18 +65,21 @@ all and a per-entry timeout there never fires even once. The two whose window th
 survive both — `OperationDeadlineConstraint` and `MemoryLimitConstraint` — and `Runtime/PageBudget` is where a
 page arms them.
 
-**A turn is one unit of work the page's thread does with the engine**, and there are exactly three kinds:
-one mailbox request (`PageLoop.PostAsync`), one `ProcessTasks` drain — which is every due timer callback,
-microtask, promise reaction and animation-frame batch together — and one inline `<script>`
-(`PageScriptingService`, and the parser driver after it). Each takes `BrowserOptions.MaxTaskDuration` and,
-where one is configured, `BrowserOptions.MemoryLimit`. Four consequences are easy to get wrong:
+**A budget turn is one mailbox request, one engine task together with its complete microtask checkpoint,
+or one inline `<script>`.** A timer callback, a rendering/observer task, an animation-frame batch and a
+protocol command are separate tasks, even when all were queued before one pump. Each takes
+`BrowserOptions.MaxTaskDuration` and, where configured, `BrowserOptions.MemoryLimit`. The engine's internal
+`IEventLoopTaskBudget` hook arms `PageBudget` around the task and the checkpoint, not around a drain.
+`PageLoop.Turns` remains a scheduling instrument: it counts mailbox requests and pump passes, including an
+empty pass, not these potentially nested budget scopes. Four consequences are easy to get wrong:
 
 - **A request's bracket is outside `PostAsync`'s own `try`/`catch`**, which is what makes a budget failure the
-  *caller's*: `Page.EvaluateAsync` faults with `TimeoutException`. A drain's erupts into the pump, becomes a
+  *caller's*: `Page.EvaluateAsync` faults with `TimeoutException`. A task's erupts into the pump, becomes a
   `PageErrorKind.BudgetExceeded` entry, and the loop goes on — a page survives its scripts.
-- **A request that pumps brackets its own turns and is posted `bracketed: false`.** `WaitForIdleAsync` is the
-  one; bracketing the whole wait would charge every drain *and every park* to one budget and fail a wait
-  longer than `MaxTaskDuration` for no reason. A `Page` member added later wants the default.
+- **A request that pumps is posted `bracketed: false`.** `WaitForIdleAsync` is one; the engine brackets each
+  task, so bracketing the wait would charge unrelated tasks and parks to one budget. Page, parser and worker
+  pumps use internal `ProcessTask`, returning after one task and its checkpoint so a busy task source cannot
+  hide cancellation or the page mailbox. A `Page` member added later wants the default request bracket.
 - **`ReplaceEngine` closes the outgoing engine's turn and opens one on the incoming engine.** A constraint
   belongs to one engine, so the turn a navigation request opened cannot be closed on the engine that replaced
   it — and doing it this way is also what stops an engine construction from spending the budget the new
@@ -91,6 +94,19 @@ A worker's pump takes the same bracket over its own engine's constraints, which 
 *not* carry is a web-API setting, so `MaxActiveTimers`, `MaxResponseBytes`, `FetchTimeout` and the page's
 user agent are named again in `ThreadPerWorkerProvider`; a new page-sized limit needs the same second call or a worker keeps the engine
 default.
+
+**The browser has separate task and microtask lanes; an ordinary `Engine` keeps its existing FIFO.**
+`PageBudget.For` installs the internal hook before the engine is published (also before a worker starts).
+The separate lane is necessary for accounting, not merely ordering: a command already queued behind the
+running command must not separate that command from a reaction it queues later. Every recursive
+`Promise.then`/`queueMicrotask` and nested event-listener checkpoint spends the same budget. Microtasks
+drained at the end of a mailbox evaluation keep that evaluation's budget too. The generation fence, queue
+clearing and wake/wait checks cover both lanes. `EngineDispatcher.Drain` answers one command per posted job;
+the debugger's inline paused drain stays nested and must not re-arm the suspended task.
+`HasPendingEventLoopJobs` means pending checkpoint work on this lane, not other tasks; otherwise two
+web-API feature pumps could defer forever on each other. Timer promotion still waits for both lanes to
+empty. Idle callbacks execute directly during promotion, not as queued jobs, so the pump must give each
+one its own task/checkpoint budget too.
 
 `BrowserOptions.ForUntrustedContent` applies `Options.ForUntrustedCode` from inside the factory's own
 construction callback, so the profile is expanded before the engine builds anything and re-expanded over the

--- a/Jint.Browser/Runtime/PageBudget.cs
+++ b/Jint.Browser/Runtime/PageBudget.cs
@@ -45,7 +45,7 @@ namespace Jint.Browser.Runtime;
 /// worker's own pump for a worker.
 /// </para>
 /// </remarks>
-internal sealed class PageBudget
+internal sealed class PageBudget : IEventLoopTaskBudget
 {
     private readonly OperationDeadlineConstraint? _deadline;
     private readonly MemoryLimitConstraint? _memory;
@@ -75,7 +75,28 @@ internal sealed class PageBudget
             ? engine.Constraints.Find<MemoryLimitConstraint>()
             : null;
 
-        return new PageBudget(deadline, memory, turn);
+        var budget = new PageBudget(deadline, memory, turn);
+        engine.Tasks.ConfigureTaskBudget(budget);
+        return budget;
+    }
+
+    bool IEventLoopTaskBudget.BeginTask(bool isTask)
+    {
+        if (!isTask && _depth > 0)
+        {
+            return false;
+        }
+
+        BeginTurn();
+        return true;
+    }
+
+    void IEventLoopTaskBudget.EndTask()
+    {
+        if (IsArmed)
+        {
+            EndTurn();
+        }
     }
 
     /// <summary>Whether anything is actually bounded, which is what makes a turn worth bracketing.</summary>

--- a/Jint.Browser/Runtime/PageLoop.cs
+++ b/Jint.Browser/Runtime/PageLoop.cs
@@ -8,7 +8,7 @@ namespace Jint.Browser.Runtime;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The shape is the engine's documented host loop: drain the mailbox, call <c>Tasks.ProcessTasks()</c>, then
+/// The shape is the engine's host loop: drain the mailbox, run one task and its microtasks, then
 /// park in <c>Tasks.WaitForScheduledWork</c> for the shorter of the idle interval and whatever the engine
 /// says is next. Jint never starts a thread of its own, so a page that is not pumped runs no timer callback
 /// and settles no promise; this is what pumps it.
@@ -25,8 +25,8 @@ namespace Jint.Browser.Runtime;
 /// rather than left to hang.
 /// </para>
 /// <para>
-/// <b>Every turn is bracketed.</b> One mailbox request and one <c>ProcessTasks</c> drain are each one turn,
-/// and each takes the page's <see cref="PageBudget"/> — see
+/// <b>Every task is bracketed.</b> A mailbox request and each engine task together with its microtask
+/// checkpoint take the page's <see cref="PageBudget"/> — see
 /// <see cref="BrowserOptions.MaxTaskDuration"/>. A request that runs out of budget fails its own task,
 /// because the bracket is outside <see cref="PostAsync{T}"/>'s own <c>catch</c>; a drain that runs out
 /// erupts here and is recorded like anything else that erupts, and the loop goes on.
@@ -108,7 +108,7 @@ internal sealed class PageLoop : IDisposable
     /// <remarks>
     /// <para>
     /// <b>One turn is what the page runtime's <c>AGENTS.md</c> calls one</b>, counted at the two places the
-    /// loop takes one: a <b>bracketed mailbox request</b>, and a <b><c>ProcessTasks</c> drain</b>. Both are
+    /// loop takes one: a <b>bracketed mailbox request</b>, and a <b>single-task pump pass</b>. Both are
     /// counted as they open, so a value read from the loop thread itself — from inside a request, a job or a
     /// listener — is the ordinal of the turn currently running, and two things that read the same number ran
     /// in the same turn. A drain that finds nothing due still counts, because the loop still took it.
@@ -116,7 +116,7 @@ internal sealed class PageLoop : IDisposable
     /// <para>
     /// <b>A request posted <c>bracketed: false</c> is not a turn, and neither is a drain it performs.</b>
     /// Those are the pumps — <c>Page.WaitForIdleAsync</c> and <c>Page.WaitForNavigationAsync</c> — and each
-    /// takes the page's <see cref="PageBudget"/> over its own drains directly rather than through the loop,
+    /// lets the engine take the page's <see cref="PageBudget"/> over each task rather than through the loop,
     /// so the count stands still for as long as one of them holds the thread. That is the honest reading:
     /// the loop is not turning, something else is using it.
     /// </para>
@@ -164,7 +164,7 @@ internal sealed class PageLoop : IDisposable
     /// <param name="work">What to do with the engine, on the thread that owns it.</param>
     /// <param name="bracketed">
     /// Whether the request is one turn and takes the page's turn budget. <see langword="false"/> is for a
-    /// request that <i>pumps</i> — it brackets each drain itself, so bracketing the request as well would
+    /// request that <i>pumps</i> — the engine brackets each task, so bracketing the request as well would
     /// charge a whole wait to one turn's budget and fail it. There are two of those and both are here in the
     /// package; a member added later wants the default.
     /// </param>
@@ -410,16 +410,15 @@ internal sealed class PageLoop : IDisposable
             var hasScheduledWork = tasks.TimeUntilNextScheduledWork is { Ticks: <= 0 };
             try
             {
-                // One drain is one turn: every timer callback, microtask, promise reaction and animation
-                // frame that was due shares one time and one allocation budget, because none of them reaches
-                // ExecuteWithConstraints and so none of them is bounded by a per-entry limit at all.
-                BeginLoopTurn(bracketed: true);
+                // The engine brackets one task together with its entire microtask checkpoint. Return to
+                // the mailbox between tasks, rather than letting a busy task source monopolize the loop.
+                _turns++;
 
                 try
                 {
                     if (hasScheduledWork)
                     {
-                        tasks.ProcessTasks();
+                        tasks.ProcessTask();
                     }
                 }
                 finally

--- a/Jint.Browser/Runtime/Parsing/AGENTS.md
+++ b/Jint.Browser/Runtime/Parsing/AGENTS.md
@@ -29,10 +29,10 @@ property**, and it is why nothing else in the driver needs a lock.
 
 **Timers fire exactly where a browser fires them.** While the parser is tokenizing it holds the baton and the
 loop runs nothing, which is right — in a browser the parser *is* the task the event loop is running. While the
-loop is fetching a parser-blocking script it holds the baton and pumps `ProcessTasks`, so timers, promise jobs
+loop is fetching a parser-blocking script it holds the baton and pumps one task plus its microtasks, so timers, promise jobs
 and animation frames run while the page waits for the network. `ParserBaton.PumpUntil` is that pump, and
 `DocumentLoadTests.TimersFireWhileAParserBlockingScriptIsOnItsWay` is the proof (it reads zero without it).
-What that pump swallows it reports: a job erupting out of `ProcessTasks` must not end the load, and it must
+What that pump swallows it reports: a job erupting out of `ProcessTask` must not end the load, and it must
 not vanish either, so it goes to the page recorder — which is the only way an execution constraint aborting
 a timer mid-parse is visible at all.
 
@@ -46,8 +46,8 @@ the token every subresource fetch is linked to: the fetch in flight fails, the p
 **Every turn inside the parse is a turn.** A document load is *one* mailbox request, so `PageLoop` opens one
 budget turn around the whole of it — and that turn's deadline is wall-clock, so by the time a slow
 `<script src>` has come back it is long gone. Each script therefore takes a nested turn of its own
-(`ParserDriver.Execute`, `RunModule`), and so does **each drain of the job queue** the pump runs
-(`ParserBaton.Drain`), which is the same rule `PageLoop.Pump` follows for the drains it runs itself. Without
+(`ParserDriver.Execute`, `RunModule`), and so does **each task and its microtask checkpoint** the pump runs
+(`ParserBaton.Drain`), through the engine's `PageBudget` hook, just as in `PageLoop.Pump`. Without
 that last one a timer callback that fires late in a slow load is killed for the enclosing turn's exhaustion
 rather than its own — `DocumentLoadTests.ATimerThatFiresLateInASlowLoadGetsABudgetOfItsOwn` is that case, and
 it fails without the bracket. A budget running out is a `PageErrorKind.BudgetExceeded` and the load goes on,
@@ -56,7 +56,7 @@ can read.
 
 **The residual, stated because it is the one thing a budget does not reach.** `Serve` holds the loop for the
 whole parse, so while the baton is in the parser's hands the loop runs nothing and an execution constraint
-cannot fire. Every fetch is bounded by `BrowserOptions.SubresourceTimeout` and every script and every drain
+cannot fire. Every fetch is bounded by `BrowserOptions.SubresourceTimeout` and every script and every task
 takes a turn, which leaves AngleSharp's tokenizer as the only unbounded step. There is still no *total*
 budget on the parse — `PageLoop`'s turn is the enclosing one, and nothing re-arms it for the parse as a whole
 — so what a wedged parser thread costs is bounded by the page's own token instead: closing the page ends

--- a/Jint.Browser/Runtime/Parsing/ParserBaton.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserBaton.cs
@@ -28,7 +28,7 @@ namespace Jint.Browser.Runtime.Parsing;
 /// <b>Timers fire exactly where a browser fires them.</b> While the parser is tokenizing it holds the baton
 /// and the loop runs nothing — which is right, because in a browser the parser *is* the task the event loop
 /// is running. While the loop is fetching a parser-blocking script it holds the baton and pumps
-/// <see cref="Engine.TaskOperations.ProcessTasks"/>, so timers, promise jobs and animation frames run while
+/// one task and its microtasks, so timers, promise jobs and animation frames run while
 /// the page waits for the network. That is the browser-correct timing, and it is what
 /// <see cref="PumpUntil(Task)"/> is for.
 /// </para>
@@ -39,7 +39,6 @@ internal sealed class ParserBaton : IDisposable
     private readonly SemaphoreSlim _arrived = new(0);
     private readonly Engine _engine;
     private readonly Engine.TaskOperations _tasks;
-    private readonly PageBudget _budget;
     private readonly TimeSpan _idle;
     private readonly CancellationToken _cancellationToken;
     private readonly Action<Exception> _onPumpError;
@@ -47,11 +46,10 @@ internal sealed class ParserBaton : IDisposable
     private volatile int _parserThreadId;
     private volatile bool _abandoned;
 
-    internal ParserBaton(Engine engine, PageBudget budget, TimeSpan idle, Action<Exception> onPumpError, CancellationToken cancellationToken)
+    internal ParserBaton(Engine engine, TimeSpan idle, Action<Exception> onPumpError, CancellationToken cancellationToken)
     {
         _engine = engine;
         _tasks = engine.Tasks;
-        _budget = budget;
         _idle = idle <= TimeSpan.Zero ? TimeSpan.FromMilliseconds(5) : idle;
         _cancellationToken = cancellationToken;
         _onPumpError = onPumpError;
@@ -303,8 +301,8 @@ internal sealed class ParserBaton : IDisposable
     /// <summary>One drain of the engine's job queue, bracketed and reported the way the page loop does it.</summary>
     /// <remarks>
     /// <para>
-    /// <b>A drain is a turn</b>, which is <c>PageLoop.Pump</c>'s rule and has to be this pump's too: these
-    /// drains happen <i>inside</i> the mailbox request that is parsing the document, so without a bracket a
+    /// <b>A task and its checkpoint are one turn</b>, just as in <c>PageLoop.Pump</c>: these
+    /// tasks run <i>inside</i> the mailbox request that is parsing the document, so without a bracket a
     /// timer callback firing while a parser-blocking script is on its way would run with no budget at all —
     /// and the enclosing turn's deadline would go stale across a slow fetch. A nested turn re-arms it and
     /// hands the enclosing turn a full budget back, which is exactly what <see cref="PageBudget"/> is for.
@@ -319,11 +317,8 @@ internal sealed class ParserBaton : IDisposable
     {
         try
         {
-            using (_budget.BeginTurn())
-            {
-                _tasks.ProcessTasks();
-                PageRuntime.Find(_engine)?.UpdateRendering();
-            }
+            _tasks.ProcessTask();
+            PageRuntime.Find(_engine)?.UpdateRendering();
         }
         catch (Exception exception)
         {

--- a/Jint.Browser/Runtime/Parsing/ParserDriver.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserDriver.cs
@@ -70,7 +70,7 @@ internal sealed class ParserDriver : IDisposable
         _maxRedirects = runtime.Options.MaxRedirects;
         _timeout = runtime.Options.SubresourceTimeout;
         _cancellationToken = cancellationToken;
-        _baton = new ParserBaton(runtime.Engine, runtime.Budget, runtime.Options.PumpIdle, OnPumpError, cancellationToken);
+        _baton = new ParserBaton(runtime.Engine, runtime.Options.PumpIdle, OnPumpError, cancellationToken);
     }
 
     /// <summary>Parses <paramref name="html"/> as <paramref name="url"/> and runs the document's scripts.</summary>

--- a/Jint.Browser/Workers/ThreadPerWorkerProvider.cs
+++ b/Jint.Browser/Workers/ThreadPerWorkerProvider.cs
@@ -34,8 +34,8 @@ namespace Jint.Browser.Workers;
 /// <para>
 /// <b>A worker's turns are bounded the way a page's are.</b> <c>CreateDefaultOptions</c> replays the
 /// parent's constraint <i>factories</i>, so a worker has an <c>OperationDeadlineConstraint</c> and — where
-/// the page has one — a <c>MemoryLimitConstraint</c> of its own, and the pump below brackets each drain with
-/// them exactly as <see cref="Runtime.PageLoop"/> does. Without that a worker would be the one engine here
+/// the page has one — a <c>MemoryLimitConstraint</c> of its own. Each task and its microtasks take these
+/// budgets, exactly as in <see cref="Runtime.PageLoop"/>. Without that a worker would be the one engine here
 /// with no wall-clock bound at all: an inherited <c>TimeoutInterval</c> never fires on an engine that is only
 /// ever pumped. The three web-API limits are not constraints and do not travel with the posture, so they are
 /// named again below.
@@ -136,7 +136,9 @@ internal sealed class ThreadPerWorkerProvider : WorkerProvider
                 options.WebApi.Fetch.UserAgent);
         }
 
-        return new Engine(options);
+        var engine = new Engine(options);
+        PageBudget.For(engine, _options);
+        return engine;
     }
 
     /// <inheritdoc />
@@ -209,23 +211,14 @@ internal sealed class ThreadPerWorkerProvider : WorkerProvider
     {
         var worker = connection.Worker;
 
-        // The same bracket the page loop puts around its own turns, over the same two constraints: a worker
-        // inherits its parent's constraint factories, so it has an OperationDeadlineConstraint and — where
-        // the page has one — a MemoryLimitConstraint of its own. Without it a worker is the one engine in
-        // the package with no wall-clock bound at all, because a pumped engine reaches ExecuteWithConstraints
-        // never and its inherited TimeoutInterval therefore never fires.
-        var budget = PageBudget.For(worker, _options);
-
+        // CreateWorkerEngine installed the task budget before publishing the engine to this thread.
         try
         {
             while (!connection.IsEnded)
             {
                 try
                 {
-                    using (budget.BeginTurn())
-                    {
-                        worker.Tasks.ProcessTasks();
-                    }
+                    worker.Tasks.ProcessTask();
                 }
                 catch (Exception exception) when (PageBudget.IsBudgetFailure(exception))
                 {

--- a/Jint.DevTools/Session/AGENTS.md
+++ b/Jint.DevTools/Session/AGENTS.md
@@ -17,7 +17,7 @@ mechanism, in order:
    hands the request to `EngineDispatcher.DispatchAsync`, which enqueues it and waits.
 2. The enqueue calls `engine.Tasks.Post(Drain)`, the one engine entry a thread that does not own the engine
    may call. It wakes whichever thread is pumping.
-3. `Drain` runs **on the engine thread, inside an ordinary event-loop job**, answers the command, and
+3. `Drain` runs **on the engine thread, inside an ordinary event-loop job**, answers one command, and
    completes the waiting task with the finished JSON.
 4. The transport thread writes that string. **No `JsValue` ever crosses.**
 
@@ -28,6 +28,10 @@ Four consequences that are not negotiable:
   attaches reactions and completes from the job that runs them, which is V8's shape.
 - **The drain must never throw.** It is a job on the host's own pump, so an exception erupts out of
   `ProcessTasks` into the host. Every item catches everything and answers with it.
+- **One running-mode drain answers one command or host work item.** Work left queued is posted again.
+  A page's task budget includes that command's microtask checkpoint, not the other commands waiting behind
+  it. Never fold the queue back into one job: an expensive actionability burst would spend a later Vue
+  reaction's deadline. The paused drain remains inline inside the suspended task and does not re-arm it.
 - **A command that times out is answered, not cancelled.** `CommandTimeout` bounds the *client's* wait; the
   item stays queued and still runs when the engine is next pumped. The two messages are told apart
   deliberately — an item nothing dequeued says `Engine is not being pumped`, one that started and did not
@@ -183,4 +187,3 @@ A scope a client expands is a **snapshot**: environment records are not objects,
 bindings are copied into one — getter-free, like every describing path here — while a global or `with`
 scope is answered as the object it already is. A binding in its temporal dead zone is absent rather than
 shown as `undefined`, and `Debugger.setVariableValue` writes through.
-

--- a/Jint.DevTools/Session/EngineDispatcher.cs
+++ b/Jint.DevTools/Session/EngineDispatcher.cs
@@ -167,13 +167,13 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
     }
 
     /// <summary>
-    /// Runs everything queued, on the engine thread.
+    /// Runs one command or host work item, on the engine thread.
     /// </summary>
     /// <remarks>
     /// <para>
     /// Called as the event-loop job <see cref="Engine.TaskOperations.Post(System.Action)"/> queued, and
-    /// directly by <see cref="EngineTarget.Pump"/> and the library-owned loop. It drains everything rather
-    /// than one item, so the extra passes an unconditional post produces cost a dequeue that finds nothing.
+    /// directly by <see cref="EngineTarget.Pump"/> and the library-owned loop. One item per job leaves a
+    /// microtask checkpoint and, for a page, a fresh task budget between commands.
     /// </para>
     /// <para>
     /// <b>It never re-enters itself.</b> A command runs script, script pauses, the pause loop answers a
@@ -192,9 +192,10 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
 
         try
         {
-            while (_commands.TryDequeue(out var item))
+            if (_commands.TryDequeue(out var item))
             {
                 item.Run();
+                return;
             }
 
             if (IsWaitingForDebugger)
@@ -202,7 +203,7 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
                 return;
             }
 
-            while (_hostWork.TryDequeue(out var work))
+            if (_hostWork.TryDequeue(out var work))
             {
                 work(_engine);
             }
@@ -210,6 +211,13 @@ internal sealed class EngineDispatcher : ICommandGateway, IDisposable
         finally
         {
             Volatile.Write(ref _draining, 0);
+
+            // Each command is one event-loop task, followed by its microtask checkpoint. Also repost
+            // host work held while waiting for a debugger, whose original wake jobs may be spent.
+            if (!_commands.IsEmpty || (!IsWaitingForDebugger && !_hostWork.IsEmpty))
+            {
+                ScheduleDrain();
+            }
         }
     }
 

--- a/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
+++ b/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Jint.Browser;
+using Jint.Constraints;
 using Jint.DevTools;
 using Jint.Tests.Browser.Fixtures;
 using Jint.Tests.Browser.Layout;
@@ -137,6 +138,70 @@ public class PlaywrightCourseTests
             }
         }
 
+        await page.CloseAsync();
+    }
+
+    [Test]
+    public async Task PlaywrightUpdatesTheVueTreeAfterSeparateQueuedTasks()
+    {
+        var clock = new TaskBudgetClock();
+        var options = new BrowserOptions().ConfigureEngine(options =>
+        {
+            // Only the page's host-owned deadline uses the fake clock; timers and promise waits do not.
+            options.RemoveConstraints(static constraint => constraint is OperationDeadlineConstraint);
+            options.AddConstraint(() => new OperationDeadlineConstraint(clock));
+            options.Configure(engine =>
+            {
+                engine.SetValue("__checkTaskBudget", () => engine.Constraints.Check());
+                engine.SetValue("__queueBudgetedTasks", () =>
+                {
+                    for (var i = 0; i < 2; i++)
+                    {
+                        engine.Tasks.Post(() =>
+                        {
+                            engine.Execute(
+                                "Vue.nextTick(() => { __checkTaskBudget(); globalThis.__budgetedReactions++; });");
+                            clock.Advance(TimeSpan.FromSeconds(4));
+                        });
+                    }
+                });
+            });
+        });
+        options.MaxTaskDuration.Should().Be(TimeSpan.FromSeconds(5));
+
+        await using var lane = await ClientLane.OpenAsync(options: options);
+        var page = await lane.NewPageAsync("vue-folder-tree");
+        await page.EvaluateAsync(
+            """
+            () => {
+              globalThis.__budgetedReactions = 0;
+              for (const id of ['load', 'create']) {
+                document.getElementById(id).addEventListener(
+                  'click', () => __queueBudgetedTasks(), { capture: true, once: true });
+              }
+            }
+            """);
+
+        // Both tasks are queued by the actual input dispatch, before either can run. Each costs four
+        // seconds, including its Vue reaction; only a drain-wide five-second deadline rejects the pair.
+        // Advancing after Execute leaves the old FIFO's pending Vue nextTick jobs to discover the expiry.
+        // The reaction checks explicitly rather than depending on the interpreter's amortized cadence.
+        await page.Locator("#load").ClickAsync();
+        await page.Locator("#children").WaitForAsync();
+        await page.Locator("#create").ClickAsync();
+        await page.Locator(".folder-name").Nth(1).WaitForAsync();
+
+        (await page.Locator(".folder-name").AllTextContentsAsync()).Should().Equal("Files", "TestFolder");
+        foreach (var context in lane.Pages.Contexts)
+        {
+            foreach (var hostPage in context.Pages)
+            {
+                hostPage.Errors.Should().BeEmpty();
+            }
+        }
+
+        (await page.EvaluateAsync<int>("() => globalThis.__budgetedReactions")).Should().Be(4);
+        (await page.EvaluateAsync<bool>("() => resizeHeights.some(height => height > 40)")).Should().BeTrue();
         await page.CloseAsync();
     }
 
@@ -494,6 +559,17 @@ public class PlaywrightCourseTests
         await page.CloseAsync();
     }
 
+    private sealed class TaskBudgetClock : TimeProvider
+    {
+        private long _ticks = 1;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _ticks;
+
+        internal void Advance(TimeSpan elapsed) => _ticks += elapsed.Ticks;
+    }
+
     /// <summary>A server serving the course, a browser, a protocol server and a connected Playwright.</summary>
     private sealed class ClientLane : IAsyncDisposable
     {
@@ -525,12 +601,14 @@ public class PlaywrightCourseTests
 
         internal IBrowserContext Context { get; }
 
-        internal static async Task<ClientLane> OpenAsync(Action<LoopbackServer>? routes = null)
+        internal static async Task<ClientLane> OpenAsync(
+            Action<LoopbackServer>? routes = null,
+            BrowserOptions? options = null)
         {
             var server = FixtureOrigin.Serve(new LoopbackServer());
             routes?.Invoke(server);
 
-            var pages = new global::Jint.Browser.Browser();
+            var pages = new global::Jint.Browser.Browser(options);
             await pages.NewContextAsync(new PageContextOptions { UrlFilter = server.Owns }).ConfigureAwait(false);
 
             var protocol = new DevToolsServer();

--- a/Jint.Tests.Browser/Runtime/PageTaskBudgetTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageTaskBudgetTests.cs
@@ -1,0 +1,310 @@
+using Jint.Browser;
+using Jint.Browser.Runtime;
+using Jint.Constraints;
+using Jint.Runtime;
+using Jint.Tests.Browser.DevTools;
+
+namespace Jint.Tests.Browser.Runtime;
+
+public sealed class PageTaskBudgetTests
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public async Task SeparateQueuedTasksReceiveSeparateBudgets()
+    {
+        var clock = new BudgetClock();
+        await using var browser = new global::Jint.Browser.Browser(Options(clock));
+        var page = await browser.NewPageAsync();
+        var completed = 0;
+
+        await page.RunOnLoopAsync(engine =>
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                engine.Tasks.Post(() =>
+                {
+                    clock.Advance();
+                    engine.Constraints.Check();
+                    completed++;
+                });
+            }
+
+            return true;
+        });
+
+        (await page.WaitForIdleAsync(Bound)).Should().BeTrue();
+        completed.Should().Be(3);
+        page.Errors.Should().BeEmpty();
+    }
+
+    [TestCase(false, false)]
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    public async Task SeparateQueuedCommandsReceiveSeparateBudgets(bool precedingTask, bool firstCommandOverruns)
+    {
+        var clock = new BudgetClock();
+        await using var session = await PageSession.CreateAsync(options: Options(clock));
+        var page = await session.NewPageAsync();
+        var sessionId = await session.AttachAsync(await session.TargetForAsync(page));
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var release = new ManualResetEventSlim();
+        var held = page.RunOnLoopAsync(engine =>
+        {
+            if (precedingTask)
+            {
+                engine.Tasks.Post(() =>
+                {
+                    clock.Advance();
+                    engine.Constraints.Check();
+                });
+            }
+
+            entered.SetResult();
+            release.Wait(Bound).Should().BeTrue();
+            return true;
+        });
+
+        Task<System.Text.Json.JsonElement>[] commands;
+        try
+        {
+            await entered.Task.WaitAsync(Bound);
+            commands = Enumerable.Range(0, 3)
+                .Select(i => session.SendAsync("Runtime.evaluate",
+                    firstCommandOverruns && i == 0
+                        ? """{"expression":"spend(); spend(); 42","returnByValue":true}"""
+                        : """{"expression":"spend(); 42","returnByValue":true}""", sessionId))
+                .ToArray();
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await held.WaitAsync(Bound);
+        var replies = await Task.WhenAll(commands).WaitAsync(Bound);
+        for (var i = 0; i < replies.Length; i++)
+        {
+            var reply = replies[i];
+            if (firstCommandOverruns && i == 0)
+            {
+                reply.GetProperty("error").GetProperty("message").GetString().Should().Be("Command timed out");
+                continue;
+            }
+
+            reply.TryGetProperty("error", out var error).Should().BeFalse("command failed: {0}", error);
+            reply.GetProperty("result").GetProperty("result").GetProperty("value").GetInt32().Should().Be(42);
+        }
+
+        page.Errors.Should().BeEmpty();
+    }
+
+    [TestCase("Promise.resolve().then")]
+    [TestCase("queueMicrotask")]
+    public async Task ATaskAndItsMicrotaskCheckpointShareOneBudget(string enqueue)
+    {
+        var clock = new BudgetClock();
+        await using var browser = new global::Jint.Browser.Browser(Options(clock));
+        var page = await browser.NewPageAsync();
+        await page.RunOnLoopAsync(engine =>
+        {
+            engine.Tasks.Post(() => engine.Execute(
+                $$"""spend(); {{enqueue}}(() => { spend(); globalThis.escaped = true; });"""));
+            // Already queued before the first task creates its reaction. It must not split the checkpoint.
+            engine.Tasks.Post(() => engine.SetValue("later", true));
+            return true;
+        });
+
+        (await page.WaitForIdleAsync(Bound)).Should().BeTrue();
+        page.Errors.Should().ContainSingle().Which.Kind.Should().Be(PageErrorKind.BudgetExceeded);
+        (await page.EvaluateAsync<bool>("typeof escaped === 'undefined' && later")).Should().BeTrue();
+    }
+
+    [TestCase("Promise.resolve().then")]
+    [TestCase("queueMicrotask")]
+    public async Task RecursiveMicrotasksCannotRenewTheirBudget(string enqueue)
+    {
+        var clock = new BudgetClock();
+        await using var browser = new global::Jint.Browser.Browser(Options(clock));
+        var page = await browser.NewPageAsync();
+        await page.RunOnLoopAsync(engine =>
+        {
+            engine.Tasks.Post(() => engine.Execute(
+                $$"""
+                  globalThis.calls = 0;
+                  function spin() { spend(); calls++; {{enqueue}}(spin); }
+                  {{enqueue}}(spin);
+                  """));
+            return true;
+        });
+
+        (await page.WaitForIdleAsync(Bound)).Should().BeTrue();
+        page.Errors.Should().ContainSingle().Which.Kind.Should().Be(PageErrorKind.BudgetExceeded);
+        (await page.EvaluateAsync<int>("calls")).Should().Be(1);
+    }
+
+    [Test]
+    public async Task AMailboxRequestKeepsItsBudgetThroughItsMicrotasks()
+    {
+        var clock = new BudgetClock();
+        await using var browser = new global::Jint.Browser.Browser(Options(clock));
+        var page = await browser.NewPageAsync();
+
+        var act = () => page.EvaluateAsync("spend(); Promise.resolve().then(() => spend());");
+        await act.Should().ThrowAsync<TimeoutException>();
+        page.Errors.Should().BeEmpty();
+        (await page.EvaluateAsync<int>("42")).Should().Be(42);
+    }
+
+    [Test]
+    public async Task SeparateTasksReceiveSeparateAllocationBudgets()
+    {
+        await using var browser = new global::Jint.Browser.Browser(new BrowserOptions { MemoryLimit = 4_000_000 });
+        var page = await browser.NewPageAsync();
+        var completed = 0;
+        await page.RunOnLoopAsync(engine =>
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                engine.Tasks.Post(() =>
+                {
+                    GC.KeepAlive(new byte[3_000_000]);
+                    engine.Constraints.Check();
+                    completed++;
+                });
+            }
+
+            return true;
+        });
+
+        (await page.WaitForIdleAsync(Bound)).Should().BeTrue();
+        completed.Should().Be(3);
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ATaskAndItsMicrotasksShareTheirAllocationBudget()
+    {
+        await using var browser = new global::Jint.Browser.Browser(new BrowserOptions { MemoryLimit = 4_000_000 });
+        var page = await browser.NewPageAsync();
+        await page.RunOnLoopAsync(engine =>
+        {
+            engine.SetValue("allocate", () =>
+            {
+                GC.KeepAlive(new byte[3_000_000]);
+                engine.Constraints.Check();
+            });
+            engine.Tasks.Post(() => engine.Execute(
+                "allocate(); Promise.resolve().then(() => { allocate(); globalThis.escaped = true; });"));
+            return true;
+        });
+
+        (await page.WaitForIdleAsync(Bound)).Should().BeTrue();
+        page.Errors.Should().ContainSingle().Which.Kind.Should().Be(PageErrorKind.BudgetExceeded);
+        (await page.EvaluateAsync<bool>("typeof escaped === 'undefined'")).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ATasksMicrotasksRunBeforeTheNextQueuedTask()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.RunOnLoopAsync(engine =>
+        {
+            engine.Tasks.Post(() => engine.Execute(
+                "globalThis.order = ['task']; Promise.resolve().then(() => order.push('microtask'));"));
+            engine.Tasks.Post(() => engine.Execute("order.push('next task')"));
+            return true;
+        });
+
+        (await page.WaitForIdleAsync(Bound)).Should().BeTrue();
+        (await page.EvaluateAsync<string>("order.join(',')")).Should().Be("task,microtask,next task");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [TestCase("setTimeout")]
+    [TestCase("requestIdleCallback")]
+    public async Task ScheduledCallbacksReceiveSeparateBudgets(string schedule)
+    {
+        var clock = new BudgetClock();
+        await using var browser = new global::Jint.Browser.Browser(Options(clock));
+        var page = await browser.NewPageAsync();
+        await page.RunOnLoopAsync(engine =>
+        {
+            engine.Tasks.Post(() => engine.Execute(
+                $$"""
+                  globalThis.completed = 0;
+                  for (let i = 0; i < 3; i++) {
+                    {{schedule}}(() => { spend(); completed++; });
+                  }
+                  """));
+            return true;
+        });
+
+        (await page.WaitForIdleAsync(Bound)).Should().BeTrue();
+        (await page.EvaluateAsync<int>("completed")).Should().Be(3);
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnIdleCallbackAndItsMicrotasksAreBounded()
+    {
+        var clock = new BudgetClock();
+        await using var browser = new global::Jint.Browser.Browser(Options(clock));
+        var page = await browser.NewPageAsync();
+        await page.RunOnLoopAsync(engine =>
+        {
+            engine.Tasks.Post(() => engine.Execute(
+                "requestIdleCallback(() => { spend(); queueMicrotask(() => { spend(); globalThis.escaped = true; }); });"));
+            return true;
+        });
+
+        (await page.WaitForIdleAsync(Bound)).Should().BeTrue();
+        page.Errors.Should().ContainSingle().Which.Kind.Should().Be(PageErrorKind.BudgetExceeded);
+        (await page.EvaluateAsync<bool>("typeof escaped === 'undefined'")).Should().BeTrue();
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void BothLanesDiscardWorkFromAnEndedEvaluationCycle(bool microtask)
+    {
+        using var engine = new Engine();
+        PageBudget.For(engine, new BrowserOptions());
+        var snapshot = engine.Advanced.CaptureGlobalSnapshot();
+        var registration = engine.CaptureEventLoopRegistration();
+        var kind = microtask ? EventLoopJobKind.Microtask : EventLoopJobKind.Task;
+        var calls = new List<string>();
+        engine.AddToEventLoop(() => calls.Add("queued before restore"), registration, kind);
+
+        engine.Advanced.RestoreGlobalSnapshot(snapshot);
+        engine.AddToEventLoop(() => calls.Add("arrived after restore"), registration, kind);
+        engine.AddToEventLoop(() => calls.Add("fresh"), kind);
+        engine.Tasks.ProcessTasks();
+
+        calls.Should().Equal("fresh");
+    }
+
+    private static BrowserOptions Options(BudgetClock clock)
+    {
+        return new BrowserOptions().ConfigureEngine(options =>
+        {
+            options.RemoveConstraints(static constraint => constraint is OperationDeadlineConstraint);
+            options.AddConstraint(() => new OperationDeadlineConstraint(clock));
+            options.Configure(engine => engine.SetValue("spend", () =>
+            {
+                clock.Advance();
+                engine.Constraints.Check();
+            }));
+        });
+    }
+
+    private sealed class BudgetClock : TimeProvider
+    {
+        private long _ticks = 1;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public override long GetTimestamp() => _ticks;
+
+        internal void Advance() => _ticks += TimeSpan.FromSeconds(4).Ticks;
+    }
+}

--- a/Jint/Engine.Pump.cs
+++ b/Jint/Engine.Pump.cs
@@ -93,14 +93,23 @@ public partial class Engine
     /// </summary>
     /// <returns>Whether a timer was promoted, i.e. whether the pump has more work to do.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool TryPromoteDueTimerJob()
+    internal bool TryPromoteDueTimerJob(bool includeIdleCallbacks = true)
     {
 #if NET8_0_OR_GREATER
         var webApi = _webApi;
-        return webApi is not null && webApi.TryPromoteDeferredWork();
+        return webApi is not null && webApi.TryPromoteDeferredWork(includeIdleCallbacks);
 #else
         // Timers are the one web API that needs engine infrastructure, and every line of them is net8.0 and
         // later; downlevel there is nothing to promote and the JIT folds this call away to nothing.
+        return false;
+#endif
+    }
+
+    internal bool TryRunIdleCallback()
+    {
+#if NET8_0_OR_GREATER
+        return _webApi?.IdleCallbacks is { } idle && idle.TryRunIdleCallback();
+#else
         return false;
 #endif
     }

--- a/Jint/Engine.Tasks.cs
+++ b/Jint/Engine.Tasks.cs
@@ -63,6 +63,15 @@ public partial class Engine
             _engine.RunAvailableContinuations();
         }
 
+        internal void ConfigureTaskBudget(IEventLoopTaskBudget budget)
+            => _engine._eventLoop.ConfigureTaskBudget(budget);
+
+        internal void ProcessTask()
+        {
+            using var ownership = _engine.EnterHostCall();
+            _engine._eventLoop.RunAvailableContinuations(_engine, singleTask: true);
+        }
+
         /// <summary>
         /// Enqueues <paramref name="action"/> as an event-loop job, from any thread, waking a parked pump.
         /// </summary>

--- a/Jint/Engine.WebApi.cs
+++ b/Jint/Engine.WebApi.cs
@@ -203,11 +203,10 @@ public partial class Engine
     }
 
     /// <summary>
-    /// Whether the event loop still has jobs queued behind the one running now. Only the web-API scheduler
-    /// reads it, to keep a task from overtaking the microtasks of the turn it was posted in — see
-    /// <see cref="Runtime.EventLoop.HasPendingJobs"/>.
+    /// Whether a deferred task must yield to a pending checkpoint. On an ordinary engine this is its FIFO;
+    /// on a browser engine it is only the microtask lane, never another task waiting for its own turn.
     /// </summary>
-    internal bool HasPendingEventLoopJobs => _eventLoop.HasPendingJobs;
+    internal bool HasPendingEventLoopJobs => _eventLoop.HasPendingCheckpointJobs;
 }
 
 /// <summary>
@@ -775,7 +774,7 @@ internal sealed class WebApiEngineState
     /// The order is the priority: a due timer is a task, and idle callbacks are what a browser runs in the
     /// slack after the tasks are done, so nothing idle may overtake a timer that is already due.
     /// </remarks>
-    internal bool TryPromoteDeferredWork()
+    internal bool TryPromoteDeferredWork(bool includeIdleCallbacks)
     {
         var timers = Timers;
         if (timers is not null && timers.TryTakeDue(out var entry))
@@ -787,7 +786,7 @@ internal sealed class WebApiEngineState
             return true;
         }
 
-        return IdleCallbacks is { } idle && idle.TryRunIdleCallback();
+        return includeIdleCallbacks && IdleCallbacks is { } idle && idle.TryRunIdleCallback();
     }
 
     /// <summary>

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -3060,6 +3060,8 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     private List<JsPromise>? _rejectionNotifications;
 
+    internal bool HasPendingRejectionNotifications => _rejectionNotifications is { Count: > 0 };
+
     /// <summary>
     /// Drops every notification this engine still owes, for
     /// <see cref="AdvancedOperations.RestoreGlobalSnapshot"/>.

--- a/Jint/Runtime/EventLoop.cs
+++ b/Jint/Runtime/EventLoop.cs
@@ -21,7 +21,7 @@ internal readonly record struct EventLoopRegistration(
     MemoryLimitConstraint.OperationState? MemoryState);
 
 /// <summary>
-/// Which of HTML's two queues an entry on Jint's single job queue would have been on: its <i>microtask
+/// Which of HTML's two queues an entry belongs on: its <i>microtask
 /// queue</i>, or one of its <i>task queues</i>.
 /// <para>
 /// https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model
@@ -29,7 +29,8 @@ internal readonly record struct EventLoopRegistration(
 /// </summary>
 /// <remarks>
 /// <para>
-/// Jint has one queue, and running it in order is right for everything except one question:
+/// Ordinary Engine hosts retain one FIFO; browser engines separate tasks from microtasks so a task and
+/// its complete checkpoint share one budget. Both modes need the same classification:
 /// <see cref="EventLoop.RunMicrotaskCheckpoint"/> has to know where the microtasks end. So every enqueue
 /// site says which it is, at the site, and the two <see cref="Engine.AddToEventLoop(Action, EventLoopJobKind)"/>
 /// overloads take it with no default — a new source of deferred work has to decide rather than inherit.
@@ -46,7 +47,7 @@ internal readonly record struct EventLoopRegistration(
 internal enum EventLoopJobKind : byte
 {
     /// <summary>
-    /// A task. The checkpoint stops at it, and it runs in the turn's own drain.
+    /// A task. It runs outside the microtask checkpoint.
     /// </summary>
     Task,
 
@@ -106,6 +107,7 @@ internal readonly struct EventLoopJob
 
     public int Generation => _generation;
     public MemoryLimitConstraint.OperationState? MemoryState => _memoryState;
+    internal bool IsTask => _kind == EventLoopJobKind.Task && !ReferenceEquals(_state, EventLoop.WakeJob);
 
     /// <summary>
     /// Whether <see cref="EventLoop.RunMicrotaskCheckpoint"/> may run this job: a
@@ -128,6 +130,15 @@ internal readonly struct EventLoopJob
     }
 }
 
+/// <summary>
+/// The browser's budget over a task and its complete microtask checkpoint, never over a pump drain.
+/// </summary>
+internal interface IEventLoopTaskBudget
+{
+    bool BeginTask(bool isTask);
+    void EndTask();
+}
+
 internal sealed record EventLoop
 {
     /// <summary>
@@ -144,6 +155,41 @@ internal sealed record EventLoop
     internal static readonly Action WakeJob = static () => { };
 
     private readonly ConcurrentQueue<EventLoopJob> _events = new();
+    private ConcurrentQueue<EventLoopJob>? _tasks;
+    private IEventLoopTaskBudget? _taskBudget;
+
+    // Installed before a browser engine runs script. Ordinary embedders retain their single FIFO and
+    // host-owned budget contract; a browser needs HTML's two lanes to keep a task's reactions ahead of
+    // the next task, even when that task was queued before the reactions.
+    internal void ConfigureTaskBudget(IEventLoopTaskBudget budget)
+    {
+        if (_tasks is not null)
+        {
+            Throw.InvalidOperationException("The event loop already has a task budget.");
+        }
+
+        var tasks = new ConcurrentQueue<EventLoopJob>();
+        var pending = new Queue<EventLoopJob>();
+        while (_events.TryDequeue(out var job))
+        {
+            if (job.IsTask)
+            {
+                tasks.Enqueue(job);
+            }
+            else
+            {
+                pending.Enqueue(job);
+            }
+        }
+
+        foreach (var job in pending)
+        {
+            _events.Enqueue(job);
+        }
+
+        _taskBudget = budget;
+        _tasks = tasks;
+    }
 
     /// <summary>
     /// Tracks whether we are currently processing the event loop.
@@ -162,12 +208,13 @@ internal sealed record EventLoop
     internal bool IsRunningJob => Volatile.Read(ref _isProcessing) == 1;
 
     /// <summary>
-    /// Whether any job is still queued. Read from inside a running job by work that must not overtake the
-    /// jobs behind it: the web-API scheduler's drain job consults it to reproduce HTML's <i>microtask
-    /// checkpoint</i>, re-queueing itself while anything else is pending so that a scheduler task never runs
-    /// before a promise reaction that was queued in the same turn.
+    /// Whether either lane has queued work, including wake entries.
     /// </summary>
-    internal bool HasPendingJobs => !_events.IsEmpty;
+    internal bool HasPendingJobs => !_events.IsEmpty || _tasks is { IsEmpty: false };
+
+    // Feature pumps yield to the original FIFO for ordinary engines, but only to reactions in a browser.
+    // Yielding to other tasks on the separate lane would let two feature pumps defer on each other forever.
+    internal bool HasPendingCheckpointJobs => !_events.IsEmpty;
 
     /// <summary>
     /// Tracks the thread ID of the thread that is currently waiting on a promise.
@@ -237,20 +284,21 @@ internal sealed record EventLoop
     /// </summary>
     internal void NextGeneration() => Interlocked.Increment(ref _generation);
 
-    public bool IsEmpty => _events.IsEmpty;
+    public bool IsEmpty => !HasPendingJobs;
 
     /// <summary>
     /// How many jobs are queued right now, for <see cref="Engine.DiagnosticOperations.GetMemoryReport(int)"/>.
     /// A sample rather than a stable value: a background thread settling a promise enqueues from there.
     /// </summary>
-    internal int QueueDepth => _events.Count;
+    internal int QueueDepth => _events.Count + (_tasks?.Count ?? 0);
 
     public void Enqueue(Action continuation, EventLoopJobKind kind)
         => Enqueue(new EventLoopJob(continuation, Generation, memoryState: null, kind));
 
     public void Enqueue(in EventLoopJob job)
     {
-        _events.Enqueue(job);
+        var queue = job.IsTask ? _tasks ?? _events : _events;
+        queue.Enqueue(job);
 
         // Null means no thread has ever block-drained this engine, so there is nobody to wake. The enqueue
         // above and WaitForWork's event-creation are both full fences, so whichever of the two raced ahead,
@@ -299,7 +347,7 @@ internal sealed record EventLoop
         // A non-empty queue only ends the wait when this thread can actually drain it. Nested inside a job
         // (IsRunningJob), the re-entrancy guard makes queued jobs unrunnable from here, and returning early
         // for them would turn this bounded wait into a hot spin for the caller's whole timeout.
-        if ((!_events.IsEmpty && !IsRunningJob) || completedEvent?.IsSet == true)
+        if ((HasPendingJobs && !IsRunningJob) || completedEvent?.IsSet == true)
         {
             return;
         }
@@ -323,7 +371,7 @@ internal sealed record EventLoop
     public Task WaitForEventAsync(CancellationToken cancellationToken)
     {
         // Fast path: already have events queued
-        if (!_events.IsEmpty)
+        if (HasPendingJobs)
         {
             return Task.CompletedTask;
         }
@@ -340,7 +388,7 @@ internal sealed record EventLoop
         // rather than removing from the list — Enqueue's broadcast TrySetResult on
         // an already-completed TCS is a no-op, so leaving the entry costs nothing
         // beyond a single GC root until the next Enqueue clears the list.
-        if (!_events.IsEmpty)
+        if (HasPendingJobs)
         {
             tcs.TrySetResult(true);
             return tcs.Task;
@@ -397,9 +445,16 @@ internal sealed record EventLoop
         while (_events.TryDequeue(out _))
         {
         }
+
+        if (_tasks is { } tasks)
+        {
+            while (tasks.TryDequeue(out _))
+            {
+            }
+        }
     }
 
-    public void RunAvailableContinuations(Engine engine)
+    public void RunAvailableContinuations(Engine engine, bool singleTask = false)
     {
         // If there's a waiting thread (e.g., in UnwrapIfPromise), only that thread
         // should execute continuations. This prevents background threads (from Task
@@ -420,6 +475,12 @@ internal sealed record EventLoop
 
         try
         {
+            if (_tasks is not null)
+            {
+                RunTasks(engine, singleTask);
+                return;
+            }
+
             while (true)
             {
                 // An Atomics.waitAsync timeout is the one piece of scheduled work that cannot wait for the
@@ -485,6 +546,108 @@ internal sealed record EventLoop
         }
     }
 
+    private void RunTasks(Engine engine, bool singleTask)
+    {
+        engine.SettleTimedOutAtomicsWaiters();
+
+        // Pending reactions belong to the surrounding script/mailbox request when there is one, not to
+        // a new budget just because that script has returned to the pump.
+        if (!_events.IsEmpty || engine.HasPendingRejectionNotifications)
+        {
+            var entered = _taskBudget!.BeginTask(isTask: false);
+            try
+            {
+                RunTaskCheckpoint(engine);
+            }
+            finally
+            {
+                if (entered)
+                {
+                    _taskBudget.EndTask();
+                }
+            }
+        }
+
+        while (true)
+        {
+            if (!_tasks!.TryDequeue(out var task))
+            {
+                if (engine.TryPromoteDueTimerJob(includeIdleCallbacks: false))
+                {
+                    continue;
+                }
+
+                // Unlike a timer, an idle callback runs directly rather than being promoted to a job.
+                // It still owns one budget together with its reactions.
+                _taskBudget!.BeginTask(isTask: true);
+                try
+                {
+                    if (!engine.TryRunIdleCallback())
+                    {
+                        return;
+                    }
+
+                    RunTaskCheckpoint(engine);
+                }
+                finally
+                {
+                    _taskBudget.EndTask();
+                }
+
+                if (singleTask)
+                {
+                    return;
+                }
+
+                continue;
+            }
+
+            if (task.Generation != Generation)
+            {
+                continue;
+            }
+
+            _taskBudget!.BeginTask(isTask: true);
+            try
+            {
+                engine.RunEventLoopJob(in task);
+                RunTaskCheckpoint(engine);
+            }
+            finally
+            {
+                _taskBudget.EndTask();
+            }
+
+            if (singleTask)
+            {
+                return;
+            }
+        }
+    }
+
+    private void RunTaskCheckpoint(Engine engine)
+    {
+        // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint
+        // No new budget inside this loop: a recursive Promise.then/queueMicrotask chain is still part
+        // of the task that queued it, including when unrelated tasks are already waiting.
+        do
+        {
+            while (true)
+            {
+                engine.SettleTimedOutAtomicsWaiters();
+                if (!_events.TryDequeue(out var job))
+                {
+                    break;
+                }
+
+                if (job.Generation == Generation)
+                {
+                    engine.RunEventLoopJob(in job);
+                }
+            }
+        } while (engine.NotifyAboutRejectedPromises());
+    }
+
     /// <summary>
     /// HTML's <i>perform a microtask checkpoint</i>
     /// (https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint), run from
@@ -494,15 +657,17 @@ internal sealed record EventLoop
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>It runs the microtasks at the head of the queue and stops at the first task.</b> Jint has a single
-    /// queue where HTML has a microtask queue and a set of task queues, so which of the two an entry belongs
-    /// to is carried by the entry: every enqueue site states an <see cref="EventLoopJobKind"/>, and
+    /// <b>It runs the microtasks at the head of the queue and stops at the first task.</b> An ordinary
+    /// Engine has a single queue where HTML has a microtask queue and a set of task queues, so an entry's kind
+    /// is carried by the entry: every enqueue site states an <see cref="EventLoopJobKind"/>, and
     /// <see cref="EventLoopJob.MayRunInMicrotaskCheckpoint"/> is that answer. Running a task from here would
     /// run one inside a checkpoint, which no event loop does; <b>skipping past it</b> to a microtask behind
     /// it would reorder the one queue, which is the approximation that remains — a
     /// <c>queueMicrotask</c> callback queued behind an <c>XMLHttpRequest</c> delivery waits for the turn's
     /// own drain, where a browser would run it first. That is the behaviour every dispatch had before this
     /// method existed, so what still waits costs nothing that was ever promised.
+    /// Browser engines instead put tasks on a separate lane, so this checkpoint reaches every reaction
+    /// without running or reordering tasks.
     /// <see cref="WakeJob"/> is looked past rather than stopped at, because a wake is not work.
     /// </para>
     /// <para>

--- a/Jint/WebApi/AGENTS.md
+++ b/Jint/WebApi/AGENTS.md
@@ -13,6 +13,9 @@ These are owned by WHATWG living standards rather than by ECMA-262, each with it
 
 ### Web APIs
 
+The single-queue descriptions below apply to ordinary `Engine` hosts. Browser task/checkpoint lanes and
+budgets are governed by [`Jint.Browser/Runtime/AGENTS.md`](../../Jint.Browser/Runtime/AGENTS.md).
+
 `Jint/WebApi/` holds the opt-in WHATWG surface — `console`, `DOMException`, and the timers/encoding/URL/fetch features still landing — with one subfolder and matching namespace per feature (`Console/`, `DomException/`, …). It is deliberately *not* under `Jint/Native/`, which mirrors ECMAScript; these are host APIs guided by WinterTC's Minimum Common Web Platform API, they use the BCL only (no new package dependencies), and their JS-facing types are `internal sealed` and authored with the source generator exactly like the built-ins.
 
 Four conventions hold across the subtree:

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -75,7 +75,7 @@ fraction of Chromium's CPU and memory per page, at some multiple of its wall-clo
   in v1. The previous engine receives `beforeunload`, `pagehide` and `unload`, its cancellation token is
   cancelled, its pending fetches abandoned, and it is disposed on the page loop.
 - **One `PageLoop` thread per page**, owning the engine and the DOM: it drains a mailbox of host and protocol
-  work, calls `Tasks.ProcessTasks()`, runs the animation-frame lane, and sleeps by
+  work, runs one engine task and its microtask checkpoint, runs the animation-frame lane, and sleeps by
   `Tasks.TimeUntilNextScheduledWork` — the `WptHarness.PumpWorker` shape. Every public `Page` API and every CDP
   command posts to the mailbox and awaits a completion; nothing else touches the engine or the DOM. Workers come
   from a `ThreadPerWorkerProvider` (the package is a host, so it may start threads; the engine still never does).
@@ -181,8 +181,10 @@ frame's document — AngleSharp opens it into the nested browsing context it alr
 The constraints gotcha in the root `AGENTS.md` applies twice over: a page is a host-driven sequence of entries,
 and its event loop is pumped. So a page's budget is built only from what survives the per-entry reset.
 `BrowserOptions.MaxTaskDuration` brackets each **turn** with `OperationDeadlineConstraint.Begin`/`End`, and a
-turn is one mailbox request, one `ProcessTasks` drain (every due timer callback, microtask, promise reaction
-and animation-frame batch together) or one inline `<script>`. A request that runs out of budget fails its own
+turn is one mailbox request, one task (timer callback, observer/rendering task, animation-frame batch or
+protocol command) and its complete microtask checkpoint, or one inline `<script>`. Browser engines separate
+task and microtask lanes so recursive reactions stay in their originating task's budget even when another
+task was already queued; ordinary engine hosts retain their existing FIFO. A request that runs out of budget fails its own
 task with `TimeoutException`; a drain's and a script's are recorded as a `PageErrorKind.BudgetExceeded` entry
 and the page survives. `BrowserOptions.MemoryLimit` arms a per-page `MemoryLimitConstraint` over the same turn,
 and a worker's pump takes the same bracket over the constraint factories its parent replayed. `Page.Close` and

--- a/docs/v5-migration.md
+++ b/docs/v5-migration.md
@@ -5456,6 +5456,19 @@ options.WebApi.Fetch.BaseUrl = new Uri("https://example.org/pages/one.html");
 a `SyntaxError` rather than a request to a host nobody named. The only scripts affected are ones that were
 throwing.
 
+### 4.131 Browser task budgets no longer cover an entire queue drain
+
+`Jint.Browser` applies `BrowserOptions.MaxTaskDuration` and `MemoryLimit` to each queued task and its complete
+microtask checkpoint, rather than to all the work available to one pump. Separately queued timer callbacks,
+observer/rendering tasks and CDP commands receive separate allowances; the default time budget remains five
+seconds. An expensive prior command no longer interrupts a later promise reaction just because both were
+available together. Recursive promise and `queueMicrotask` chains cannot renew their task's budget.
+
+Browser engines run a task's microtasks before the next queued task, even when that next task arrived first.
+Page, parser and worker pumps return between tasks. Ordinary `Engine.Tasks.ProcessTasks` hosts keep their
+existing FIFO and host-owned constraint-reset behavior. The DevTools running-mode dispatcher now answers one
+command per posted job; paused debugging remains inline in the suspended command. No public API was added.
+
 ## 5. New in v5
 
 Everything in the table below is opt-in: nothing in it is installed unless the host asks for it, so


### PR DESCRIPTION
## Summary

Fix page-loop budget accounting that interrupted OrchardCore's Vue media-tree updates. The page, parser and worker pumps previously charged an entire queue drain against one deadline, while the DevTools dispatcher ran multiple protocol commands inside one queued task. Individually safe operations could therefore exhaust the budget of a later promise reaction.

- Give each browser task its own budget covering its complete recursive microtask checkpoint, using internal task/microtask lanes.
- Process one running-mode CDP command or host work item per dispatcher job, and return between tasks in page, parser and worker pumps.
- Preserve individual-task protection for timers and directly executed idle callbacks, recursive promises and `queueMicrotask` chains, memory accounting, cancellation, generation fences and paused debugging.
- Keep the default five-second budget, ordinary Engine FIFO behavior and public API unchanged. No sleeps, retries, forced clicks or readiness workarounds.
- Add deterministic task, command, allocation, snapshot and real Playwright/Vue regressions, and update the accounting documentation.

## Reproduction and validation

The deterministic Playwright/Vue regression fails against the original `fcbb73e2326e4bd0fb8f511df363e2971450f7c2` runtime with `PageLoop: The operation's time budget elapsed`; only two of four Vue `nextTick` reactions complete. It passes with this change. Initial separate queued-task and queued-command regressions also failed against the original runtime.

All local runs used fresh Release builds:

| Coverage | net8 | net10 |
| --- | ---: | ---: |
| Final focused browser budgets, all 14 enabled Playwright course cases, DOM-binding and fixture guardians, with host-contract verification | 60 passed | 60 passed |
| Core scheduling, idle callbacks, Atomics, diagnostics and instruction/spec/migration guardians, with host-contract verification | 165 passed | 165 passed |
| DevTools session, protocol and API selection | 349 passed | 351 passed |
| Public-interface host constraints, snapshots and API selection, with host-contract verification | 139 passed | 149 passed |

An earlier broader relevant browser selection passed 429 cases on each framework; its 13 gated client cases were subsequently exercised with clients enabled. All five shipped engine target assets compiled.

Independent integration validation:

- **Live OrchardCore MediaAppTests improved from 4/9 to 9/9 on net10**, using a consistent local Jint/Jint.DevTools/Jint.Browser dependency graph; exit code 0.
- The unchanged full Orchard media bundle passed three consecutive real-CDP runs on each of net8 and net10, with TestFolder visible and no budget errors.

## Scope and limitations

The preexisting `javascript:void(0)` Navigation diagnostic is unrelated and unchanged. Full repository, WPT and Test262 suites were not run.