### PR TITLE
Fix JSON and textual document navigation in Jint.Browser

### DIFF
--- a/Jint.Browser/Runtime/DocumentFetch.cs
+++ b/Jint.Browser/Runtime/DocumentFetch.cs
@@ -32,9 +32,9 @@ internal sealed record FetchedDocument(string Html, string Url, PageResponse Res
 /// deliberately does not run it twice.
 /// </para>
 /// <para>
-/// <b>What a document may be.</b> <c>text/html</c> is parsed as markup and <c>text/plain</c> is wrapped in
-/// HTML's own plain-text document — a <c>&lt;pre&gt;</c> holding the text, which is what makes
-/// <c>document.body.textContent</c> the file. Anything else is refused with a
+/// <b>What a document may be.</b> <c>text/html</c> is parsed as markup; JSON, JavaScript,
+/// <c>text/plain</c>, <c>text/css</c> and <c>text/vtt</c> use HTML's text document — a <c>&lt;pre&gt;</c>
+/// holding the text, which is what makes <c>document.body.textContent</c> the file. Anything else is refused with a
 /// <see cref="NavigationFailedException"/> naming the type, because a page showing a PDF or an image as if
 /// it were markup would be worse than a page saying it cannot.
 /// </para>
@@ -209,7 +209,12 @@ internal static class DocumentFetch
             return text;
         }
 
-        if (string.Equals(essence, "text/plain", StringComparison.OrdinalIgnoreCase))
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#loading-a-document
+        // https://mimesniff.spec.whatwg.org/#json-mime-type
+        // MIME essences are already lowercased. These types are text documents, not markup or scripts.
+        if (essence is "text/plain" or "text/css" or "text/vtt" or "application/json" or "text/json"
+            || essence.EndsWith("+json", StringComparison.Ordinal)
+            || AngleSharp.Io.MimeTypeNames.IsJavaScript(essence))
         {
             return PlainTextDocument(text);
         }
@@ -217,12 +222,13 @@ internal static class DocumentFetch
         throw new NavigationFailedException(
             url,
             "Navigation to '" + url + "' produced a '" + essence + "' response, and a page can render only "
-            + "text/html and text/plain in this version. Fetch it with fetch() or XMLHttpRequest instead.");
+            + "HTML and text documents (plain text, JSON, JavaScript, CSS and WebVTT) in this version. "
+            + "Fetch it with fetch() or XMLHttpRequest instead.");
     }
 
     /// <summary>
-    /// HTML's plain-text document: the text inside a <c>&lt;pre&gt;</c>, so that
-    /// <c>document.body.textContent</c> is the file and the DOM is a real one.
+    /// https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-text — the text inside a
+    /// <c>&lt;pre&gt;</c>, so that <c>document.body.textContent</c> is the file and the DOM is a real one.
     /// </summary>
     private static string PlainTextDocument(string text)
     {
@@ -231,7 +237,9 @@ internal static class DocumentFetch
             .Replace("<", "&lt;", StringComparison.Ordinal)
             .Replace(">", "&gt;", StringComparison.Ordinal);
 
-        return "<html><head></head><body><pre>" + escaped + "</pre></body></html>";
+        // Text documents use no-quirks mode. The synthetic newline is the one the HTML parser discards
+        // after <pre>, so a leading newline in the response remains part of the document's text.
+        return "<!doctype html><html><head></head><body><pre>\n" + escaped + "</pre></body></html>";
     }
 
     private static bool LooksLikeMarkup(string text)

--- a/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
+++ b/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
@@ -431,6 +431,57 @@ public class PlaywrightCourseTests
         await page.CloseAsync();
     }
 
