### PR TITLE
Publish native browser tools and standalone release binaries

### DIFF
--- a/.github/browser-tool.nuget.config
+++ b/.github/browser-tool.nuget.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="tool-under-test" value="../artifacts/browser-tool-packages" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <!-- The SDK may download apphost templates while installing a tool. Only those may come from
+       nuget.org; both the manifest and the native implementation must come from this build. -->
+  <packageSourceMapping>
+    <packageSource key="tool-under-test">
+      <package pattern="Jint.Browser.Tool*" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="Microsoft.NETCore.App.Host.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/.github/workflows/browser-tool.yml
+++ b/.github/workflows/browser-tool.yml
@@ -1,0 +1,139 @@
+name: Browser tool distribution
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  native:
+    name: browser tool - ${{ matrix.rid }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rid: linux-x64, image: ubuntu-22.04 }
+          - { rid: linux-arm64, image: ubuntu-24.04-arm }
+          - { rid: osx-x64, image: macos-15-intel }
+          - { rid: osx-arm64, image: macos-15 }
+          - { rid: win-x64, image: windows-2022, extension: .exe }
+          - { rid: win-arm64, image: windows-11-arm, extension: .exe }
+    runs-on: ${{ matrix.image }}
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0
+
+      - name: Ensure the Linux native toolchain is present
+        if: runner.os == 'Linux'
+        run: |
+          if ! command -v clang > /dev/null || ! dpkg -s zlib1g-dev > /dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends clang zlib1g-dev
+          fi
+
+      - name: Determine package version
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ -n "$RELEASE_TAG" ]]; then
+            VERSION="${RELEASE_TAG#v}"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            PREFIX="$(dotnet msbuild Jint.Browser.Tool/Jint.Browser.Tool.csproj -getProperty:VersionPrefix | tr -d '\r')"
+            VERSION="$PREFIX-preview-$GITHUB_RUN_NUMBER"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "numeric=${VERSION%%-*}" >> "$GITHUB_OUTPUT"
+
+      # The SDK packs only the manifest without a RID; AOT implementations must be built on their OS.
+      - name: Pack the manifest and native implementation
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          NUMERIC_VERSION: ${{ steps.version.outputs.numeric }}
+          RID: ${{ matrix.rid }}
+        run: |
+          dotnet pack Jint.Browser.Tool/Jint.Browser.Tool.csproj -c Release \
+            -p:BrowserToolNative=true -p:Version="$VERSION" \
+            -p:AssemblyVersion="$NUMERIC_VERSION" -p:FileVersion="$NUMERIC_VERSION" \
+            -p:ContinuousIntegrationBuild=true -o artifacts/browser-tool-packages
+          set -o pipefail
+          dotnet pack Jint.Browser.Tool/Jint.Browser.Tool.csproj -c Release -r "$RID" \
+            -p:BrowserToolNative=true -p:Version="$VERSION" \
+            -p:AssemblyVersion="$NUMERIC_VERSION" -p:FileVersion="$NUMERIC_VERSION" \
+            -p:ContinuousIntegrationBuild=true -o artifacts/browser-tool-packages \
+            2>&1 | tee browser-tool-publish.log
+
+      - name: Only the standing core-engine AOT diagnostics are allowed
+        run: |
+          # Remove the trailing project path: every ILC diagnostic there names the tool, not its source.
+          awk '/(warning|error) IL[0-9][0-9][0-9][0-9]:/ { sub(/ \[.*/, ""); print }' \
+            browser-tool-publish.log > browser-tool-diagnostics.log
+          if grep -vE '[/\\]Jint[/\\].*: (Trim|AOT) analysis warning IL[0-9]{4}:' browser-tool-diagnostics.log; then
+            echo '::error::Native publishing reported a diagnostic outside the core Jint inventory'
+            exit 1
+          fi
+
+      - name: Install from the just-built packages, without nuget.org fallback
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          dotnet tool install Jint.Browser.Tool --version "$VERSION" \
+            --tool-path artifacts/browser-tool-installed \
+            --configfile .github/browser-tool.nuget.config
+
+      - name: Exercise the installed native tool
+        env:
+          JINT_BROWSER_TOOL: ${{ github.workspace }}/artifacts/browser-tool-installed/jint-browser${{ matrix.extension }}
+          JINT_BROWSER_TOOL_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -f net10.0 \
+            --filter FullyQualifiedName~PublishedToolTests --logger "console;verbosity=normal"
+
+      - name: Stage the standalone binary from the same publish
+        env:
+          RID: ${{ matrix.rid }}
+          TOOL_EXTENSION: ${{ matrix.extension }}
+        run: |
+          mkdir -p artifacts/browser-tool-downloads
+          cp "artifacts/publish/Jint.Browser.Tool/release_net10.0_$RID/jint-browser$TOOL_EXTENSION" \
+            "artifacts/browser-tool-downloads/jint-browser-$RID$TOOL_EXTENSION"
+          "artifacts/browser-tool-downloads/jint-browser-$RID$TOOL_EXTENSION" --version
+          test "$("artifacts/browser-tool-downloads/jint-browser-$RID$TOOL_EXTENSION" eval about:blank '6 * 7' --timeout 10s | tr -d '\r')" = 42
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: browser-tool-packages-${{ matrix.rid }}
+          path: artifacts/browser-tool-packages/Jint.Browser.Tool.${{ matrix.rid }}.*.nupkg
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: browser-tool-binary-${{ matrix.rid }}
+          path: artifacts/browser-tool-downloads/*
+          if-no-files-found: error
+
+      - name: Preserve native publish diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: browser-tool-diagnostics-${{ matrix.rid }}
+          path: browser-tool-*.log
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,12 @@ env:
   VSTEST_CONNECTION_TIMEOUT: 300
 
 jobs:
+  browser-tool:
+    uses: ./.github/workflows/browser-tool.yml
+
   build:
 
+    needs: browser-tool
     runs-on: ubuntu-latest
     steps:
 
@@ -81,10 +85,25 @@ jobs:
       run: dotnet pack Jint.Browser.Mcp/Jint.Browser.Mcp.csproj --output artifacts --configuration Release -p:VersionSuffix=preview-$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=True
 
     - name: Pack Jint.Browser.Tool with dotnet
-      run: dotnet pack Jint.Browser.Tool/Jint.Browser.Tool.csproj --output artifacts --configuration Release -p:VersionSuffix=preview-$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=True
+      run: dotnet pack Jint.Browser.Tool/Jint.Browser.Tool.csproj --output artifacts --configuration Release -p:BrowserToolNative=true -p:VersionSuffix="preview-$GITHUB_RUN_NUMBER" -p:ContinuousIntegrationBuild=True
+
+    - name: Collect native tool packages
+      uses: actions/download-artifact@v8
+      with:
+        pattern: browser-tool-packages-*
+        path: artifacts
+        merge-multiple: true
 
     - name: Push with dotnet
-      run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.FEEDZ_IO_API_KEY }} --skip-duplicate --source https://f.feedz.io/sebastienros/jint/nuget/index.json
+      env:
+        FEEDZ_IO_API_KEY: ${{ secrets.FEEDZ_IO_API_KEY }}
+      run: |
+        for package in artifacts/*.nupkg; do
+          if [[ "$package" != artifacts/Jint.Browser.Tool.[0-9]* ]]; then
+            dotnet nuget push "$package" --api-key "$FEEDZ_IO_API_KEY" --skip-duplicate --source https://f.feedz.io/sebastienros/jint/nuget/index.json
+          fi
+        done
+        dotnet nuget push artifacts/Jint.Browser.Tool.[0-9]*.nupkg --api-key "$FEEDZ_IO_API_KEY" --skip-duplicate --source https://f.feedz.io/sebastienros/jint/nuget/index.json
 
   # The mirror of the PR workflow's "linux - native aot" job, and there for the reason the Test step above is:
   # a merge is not the commit CI ran on. Its own file documents what it verifies; the short version is that

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,9 @@ concurrency:
 
 jobs:
 
+  browser-tool:
+    uses: ./.github/workflows/browser-tool.yml
+
   test:
 
     name: ${{ matrix.os.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  release:
+    types: [published]
 
 env:
   DOTNET_NOLOGO: true
@@ -20,12 +22,20 @@ permissions:
   contents: read
 
 jobs:
+  browser-tool:
+    uses: ./.github/workflows/browser-tool.yml
+
   build:
 
+    # Publishing release notes must not push the same NuGet version again.
+    if: github.event_name == 'push'
+    needs: browser-tool
     runs-on: ubuntu-latest
 
     # Must match the Environment field of the nuget.org trusted publishing policy.
     # Also the place to add required reviewers if releases should be approval-gated.
+    # The policy must allow creating Jint.* packages, including the six Jint.Browser.Tool.<rid> IDs;
+    # a policy restricted to new versions of the existing Jint package cannot ship the 5.0 additions.
     environment: nuget
 
     permissions:
@@ -121,14 +131,22 @@ jobs:
 
     # The jint-browser dotnet tool, from the same tag and the same version again: it is a shell over
     # Jint.Browser, referenced by project, so a version of its own would be a second number saying nothing.
-    # PackAsTool means the asset is framework-dependent — there is no PublishAot here and cannot be.
+    # .NET 10 packs the RID-selection manifest here; the six native implementations come from the matrix.
     - name: Pack Jint.Browser.Tool with dotnet
       run: >
         dotnet pack Jint.Browser.Tool/Jint.Browser.Tool.csproj --output artifacts --configuration Release
+        -p:BrowserToolNative=true
         -p:Version=${{ steps.version.outputs.version }}
         -p:AssemblyVersion=${{ steps.version.outputs.numeric }}
         -p:FileVersion=${{ steps.version.outputs.numeric }}
         -p:ContinuousIntegrationBuild=True
+
+    - name: Collect native tool packages
+      uses: actions/download-artifact@v8
+      with:
+        pattern: browser-tool-packages-*
+        path: artifacts
+        merge-multiple: true
 
     # Kept next to the push: the minted key is short-lived, so it must not be requested
     # before the (slow) test and pack steps.
@@ -139,4 +157,37 @@ jobs:
         user: sebastienros
 
     - name: Push with dotnet
-      run: dotnet nuget push artifacts/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      env:
+        NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+      run: |
+        # Publish implementations before the manifest so a new tool version never points at absent RIDs.
+        for package in artifacts/*.nupkg; do
+          if [[ "$package" != artifacts/Jint.Browser.Tool.[0-9]* ]]; then
+            dotnet nuget push "$package" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          fi
+        done
+        dotnet nuget push artifacts/Jint.Browser.Tool.[0-9]*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  release-downloads:
+    if: github.event_name == 'release'
+    needs: browser-tool
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: browser-tool-binary-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Attach binaries and checksums to the published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          cd release-assets
+          test "$(find . -maxdepth 1 -type f -name 'jint-browser-*' | wc -l)" -eq 6
+          sha256sum jint-browser-* > SHA256SUMS
+          gh release upload "$RELEASE_TAG" jint-browser-* SHA256SUMS --clobber

--- a/Jint.Browser.Mcp/Jint.Browser.Mcp.csproj
+++ b/Jint.Browser.Mcp/Jint.Browser.Mcp.csproj
@@ -26,8 +26,9 @@
 
     <!-- Off for the reason Jint.Browser's is off, and it is that package's reason rather than this one's:
          AngleSharp is not trim-annotated. The Model Context Protocol packages are IsAotCompatible and
-         everything this serializes goes through a source-generated System.Text.Json context, so nothing here
-         is what would stop a native build; the DOM under it is. -->
+         everything this serializes goes through a source-generated System.Text.Json context. The closed
+         Jint.Browser.Tool program is exercised natively, including MCP, without asserting a general
+         trimming contract for another host's dependency graph. -->
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 

--- a/Jint.Browser.Tool/AGENTS.md
+++ b/Jint.Browser.Tool/AGENTS.md
@@ -94,16 +94,27 @@ would be a report on the profile.
 
 ### Packaging
 
-`PackAsTool` with `ToolCommandName` `jint-browser`, `net8.0;net10.0`, and the first tool package in the
-repository. Three things about it are decisions:
+`PackAsTool` with `ToolCommandName` `jint-browser`. Ordinary builds keep `net8.0;net10.0` for the
+in-process tests; **distribution sets `BrowserToolNative=true`**, selects `net10.0` and uses .NET 10's
+platform-specific Native AOT tool format. Installation requires the .NET 10 SDK, execution no runtime.
 
-- **`IsAotCompatible=false`, and the reason is AngleSharp's** rather than this project's — the same reason
-  `Jint.Browser/Jint.Browser.csproj` argues at length. `PackAsTool` and `PublishAot` cannot both be true
-  anyway, so nothing is lost by saying so out loud.
-- **It packs from `build.yml` and `release.yml` beside `Jint`, `Jint.DevTools`, `Jint.Browser`, `Jint.Browser.Playwright` and `Jint.Browser.Mcp`**, at the
-  same version and from the same tag, because it references them by project. `pr.yml` packs nothing but
-  `Jint`, so a packaging change is verified by running `dotnet pack Jint.Browser.Tool/Jint.Browser.Tool.csproj`
-  before the pull request, not by CI.
+- **Publish AOT on this executable, not as a global MSBuild property.** A global `PublishAot=true`
+  reaches Jint's downlevel targets and its source generators and fails before compiling the tool.
+  No assembly is rooted wholesale and no new IL diagnostic is suppressed. `IlcTreatWarningsAsErrors=false`
+  keeps the core engine's standing inventory visible, as in `Jint.AotExample`; the distribution workflow
+  rejects diagnostics outside that core-engine inventory. This closed program's native run is not a
+  general `IsAotCompatible` claim for the browser libraries.
+- **`browser-tool.yml` is reused by PR, build and release workflows.** Each of the six OS/architecture
+  legs packs a RID implementation and the selection manifest, installs from a source-mapped local feed,
+  and runs `Tool/PublishedToolTests` against the installed executable. The tests cover extraction, scripts,
+  CSS, XML, XPath, globalization, CDP and MCP. Set `JINT_BROWSER_TOOL` and `JINT_BROWSER_TOOL_VERSION` to
+  reproduce; without them those process tests are skipped rather than passed.
+- **`build.yml` and `release.yml` publish the same seven tool packages**, at the libraries' version:
+  six RID packages first, then `Jint.Browser.Tool`'s manifest. The manifest alone is not an installable
+  distribution. Publishing a GitHub release attaches the six single executables and `SHA256SUMS`, without
+  publishing NuGet again. The nuget.org trusted-publishing policy for `release.yml` / environment `nuget`
+  must permit creating the new `Jint.*` IDs, not only updating `Jint`. Symbols and reference documentation
+  are not runtime files.
 - **`README.md` here is the package README NuGet shows.** It is written for somebody who found the tool
   rather than the engine: it must keep saying that this renders nothing, and it must keep the exit-code
   table in step with `ExitCode`. `Jint.Browser.Mcp/README.md` is the other one, for the other audience.

--- a/Jint.Browser.Tool/Jint.Browser.Tool.csproj
+++ b/Jint.Browser.Tool/Jint.Browser.Tool.csproj
@@ -4,9 +4,8 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <OutputType>Exe</OutputType>
 
-    <!-- The package's own two target frameworks, for the same reason Jint.Browser has them: this is host
-         surface on the modern BCL, and a tool package carries one asset per framework so that whichever
-         runtime the user has installed is the one `dotnet tool install` resolves. -->
+    <!-- Keep both frameworks for the in-process command tests. Distribution below uses the .NET 10
+         platform-specific tool format, which requires the .NET 10 SDK to install. -->
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 
     <AssemblyOriginatorKeyFile>..\Jint\Jint.snk</AssemblyOriginatorKeyFile>
@@ -26,16 +25,36 @@
     <AnalysisLevel>latest-Recommended</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
-    <!--
-      Trim and AOT analysis is off for the same reason Jint.Browser's is, and it is that package's reason
-      rather than this one's: AngleSharp resolves services, element factories and attribute handlers by
-      reflection over its own assembly and carries no DynamicallyAccessedMembers claim, so a native binary
-      built from this project would fail at run time in code no analyzer here can see. A tool package is
-      framework-dependent anyway — PackAsTool and PublishAot cannot both be true — so nothing is lost by
-      saying so.
-    -->
+    <!-- Do not assert that the browser library is generally trim-safe. The closed native tool is
+         published and exercised separately, including its AngleSharp, CDP and MCP paths. -->
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
+
+  <!-- Scope AOT to this executable: a command-line PublishAot=true would propagate to Jint's
+       downlevel targets and its netstandard source generators, where AOT is unsupported. -->
+  <PropertyGroup Condition="'$(BrowserToolNative)' == 'true'">
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <AssemblyName>jint-browser</AssemblyName>
+    <ToolPackageRuntimeIdentifiers>linux-x64;linux-arm64;osx-x64;osx-arm64;win-x64;win-arm64</ToolPackageRuntimeIdentifiers>
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+    <IncludeSymbols>false</IncludeSymbols>
+    <!-- The same standing Jint interop inventory as Jint.AotExample. Keep the diagnostics visible;
+         the distribution workflow rejects diagnostics outside the core engine and runs the binary. -->
+    <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <Target Name="RemoveNativeToolReferenceDocumentation"
+          AfterTargets="ComputeFilesToPublish"
+          Condition="'$(BrowserToolNative)' == 'true'">
+    <ItemGroup>
+      <!-- Project-reference PDBs and XML documentation are not inputs at run time. Native symbols stay
+           in the intermediate directory; both the RID package and the download contain one executable. -->
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
+                            Condition="'%(Extension)' == '.pdb' or '%(Extension)' == '.xml'" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\Jint.Browser\Jint.Browser.csproj" />

--- a/Jint.Browser.Tool/README.md
+++ b/Jint.Browser.Tool/README.md
@@ -6,13 +6,49 @@ follows its network, and answers what the page turned out to be — as markdown,
 tree, or over the Chrome DevTools Protocol so that Puppeteer and Playwright can drive it.
 
 **It renders nothing.** There is no layout, no pixels, no screenshots and no PDFs, and there is no browser to
-download: it is a .NET tool that runs in one process on any platform .NET runs on. What it costs is a
+download: it runs in one process. What it costs is a
 fraction of Chromium's memory and CPU per page; what it costs you back is wall-clock time, because the
 JavaScript is interpreted.
 
 ```bash
 dotnet tool install -g Jint.Browser.Tool
 ```
+
+## Installation and standalone downloads
+
+Starting with 5.0, installation requires the **.NET 10 SDK or later**. The SDK selects a self-contained
+Native AOT package for the current platform; running it does not require a .NET runtime.
+
+The [GitHub Releases page](https://github.com/sebastienros/jint/releases) also carries the same executable
+as a single-file download, with no SDK or runtime installation required:
+
+| Platform | x64 | arm64 |
+| --- | --- | --- |
+| Linux (glibc) | `jint-browser-linux-x64` | `jint-browser-linux-arm64` |
+| macOS | `jint-browser-osx-x64` | `jint-browser-osx-arm64` |
+| Windows | `jint-browser-win-x64.exe` | `jint-browser-win-arm64.exe` |
+
+Download the file for your OS and architecture and compare its SHA-256 hash with the release's
+`SHA256SUMS`. On Linux/macOS, run `chmod +x` on the downloaded file, then rename it to `jint-browser`
+and place it on your `PATH`. On Windows, rename it to `jint-browser.exe` and place it on your `PATH`.
+No Apple notarization or Windows Authenticode signature is provided.
+
+Linux builds use Ubuntu 22.04 (x64) and Ubuntu 24.04 (arm64), so they require at least those versions'
+glibc and the usual .NET native dependencies, including ICU, OpenSSL and zlib. Alpine/musl is not included.
+No invariant-globalization mode is used: JavaScript `Intl` remains available.
+
+Native publishing is scoped to this tool, not a general trimming guarantee for browser library consumers.
+To build it from source, use the .NET 10 SDK and the target OS's
+[Native AOT prerequisites](https://learn.microsoft.com/dotnet/core/deploying/native-aot/):
+
+```bash
+dotnet publish Jint.Browser.Tool/Jint.Browser.Tool.csproj -c Release -f net10.0 \
+  -r linux-x64 -p:BrowserToolNative=true
+```
+
+Use `dotnet pack -p:BrowserToolNative=true` on that project without a RID for the NuGet selection manifest,
+and once per RID with `-r` for each implementation package. All seven packages must have the same version;
+publish the six implementations before the manifest. The release workflow does this automatically.
 
 ## Reading a page
 

--- a/Jint.Browser/Jint.Browser.csproj
+++ b/Jint.Browser/Jint.Browser.csproj
@@ -34,9 +34,9 @@
       IsAotCompatible here would turn on IL2xxx/IL3xxx analysis for THIS compilation only — where the bindings
       themselves are clean, because every generated member is a static lambda over an interface call and no
       protocol type is reached by reflection — while saying nothing at all about what a published native
-      binary would do when AngleSharp's own reflection fails at run time. A claim nothing runs is worse than
-      no claim. The v1.1 item is an inventory: publish a native Jint.Browser host, count AngleSharp's warnings,
-      and decide whether the ones that survive are answerable upstream or by a feature switch here.
+      binary would do with a different host's reflection requirements. The closed Jint.Browser.Tool program
+      is now published and exercised natively by browser-tool.yml, without rooting these assemblies; that
+      evidence supports the executable, not a general trimming contract for every library consumer.
     -->
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>

--- a/Jint.Tests.Browser/Tool/PublishedToolTests.cs
+++ b/Jint.Tests.Browser/Tool/PublishedToolTests.cs
@@ -1,0 +1,217 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Jint.Tests.Browser.Mcp;
+using Jint.Tests.Browser.Navigation;
+using ModelContextProtocol.Client;
+using PuppeteerSharp;
+
+namespace Jint.Tests.Browser.Tool;
+
+/// <summary>Drives the installed distribution, not the in-process copy of the command line.</summary>
+public sealed class PublishedToolTests
+{
+    private static readonly TimeSpan Patience = TimeSpan.FromSeconds(30);
+    private static bool HasPublishedTool => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JINT_BROWSER_TOOL"));
+    private static string Executable => Path.GetFullPath(Environment.GetEnvironmentVariable("JINT_BROWSER_TOOL")!);
+
+    [Test]
+    [IgnoreUnless(nameof(HasPublishedTool), "Set JINT_BROWSER_TOOL to an installed or published executable.")]
+    public async Task TheVersionIsThePackageVersion()
+    {
+        var result = await RunAsync("--version");
+
+        result.ExitCode.Should().Be(0, result.Error);
+        result.Error.Should().BeEmpty();
+        result.Output.Trim().Split('+')[0].Should().Be(
+            Environment.GetEnvironmentVariable("JINT_BROWSER_TOOL_VERSION"),
+            "the distribution must carry the release tag's version");
+    }
+
+    [TestCase("html")]
+    [TestCase("text")]
+    [TestCase("markdown")]
+    [TestCase("ax")]
+    [IgnoreUnless(nameof(HasPublishedTool), "Set JINT_BROWSER_TOOL to an installed or published executable.")]
+    public async Task FetchRunsScriptsAndExtractsTheDocument(string format)
+    {
+        using var server = Serve();
+
+        var result = await RunAsync("fetch", server.Url("/"), "--dump", format, "--timeout", "10s");
+
+        result.ExitCode.Should().Be(0, result.Error);
+        result.Error.Should().BeEmpty();
+        result.Output.Should().Contain("Native ready");
+        server.Received.Should().Contain(request => request.Path == "/app.js");
+    }
+
+    [Test]
+    [IgnoreUnless(nameof(HasPublishedTool), "Set JINT_BROWSER_TOOL to an installed or published executable.")]
+    public async Task EvaluationPreservesCssXmlXPathAndGlobalization()
+    {
+        using var server = Serve();
+
+        var result = await RunAsync("eval", server.Url("/"), """
+            [
+                document.body.dataset.ready,
+                getComputedStyle(document.querySelector('h1')).color,
+                new DOMParser().parseFromString('<x>xml</x>', 'text/xml').documentElement.textContent,
+                document.evaluate('count(//h1)', document, null, XPathResult.NUMBER_TYPE, null).numberValue,
+                new Intl.NumberFormat('de-DE').format(1234.5)
+            ]
+            """, "--timeout", "10s");
+
+        result.ExitCode.Should().Be(0, result.Error);
+        result.Error.Should().BeEmpty();
+        using var json = JsonDocument.Parse(result.Output);
+        json.RootElement[0].GetString().Should().Be("yes");
+        json.RootElement[1].GetString().Should().Be("rgba(255, 0, 0, 1)");
+        json.RootElement[2].GetString().Should().Be("xml");
+        json.RootElement[3].GetInt32().Should().Be(1);
+        json.RootElement[4].GetString().Should().Be("1.234,5");
+    }
+
+    [Test]
+    [IgnoreUnless(nameof(HasPublishedTool), "Set JINT_BROWSER_TOOL to an installed or published executable.")]
+    public async Task UsageAndScriptErrorsKeepTheirExitCodes()
+    {
+        var usage = await RunAsync("--unknown");
+        usage.ExitCode.Should().Be(1);
+        usage.Error.Should().NotBeEmpty();
+
+        var script = await RunAsync("eval", "about:blank", "missingFunction()", "--timeout", "10s");
+        script.ExitCode.Should().Be(4);
+        script.Output.Should().BeEmpty();
+        script.Error.Should().Contain("missingFunction");
+    }
+
+    [Test]
+    [IgnoreUnless(nameof(HasPublishedTool), "Set JINT_BROWSER_TOOL to an installed or published executable.")]
+    public async Task ServeAcceptsARealCdpClient()
+    {
+        using var server = Serve();
+        using var process = new ToolProcess("serve", "--port", "0");
+        using var stopping = new CancellationTokenSource(Patience);
+        string? endpoint = null;
+
+        while (await process.Output.ReadLineAsync(stopping.Token) is { } line)
+        {
+            if (line.Trim().StartsWith("browser: ", StringComparison.Ordinal))
+            {
+                endpoint = line.Trim()["browser: ".Length..];
+                break;
+            }
+        }
+
+        endpoint.Should().NotBeNull("the published server must announce its WebSocket");
+        await using var browser = await Puppeteer.ConnectAsync(new ConnectOptions
+        {
+            BrowserWSEndpoint = endpoint,
+            DefaultViewport = null,
+        }).WaitAsync(Patience);
+        await using var page = await browser.NewPageAsync().WaitAsync(Patience);
+        await page.GoToAsync(server.Url("/")).WaitAsync(Patience);
+
+        (await page.EvaluateExpressionAsync<string>("document.querySelector('h1').textContent")
+            .WaitAsync(Patience)).Should().Be("Native ready");
+        browser.Disconnect();
+    }
+
+    [Test]
+    [IgnoreUnless(nameof(HasPublishedTool), "Set JINT_BROWSER_TOOL to an installed or published executable.")]
+    public async Task McpPublishesSchemasAndDrivesTheBrowserOverStdio()
+    {
+        using var server = Serve();
+        using var stopping = new CancellationTokenSource(Patience);
+        var transport = new StdioClientTransport(new StdioClientTransportOptions
+        {
+            Command = Executable,
+            Arguments = ["mcp", "--allow-private-network"],
+        });
+        await using var client = await McpClient.CreateAsync(transport, cancellationToken: stopping.Token);
+
+        var tools = await client.ListToolsAsync(cancellationToken: stopping.Token);
+        tools.Select(tool => tool.Name).Should().Contain(["navigate", "snapshot", "fill", "click", "evaluate"]);
+
+        var navigation = await client.CallToolAsync("navigate",
+            new Dictionary<string, object?> { ["url"] = server.Url("/") }, cancellationToken: stopping.Token);
+        navigation.IsError.Should().NotBe(true, McpFixture.TextOf(navigation));
+
+        var fill = await client.CallToolAsync("fill",
+            new Dictionary<string, object?> { ["target"] = "#name", ["text"] = "Native input" }, cancellationToken: stopping.Token);
+        fill.IsError.Should().NotBe(true, McpFixture.TextOf(fill));
+        var click = await client.CallToolAsync("click",
+            new Dictionary<string, object?> { ["target"] = "#apply" }, cancellationToken: stopping.Token);
+        click.IsError.Should().NotBe(true, McpFixture.TextOf(click));
+
+        var snapshot = await client.CallToolAsync("snapshot", cancellationToken: stopping.Token);
+        snapshot.IsError.Should().NotBe(true, McpFixture.TextOf(snapshot));
+        McpFixture.TextOf(snapshot).Should().Contain("Native input");
+
+        var resource = await client.ReadResourceAsync("jint://page/markdown", cancellationToken: stopping.Token);
+        resource.Contents.OfType<global::ModelContextProtocol.Protocol.TextResourceContents>()
+            .Single().Text.Should().Contain("Native input");
+    }
+
+    private static LoopbackServer Serve()
+    {
+        var server = new LoopbackServer();
+        server.MapHtml("/", """
+            <!doctype html><title>Native browser</title>
+            <link rel="stylesheet" href="/style.css">
+            <h1>Before scripts</h1><input id="name"><button id="apply">Apply</button>
+            <script src="/app.js"></script>
+            """);
+        server.Map("/style.css", _ => LoopbackResponse.Css("h1 { color: red }"));
+        server.Map("/app.js", _ => LoopbackResponse.Script("""
+            document.body.dataset.ready = 'yes';
+            document.querySelector('h1').textContent = 'Native ready';
+            document.querySelector('#apply').addEventListener('click', () => {
+                document.querySelector('h1').textContent = document.querySelector('#name').value;
+            });
+            """));
+        return server;
+    }
+
+    private static async Task<ToolResult> RunAsync(params string[] arguments)
+    {
+        using var process = new ToolProcess(arguments);
+        var output = process.Output.ReadToEndAsync();
+        await process.Process.WaitForExitAsync().WaitAsync(Patience);
+        return new ToolResult(process.Process.ExitCode, await output, await process.Error);
+    }
+
+    private sealed class ToolProcess : IDisposable
+    {
+        internal ToolProcess(params string[] arguments)
+        {
+            var start = new ProcessStartInfo(Executable)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            foreach (var argument in arguments)
+            {
+                start.ArgumentList.Add(argument);
+            }
+
+            Process = Process.Start(start) ?? throw new InvalidOperationException("The browser tool did not start.");
+            Error = Process.StandardError.ReadToEndAsync();
+        }
+
+        internal Process Process { get; }
+        internal StreamReader Output => Process.StandardOutput;
+        internal Task<string> Error { get; }
+
+        public void Dispose()
+        {
+            if (!Process.HasExited)
+            {
+                Process.Kill(entireProcessTree: true);
+                Process.WaitForExit((int) Patience.TotalMilliseconds).Should().BeTrue("the tool must not outlive its test");
+            }
+
+            Process.Dispose();
+        }
+    }
+}

--- a/docs/guide/supported-platforms.md
+++ b/docs/guide/supported-platforms.md
@@ -16,13 +16,18 @@ Some APIs are available only on modern targets. The opt-in web API surface is co
 
 ## Optional packages
 
-`Jint.DevTools`, `Jint.Browser`, `Jint.Browser.Playwright`, `Jint.Browser.Tool`, and `Jint.Browser.Mcp` target
+`Jint.DevTools`, `Jint.Browser`, `Jint.Browser.Playwright`, and `Jint.Browser.Mcp` target
 .NET 8 and .NET 10.
+
+`Jint.Browser.Tool` is distributed as a native executable for Linux (glibc), macOS and Windows, on x64
+and arm64. Installing its NuGet package requires the .NET 10 SDK; standalone release downloads require
+no .NET installation. See [tool installation](../packages/jint-browser-tool/installation.md).
 
 ## Native AOT
 
 The core `Jint` package and `Jint.DevTools` support Native AOT on compatible targets, with documented
-limitations for reflection-based CLR interop. `Jint.Browser` and the packages built on it are not currently
-trim- or AOT-compatible because AngleSharp is not trim-annotated.
+limitations for reflection-based CLR interop. The browser libraries do not declare general trimming or
+AOT compatibility, because AngleSharp is not trim-annotated. The closed `jint-browser` tool is published
+and exercised as Native AOT separately.
 
 See [Native AOT and trimming](../reference/native-aot.md).

--- a/docs/packages/jint-browser-tool/installation.md
+++ b/docs/packages/jint-browser-tool/installation.md
@@ -1,10 +1,35 @@
 # Installation
 
-Install the global .NET tool:
+Starting with Jint 5.0, install the global tool with the **.NET 10 SDK or later**:
 
 ```bash
 dotnet tool install -g Jint.Browser.Tool
 ```
+
+The SDK selects a Native AOT executable for Linux, macOS or Windows on x64 or arm64. No .NET runtime is
+needed to run it. The browser libraries still target .NET 8 and .NET 10; the SDK requirement is for the
+native tool package format.
+
+## Without .NET
+
+Download a binary from [GitHub Releases](https://github.com/sebastienros/jint/releases):
+
+| Platform | x64 | arm64 |
+| --- | --- | --- |
+| Linux (glibc) | `jint-browser-linux-x64` | `jint-browser-linux-arm64` |
+| macOS | `jint-browser-osx-x64` | `jint-browser-osx-arm64` |
+| Windows | `jint-browser-win-x64.exe` | `jint-browser-win-arm64.exe` |
+
+Compare its SHA-256 hash with `SHA256SUMS` on the same release. On Linux/macOS, mark it executable with
+`chmod +x`, rename it to `jint-browser`, and put it on your `PATH`. On Windows, rename it to
+`jint-browser.exe` and put it on your `PATH`. No Apple notarization or Windows Authenticode signature is provided.
+
+Linux binaries target Ubuntu 22.04 (x64) and Ubuntu 24.04 (arm64) or compatible newer glibc systems.
+They still need OS libraries such as ICU, OpenSSL and zlib. Alpine/musl is not included.
+See [Native AOT and trimming](../../reference/native-aot.md) for the distinction between this executable
+and using the browser libraries in another native application.
+
+## Updating and running
 
 Update it later with:
 

--- a/docs/reference/native-aot.md
+++ b/docs/reference/native-aot.md
@@ -15,7 +15,20 @@ types and generated accessors for a predictable native build.
 
 ## Browser packages
 
-`Jint.Browser` and packages built on it are not currently trim- or AOT-compatible because AngleSharp discovers
-parts of its model through reflection without trimming annotations.
+`Jint.Browser` and the browser libraries do not declare general trimming or AOT compatibility: AngleSharp
+is not trim-annotated, and another host's reflection and interop requirements still need evaluation.
+
+**The `jint-browser` executable is distributed as Native AOT**, with its complete closed dependency graph
+published and exercised on Linux, macOS and Windows, for x64 and arm64. This includes DOM parsing and scripts,
+CSS, XML, XPath, globalization, CDP and MCP. No browser assembly is rooted wholesale to make the probes pass.
+The core engine's standing AOT diagnostics remain visible; diagnostics outside that inventory fail the
+distribution build.
+
+Build it with `dotnet publish Jint.Browser.Tool/Jint.Browser.Tool.csproj -c Release -f net10.0 -r <rid>
+-p:BrowserToolNative=true`. Do not pass `PublishAot=true` globally: it also affects project references
+targeting frameworks that cannot be compiled with Native AOT.
+
+The NuGet tool requires the .NET 10 SDK to install its platform-specific package; the standalone release
+downloads require neither the SDK nor a .NET runtime. See [tool installation](../packages/jint-browser-tool/installation.md).
 
 See the [Jint 5 migration guide](../guide/migrating-to-v5.md) for the complete compatibility contract.

--- a/docs/reference/package-matrix.md
+++ b/docs/reference/package-matrix.md
@@ -6,7 +6,7 @@
 | [`Jint.DevTools`](https://www.nuget.org/packages/Jint.DevTools) | net8.0, net10.0 | Jint |
 | [`Jint.Browser`](https://www.nuget.org/packages/Jint.Browser) | net8.0, net10.0 | Jint, Jint.DevTools, AngleSharp |
 | [`Jint.Browser.Playwright`](https://www.nuget.org/packages/Jint.Browser.Playwright) | net8.0, net10.0 | Jint.Browser, Microsoft.Playwright API contracts |
-| [`Jint.Browser.Tool`](https://www.nuget.org/packages/Jint.Browser.Tool) | net8.0, net10.0 | Jint.Browser, Jint.DevTools, Jint.Browser.Mcp |
+| [`Jint.Browser.Tool`](https://www.nuget.org/packages/Jint.Browser.Tool) | Native AOT; .NET 10 SDK for installation | Jint.Browser, Jint.DevTools, Jint.Browser.Mcp (compiled into the executable) |
 | [`Jint.Browser.Mcp`](https://www.nuget.org/packages/Jint.Browser.Mcp) | net8.0, net10.0 | Jint.Browser, Model Context Protocol SDK |
 
 `Jint.Browser.Tool` is installed as a .NET tool. The others are libraries consumed by an application.

--- a/docs/releases/headless-browser.md
+++ b/docs/releases/headless-browser.md
@@ -2,7 +2,7 @@
 
 **This is a draft for the maintainer to lift into the v5 release announcement**, not a published changelog —
 the repository keeps no changelog, and `.github/workflows/release.yml` produces packages from a `vX.Y.Z` tag
-and nothing else. It records what the campaign tracked by
+and attaches native tool downloads when its GitHub release is published. It records what the campaign tracked by
 [#3575](https://github.com/sebastienros/jint/issues/3575) shipped: five new packages, the engine seams they
 were built on, the upstream contributions the work produced, and what is knowingly left.
 
@@ -18,7 +18,7 @@ what was built against them are [`docs/design/devtools-protocol.md`](../design/d
 | `Jint.DevTools` | A Chrome DevTools Protocol server over a WebSocket, so a debugging client attaches to an engine the host is already running. `Runtime`, `Debugger`, `Profiler`, `Console`, `Log`, `Target`, `Browser`, `Schema`. Native AOT compatible, measured by a published binary a CI leg drives over a real socket. | `net8.0`, `net10.0` |
 | `Jint.Browser` | A headless browser: AngleSharp's parser, DOM and CSSOM under Jint, with a page runtime, HTML's script scheduling, custom elements, navigation, forms, cookies, storage, workers, a deterministic box model in place of a layout, and the page-level protocol domains that make a page drivable by Puppeteer, PuppeteerSharp, Playwright and Playwright for .NET. Not trim- or AOT-compatible in this version, because AngleSharp is not trim-annotated. | `net8.0`, `net10.0` |
 | `Jint.Browser.Playwright` | Playwright for .NET's public browser interfaces implemented directly over `Jint.Browser`, with no Node driver, CDP connection or WebSocket. Unsupported interfaces and options fail explicitly; rendering-dependent features remain outside the package. | `net8.0`, `net10.0` |
-| `Jint.Browser.Tool` | The `jint-browser` dotnet tool: `serve` publishes the protocol, `fetch` dumps a page as HTML, text, CommonMark or its accessibility tree, `eval` answers an expression evaluated in the page, and `mcp` serves the MCP server on stdio. It consumes only the package's published surface. | `net8.0`, `net10.0` |
+| `Jint.Browser.Tool` | The Native AOT `jint-browser` tool: `serve` publishes the protocol, `fetch` dumps a page as HTML, text, CommonMark or its accessibility tree, `eval` answers an expression evaluated in the page, and `mcp` serves the MCP server on stdio. It consumes only the package's published surface. | Linux, macOS, Windows; x64 and arm64. .NET 10 SDK to install via NuGet; standalone downloads need no .NET. |
 | `Jint.Browser.Mcp` | A Model Context Protocol server over the same `Page` API: eighteen tools, an accessibility snapshot carrying a `ref=` on every element that the input tools take in place of a CSS selector, and the page as a resource. A host running a server of its own composes the same tools with `AddJintBrowser()`. | `net8.0`, `net10.0` |
 
 All five are packed by `release.yml` alongside `Jint` and carry a package README of their own.


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

<!-- One short sentence (under 80 characters) describing the change. -->

Ship jint-browser as native NuGet tools and standalone release binaries.

## Details

<!--
- What changed and why
- Anything reviewers should pay extra attention to
- Notable implementation choices or trade-offs
-->

Prepare the browser tool's 5.0 distribution so users can install a native tool through NuGet or download one executable without installing .NET. The previous claim that `PackAsTool` cannot support Native AOT is outdated with the .NET 10 SDK.

- Add application-scoped `BrowserToolNative=true` publishing, keeping AOT settings away from downlevel project references and source generators.
- Reuse a six-target CI matrix for Linux, macOS and Windows on x64/arm64. Install each native package from a source-mapped local feed and exercise CLI extraction/evaluation, CSS, XML, XPath, globalization, CDP and MCP.
- Publish all six RID packages before the NuGet selection manifest. Publishing a GitHub release attaches the same standalone executables and `SHA256SUMS`, without pushing NuGet again.
- Keep the core engine's existing AOT diagnostics visible and reject diagnostics outside that inventory. This verifies the closed tool, not general trimming compatibility for browser library consumers.

**Release prerequisite:** the nuget.org trusted-publishing policy for `release.yml` / environment `nuget` must permit creating the new `Jint.*` IDs, including the six `Jint.Browser.Tool.<rid>` packages. No live publication was performed. Downloads are not Apple-notarized or Windows Authenticode-signed; Linux targets glibc rather than musl.

## Linked issue

<!-- Use "Fixes #1234" or "Closes #1234" so the issue is auto-closed on merge. For discussion-only changes use "Refs #1234". -->

N/A

## Test plan

- [x] Added process-level tests in `Jint.Tests.Browser/Tool/PublishedToolTests.cs`
- [ ] Ran `dotnet test --configuration Release` locally for the full solution; targeted Release runs completed instead
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions (N/A)
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` (N/A)
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark` (N/A)

Locally confirmed native macOS arm64 packing, installation, upgrade and single-executable publishing. All 62 command tests passed on each of net8.0 and net10.0, and all five instruction-file guardian tests passed. The standalone executable also ran without a discoverable .NET installation. Workflow validation passed; the other five platform builds await CI.

## Breaking change?

<!-- Yes / No. If yes, describe the public-API impact and any migration steps. -->

Yes for tool installation: the 5.0 NuGet tool requires the .NET 10 SDK or later to resolve native RID packages. Running the native executable requires no .NET runtime. Browser libraries continue targeting .NET 8 and .NET 10, and their public APIs are unchanged.