### PR TITLE
Fix Windows NativeAOT browser tool CI

### DIFF
--- a/.github/workflows/browser-tool.yml
+++ b/.github/workflows/browser-tool.yml
@@ -99,9 +99,34 @@ jobs:
             --tool-path artifacts/browser-tool-installed \
             --configfile .github/browser-tool.nuget.config
 
+      - name: Resolve and exercise the Windows native tool installation
+        if: runner.os == 'Windows'
+        id: windows-tool
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Native tools get a .cmd launcher on Windows, not a managed tool's .exe shim.
+          $command = Join-Path $env:GITHUB_WORKSPACE 'artifacts/browser-tool-installed/jint-browser.cmd'
+          $version = & $command --version
+          if ($LASTEXITCODE -ne 0 -or $version.Trim().Split('+')[0] -ne $env:VERSION) {
+            throw "The installed command did not report package version $env:VERSION"
+          }
+          $result = & $command eval about:blank '6 * 7' --timeout 10s
+          if ($LASTEXITCODE -ne 0 -or $result.Trim() -ne '42') {
+            throw 'The installed command did not evaluate the expression'
+          }
+
+          # Drive the installed payload without cmd.exe reparsing multiline JavaScript arguments.
+          $executables = @(Get-ChildItem artifacts/browser-tool-installed -Recurse -Force -File -Filter jint-browser.exe)
+          if ($executables.Count -ne 1) {
+            throw "Expected one installed native executable, found $($executables.Count)"
+          }
+          "executable=$($executables[0].FullName)" >> $env:GITHUB_OUTPUT
+
       - name: Exercise the installed native tool
         env:
-          JINT_BROWSER_TOOL: ${{ github.workspace }}/artifacts/browser-tool-installed/jint-browser${{ matrix.extension }}
+          JINT_BROWSER_TOOL: ${{ steps.windows-tool.outputs.executable || format('{0}/artifacts/browser-tool-installed/jint-browser', github.workspace) }}
           JINT_BROWSER_TOOL_VERSION: ${{ steps.version.outputs.version }}
         run: |
           dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -f net10.0 \

--- a/Jint.Browser.Tool/AGENTS.md
+++ b/Jint.Browser.Tool/AGENTS.md
@@ -109,6 +109,10 @@ platform-specific Native AOT tool format. Installation requires the .NET 10 SDK,
   and runs `Tool/PublishedToolTests` against the installed executable. The tests cover extraction, scripts,
   CSS, XML, XPath, globalization, CDP and MCP. Set `JINT_BROWSER_TOOL` and `JINT_BROWSER_TOOL_VERSION` to
   reproduce; without them those process tests are skipped rather than passed.
+  On Windows the SDK installs a **`.cmd` launcher**, not an `.exe` shim. The workflow checks that
+  launcher's version and argument forwarding, then discovers the native `.exe` inside the installation
+  for the process tests, so `cmd.exe` does not reparse their multiline JavaScript. The standalone download
+  is still an `.exe`; its extension is not the installed command's extension.
 - **`build.yml` and `release.yml` publish the same seven tool packages**, at the libraries' version:
   six RID packages first, then `Jint.Browser.Tool`'s manifest. The manifest alone is not an installable
   distribution. Publishing a GitHub release attaches the six single executables and `SHA256SUMS`, without


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

<!-- One short sentence (under 80 characters) describing the change. -->

Fix Windows NativeAOT browser tool smoke tests after successful installation.

## Details

<!--
- What changed and why
- Anything reviewers should pay extra attention to
- Notable implementation choices or trade-offs
-->

The two failing `main` builds successfully compile, package and install the native tools, but Windows x64 and ARM64 cannot launch the assumed `jint-browser.exe` shim. .NET 10 installs native tools with a `.cmd` launcher instead.

The shared distribution workflow now checks the Windows launcher's version and argument forwarding, then resolves exactly one native executable inside the installation for the existing process suite. This keeps coverage of the installed package without having `cmd.exe` reparse multiline JavaScript. Unix launchers and standalone `.exe` downloads are unchanged. The packaging instructions document the distinction.

## Linked issue

<!-- Use "Fixes #1234" or "Closes #1234" so the issue is auto-closed on merge. For discussion-only changes use "Refs #1234". -->

N/A

## Test plan

- [ ] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

Local runs were targeted: all 9 `PublishedToolTests` passed against a freshly packed and locally installed macOS ARM64 NativeAOT tool; all 5 `AgentInstructionFileTests` passed. `actionlint` passed, and native publishing produced no diagnostics outside the standing core-engine inventory. The Windows-only step requires the PR's Windows x64/ARM64 CI runs. Remaining checklist items are N/A for this workflow-only fix.

## Breaking change?

<!-- Yes / No. If yes, describe the public-API impact and any migration steps. -->

No.