+    /// <summary>Textual navigations commit and keep the original response, not the HTML text wrapper.</summary>
+    [TestCase("application/json", 200)]
+    [TestCase("Application/Json; charset=utf-8", 200)]
+    [TestCase("text/json", 200)]
+    [TestCase("application/vnd.api+json", 200)]
+    [TestCase("application/problem+json", 400)]
+    [TestCase("text/plain; charset=utf-8", 200)]
+    public async Task PlaywrightNavigatesToATextDocumentAndReadsTheOriginalResponse(string contentType, int status)
+    {
+        const string body = """{"openapi":"3.0.0","info":{"title":"Repro","version":"1.0"}}""";
+        await using var lane = await ClientLane.OpenAsync(server => server
+            .Map("/swagger.json", _ => new LoopbackResponse
+            {
+                Status = status,
+                Reason = status == 200 ? "OK" : "Bad Request",
+                Body = body,
+            }.With("Content-Type", contentType).With("X-Document", "original"))
+            .MapHtml("/after.html", "<!doctype html><title>After JSON</title>"));
+        var context = await lane.Client.NewContextAsync();
+        var page = await context.NewPageAsync();
+        var failed = new ConcurrentQueue<string>();
+        page.RequestFailed += (_, request) => failed.Enqueue(request.Url);
+        await page.AddInitScriptAsync(
+            """
+            window.lifecycle = [];
+            window.addEventListener('DOMContentLoaded', () => lifecycle.push('DOMContentLoaded'));
+            window.addEventListener('load', () => lifecycle.push('load'));
+            """);
+
+        var response = await page.GotoAsync(lane.Server.Url("/swagger.json"));
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(status);
+        response.Ok.Should().Be(status == 200);
+        response.Url.Should().Be(lane.Server.Url("/swagger.json"));
+        response.Headers["content-type"].Should().Be(contentType);
+        response.Headers["x-document"].Should().Be("original");
+        response.Headers["content-length"].Should().Be(Encoding.UTF8.GetByteCount(body).ToString(System.Globalization.CultureInfo.InvariantCulture));
+        (await response.TextAsync()).Should().Be(body);
+        (await response.BodyAsync()).Should().Equal(Encoding.UTF8.GetBytes(body));
+        (await response.JsonAsync())!.Value.GetProperty("openapi").GetString().Should().Be("3.0.0");
+        (await page.EvaluateAsync<string>("() => document.body.textContent")).Should().Be(body);
+        (await page.EvaluateAsync<string>("() => document.readyState")).Should().Be("complete");
+        (await page.EvaluateAsync<string[]>("() => lifecycle")).Should().Equal("DOMContentLoaded", "load");
+        failed.Should().BeEmpty();
+
+        await page.GotoAsync(lane.Server.Url("/after.html"));
+        (await page.TitleAsync()).Should().Be("After JSON");
+        await context.CloseAsync();
+    }
+
     /// <summary>A route the client fulfils itself, and the cookies its context reads afterwards.</summary>
     [Test]
     public async Task PlaywrightFulfilsARouteAndReadsTheCookies()

--- a/Jint.Tests.Browser/Navigation/NavigationTests.cs
+++ b/Jint.Tests.Browser/Navigation/NavigationTests.cs
@@ -57,17 +57,67 @@ public sealed class NavigationTests
             .Should().Be("line one\n<not markup>", "a plain-text document is the text inside a <pre>, not markup");
     }
 
-    [Test]
-    public async Task AContentTypeAPageCannotRenderIsRefusedWithTheTypeInTheMessage()
+    [TestCase("application/json")]
+    [TestCase("Application/Json; charset=\"utf-8\"")]
+    [TestCase("text/json")]
+    [TestCase("application/problem+json")]
+    [TestCase("application/vnd.api+json")]
+    [TestCase("text/plain")]
+    [TestCase("text/css")]
+    [TestCase("text/vtt")]
+    [TestCase("text/javascript")]
+    [TestCase("application/javascript")]
+    [TestCase("application/x-javascript")]
+    public async Task ATextDocumentPreservesItsTextWithoutParsingMarkupOrRunningScripts(string contentType)
     {
+        const string body = "\n{\"text\":\"</pre><script>globalThis.ran = true</script>&amp; caf\u00e9\"}\n";
         await using var fixture = await LoopbackPage.CreateAsync(server => server.Map(
             "/data.json",
-            _ => LoopbackResponse.Json("{\"a\":1}")));
+            _ => LoopbackResponse.Bytes(body, contentType)));
 
