### PR TITLE
Fix WebSocket test observer snapshot race

### DIFF
--- a/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
+++ b/Jint.Tests/Runtime/WebApi/WebSocketTests.cs
@@ -457,45 +457,85 @@ public class WebSocketTests
         Log(engine).Should().Be("open|close:1000");
     }
 
+    [Test]
+    public void ObserverSnapshotsDoNotChangeWhenAnotherCallbackIsRecorded()
+    {
+        var observer = new RecordingSocketObserver();
+        var id = new WebSocketId(1);
+        observer.OnCreated(id, new Uri("wss://example.org/socket"));
+
+        var events = observer.Events;
+        var ids = observer.Ids;
+
+        observer.OnClosed(id, 1000, "done", wasClean: true);
+
+        events.Should().Equal("created wss://example.org/socket");
+        ids.Should().Equal(id);
+        observer.Events.Should().Equal("created wss://example.org/socket", "closed 1000 done clean=True");
+        observer.Ids.Should().Equal(id, id);
+    }
+
     private sealed class RecordingSocketObserver : Jint.WebApi.WebSockets.WebSocketObserver
     {
-        internal List<string> Events { get; } = new();
+        private readonly List<string> _events = new();
+        private readonly List<Jint.WebApi.WebSockets.WebSocketId> _ids = new();
 
-        internal List<Jint.WebApi.WebSockets.WebSocketId> Ids { get; } = new();
+        // Transport callbacks can append while the test enumerates its snapshot.
+        internal IReadOnlyList<string> Events
+        {
+            get
+            {
+                lock (_events)
+                {
+                    return _events.ToArray();
+                }
+            }
+        }
+
+        internal IReadOnlyList<Jint.WebApi.WebSockets.WebSocketId> Ids
+        {
+            get
+            {
+                lock (_events)
+                {
+                    return _ids.ToArray();
+                }
+            }
+        }
 
         public override void OnCreated(Jint.WebApi.WebSockets.WebSocketId id, Uri url)
         {
-            lock (Events)
+            lock (_events)
             {
-                Ids.Add(id);
-                Events.Add("created " + url.AbsoluteUri);
+                _ids.Add(id);
+                _events.Add("created " + url.AbsoluteUri);
             }
         }
 
         public override void OnHandshakeRequest(Jint.WebApi.WebSockets.ObservedWebSocketHandshake handshake)
         {
-            lock (Events)
+            lock (_events)
             {
-                Ids.Add(handshake.Id);
-                Events.Add($"handshake {handshake.Url.AbsoluteUri} protocols={string.Join(",", handshake.Protocols)} headers={string.Join(",", handshake.Headers.Select(h => h.Name))}");
+                _ids.Add(handshake.Id);
+                _events.Add($"handshake {handshake.Url.AbsoluteUri} protocols={string.Join(",", handshake.Protocols)} headers={string.Join(",", handshake.Headers.Select(h => h.Name))}");
             }
         }
 
         public override void OnHandshakeResponse(Jint.WebApi.WebSockets.ObservedWebSocketResponse response)
         {
-            lock (Events)
+            lock (_events)
             {
-                Ids.Add(response.Id);
-                Events.Add($"response {response.Status} {response.SubProtocol} headers={string.Join(",", response.Headers.Select(h => h.Name))}");
+                _ids.Add(response.Id);
+                _events.Add($"response {response.Status} {response.SubProtocol} headers={string.Join(",", response.Headers.Select(h => h.Name))}");
             }
         }
 
         public override void OnClosed(Jint.WebApi.WebSockets.WebSocketId id, int code, string reason, bool wasClean)
         {
-            lock (Events)
+            lock (_events)
             {
-                Ids.Add(id);
-                Events.Add($"closed {code} {reason} clean={wasClean}");
+                _ids.Add(id);
+                _events.Add($"closed {code} {reason} clean={wasClean}");
             }
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

<!-- One short sentence (under 80 characters) describing the change. -->

Prevent concurrent collection modification in WebSocket observer tests.

## Details

<!--
- What changed and why
- Anything reviewers should pay extra attention to
- Notable implementation choices or trade-offs
-->

Linux CI for #3842 intermittently failed at `WebSocketTests.cs:433`: test assertions enumerated `RecordingSocketObserver.Events` while transport callbacks appended to it. Writers locked the collection, but readers did not.

Keep both event and identifier lists private and return snapshots copied under the same lock used by all four callbacks. This protects every existing count, index, and enumeration read without changing assertions, waits, or production behavior. A deterministic regression test confirms that previously captured snapshots remain unchanged after another callback.

## Linked issue

<!-- Use "Fixes #1234" or "Closes #1234" so the issue is auto-closed on merge. For discussion-only changes use "Refs #1234". -->

Refs #3842 (the CI failure is unrelated to that PR's documentation changes).

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally (scoped to `Jint.Tests/Jint.Tests.csproj`)
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions - N/A
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` - N/A
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark` - N/A

On macOS, with `NUnit.DefaultTimeout=30000`:

- Confirmed the new snapshot regression fails before the fix and passes afterward.
- Ran the 81-test WebSocket fixture, then repeated it 20 times on both `net8.0` and `net10.0`: all 3,240 repeated test executions passed.
- Ran the full owning project in Release on both frameworks: each reported 12,329 passed, 6 skipped, and 0 failed.

## Breaking change?

<!-- Yes / No. If yes, describe the public-API impact and any migration steps. -->

No. Test-only synchronization change.