-        var act = async () => await fixture.Page.NavigateAsync(fixture.Url("/data.json"));
+        var response = await fixture.Page.NavigateAsync(fixture.Url("/data.json"));
+
+        response!.Status.Should().Be(200);
+        response.Header("content-type").Should().Be(contentType);
+        (await fixture.Page.EvaluateAsync<string>("document.body.textContent")).Should().Be(body);
+        (await fixture.Page.EvaluateAsync<string>("document.querySelector('pre').textContent")).Should().Be(body);
+        (await fixture.Page.EvaluateAsync<string>("typeof globalThis.ran")).Should().Be("undefined");
+        (await fixture.Page.EvaluateAsync<int>("document.scripts.length")).Should().Be(0);
+        (await fixture.Page.EvaluateAsync<string>("document.compatMode")).Should().Be("CSS1Compat");
+        (await fixture.Page.EvaluateAsync<string>("document.readyState")).Should().Be("complete");
+        fixture.Page.Errors.Should().BeEmpty();
+    }
+
+    [TestCase("")]
+    [TestCase("{not valid JSON")]
+    public async Task AJsonDocumentDoesNotRequireAValidJsonBody(string body)
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.Map(
+            "/data.json", _ => LoopbackResponse.Json(body)));
+
+        var response = await fixture.Page.NavigateAsync(fixture.Url("/data.json"));
+
+        response!.Ok.Should().BeTrue();
+        (await fixture.Page.EvaluateAsync<string>("document.body.textContent")).Should().Be(body);
+        fixture.Page.Errors.Should().BeEmpty();
+    }
+
+    [TestCase("application/octet-stream")]
+    [TestCase("application/pdf")]
+    [TestCase("image/png")]
+    [TestCase("application/xml")]
+    [TestCase("text/xml")]
+    [TestCase("application/json-seq")]
+    public async Task AContentTypeAPageCannotRenderIsRefusedWithTheTypeInTheMessage(string contentType)
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.Map(
+            "/data",
+            _ => LoopbackResponse.Bytes("unsupported", contentType)));
+
+        var act = async () => await fixture.Page.NavigateAsync(fixture.Url("/data"));
 
         (await act.Should().ThrowAsync<NavigationFailedException>())
-            .WithMessage("*application/json*");
+            .WithMessage("*" + contentType + "*");
     }
 
     [Test]


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

<!-- One short sentence (under 80 characters) describing the change. -->

Allow JSON and other supported text responses to complete browser navigation.

## Details

<!--
- What changed and why
- Anything reviewers should pay extra attention to
- Notable implementation choices or trade-offs
-->

Playwright 1.62 connected over CDP reports `net::ERR_FAILED` when navigating to a valid HTTP 200 `application/json` response. The fetch succeeds, but `DocumentFetch.Decode` rejects every explicit MIME type except HTML and plain text before navigation commits; CDP maps that refusal to a network error.

Follow HTML's [document-loading rules](https://html.spec.whatwg.org/multipage/browsing-the-web.html#loading-a-document): JSON MIME types (`application/json`, `text/json`, and `+json`), JavaScript, CSS and WebVTT use the existing inert text-document path. Original response status, headers and captured body remain available through Playwright. The shared text wrapper now uses no-quirks mode and preserves a real leading newline instead of letting `<pre>` parsing discard it.

Unsupported XML, binary and media formats remain explicitly refused. This does not add a JSON viewer, download support or change data-URL handling; synthetic text documents retain their existing HTML DOM/frame MIME metadata, independently of the preserved HTTP Content-Type.

## Linked issue

<!-- Use "Fixes #1234" or "Closes #1234" so the issue is auto-closed on merge. For discussion-only changes use "Refs #1234". -->

Fixes #3876

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` (browser coverage is in `Jint.Tests.Browser`)
- [x] Ran `dotnet test --configuration Release` locally (focused and broader project runs below, not the full solution)
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions - N/A
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` - N/A
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark` - N/A

Reproduced the original failure with a real TCP HTTP server and Playwright's `ConnectOverCDPAsync`, new context/page and `GotoAsync`. Regression coverage checks status, headers, `BodyAsync`, `TextAsync`, `JsonAsync`, lifecycle events, subsequent HTML navigation, MIME variants, empty/invalid JSON, inert markup and leading newlines.

All runs used Release, freshly compiled code, sequential framework legs and `NUnit.NumberOfTestWorkers=1`. Browser runs enabled `JINT_BROWSER_CLIENTS=1`.

| Coverage | net8.0 | net10.0 |
| --- | ---: | ---: |
| Focused regressions | 25 passed | 25 passed |
| Browser Navigation, Parsing, DevTools, Playwright and History | 301 passed | 301 passed |
| Full `Jint.Tests.DevTools` | 407 passed | 409 passed |

No failed or skipped tests in these runs. No dependency, protocol or binding regeneration required.

## Breaking change?

<!-- Yes / No. If yes, describe the public-API impact and any migration steps. -->

No public API changes. Previously rejected supported textual responses now navigate successfully. Plain-text documents preserve their leading newline and use standards mode.