### PR TITLE
Reserve an 8 MiB native stack for browser page threads

### DIFF
--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -22,6 +22,13 @@ is that thread: it drains a mailbox of requests, processes one engine task and i
 engine-owning operations, and a navigation replaces the engine from inside a mailbox request rather than from
 outside. Jint starts no thread of its own; this is what makes a page's timers fire at all.
 
+**The page thread explicitly requests an 8 MiB native stack through `Thread(ThreadStart, int)`.**
+The platform default can be only about 512 KiB on macOS, where a finite framework traversal exhausts it
+before its JavaScript work is finished (#3884). The runtime/OS governs the actual reservation, rounding and
+commitment; the request is not 8 MiB of managed allocation per page. `StackOverflowGuard` and configured
+recursion limits stay in force. All public and protocol page creation, including the test fixtures, uses
+this same `PageLoop` constructor; never compensate with a larger stack only in a test host.
+
 Five rules follow, and each of them is a way to break the package silently:
 
 - **Every public `Page` member is a mailbox request, and the request is what holds the engine.** A new member

--- a/Jint.Browser/Runtime/PageLoop.cs
+++ b/Jint.Browser/Runtime/PageLoop.cs
@@ -34,6 +34,12 @@ namespace Jint.Browser.Runtime;
 /// </remarks>
 internal sealed class PageLoop : IDisposable
 {
+    // A platform-default stack can be only ~512 KiB (macOS), too small for finite framework
+    // traversals through the interpreter. Request 8 MiB through .NET's portable thread API;
+    // the runtime/OS controls rounding and commitment. This is not a JavaScript recursion limit:
+    // StackOverflowGuard and any configured MaxRecursionDepth still bound execution.
+    private const int StackSize = 8 * 1024 * 1024;
+
     private readonly Channel<LoopRequest> _mailbox = Channel.CreateUnbounded<LoopRequest>(
         new UnboundedChannelOptions { SingleReader = true, AllowSynchronousContinuations = false });
 
@@ -81,7 +87,7 @@ internal sealed class PageLoop : IDisposable
         _engineFactory = engineFactory;
         _onPumpError = onPumpError;
         _onTurnEnd = onTurnEnd;
-        _thread = new Thread(Run) { IsBackground = true, Name = name };
+        _thread = new Thread(Run, maxStackSize: StackSize) { IsBackground = true, Name = name };
         _closingToken = _closing.Token;
     }
 

--- a/Jint.Tests.Browser/Runtime/PageStackTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageStackTests.cs
@@ -1,0 +1,147 @@
+using System.Runtime.InteropServices;
+using Jint.Browser;
+using Jint.Runtime;
+
+namespace Jint.Tests.Browser.Runtime;
+
+using Browser = global::Jint.Browser.Browser;
+
+public sealed class PageStackTests
+{
+    // Two mutually recursive calls per level, with siblings and DOM writes on the way back out.
+    // This is finite framework work, not unbounded recursion or a tail call.
+    private const string Traversal = """
+        var root = { child: null, sibling: null };
+        for (var i = 0; i < 256; i++) {
+            root = { child: root, sibling: null };
+            root.child.sibling = { child: null, sibling: null };
+        }
+        var visited = 0;
+        var target = document.getElementById('result');
+        function commitMutationEffects(node) {
+            recursivelyTraverseMutationEffects(node);
+            target.textContent = String(++visited);
+        }
+        function recursivelyTraverseMutationEffects(parent) {
+            var child = parent.child;
+            while (child !== null) {
+                commitMutationEffects(child);
+                child = child.sibling;
+            }
+        }
+        """;
+
+    [TestCase("inline")]
+    [TestCase("evaluate")]
+    [TestCase("timer")]
+    public async Task AFiniteDeepCommitTraversalCompletesOnTheProductionPageThread(string entry)
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        var invocation = entry == "inline" ? "commitMutationEffects(root);" : "";
+        await page.SetContentAsync("<p id='result'></p><script>" + Traversal + invocation + "</script>");
+
+        if (entry == "evaluate")
+        {
+            await page.EvaluateAsync("commitMutationEffects(root)");
+        }
+        else if (entry == "timer")
+        {
+            await page.EvaluateAsync("setTimeout(() => commitMutationEffects(root), 0)");
+            await page.WaitForIdleAsync(TimeSpan.FromSeconds(10));
+        }
+
+        (await page.EvaluateAsync<string>("target.textContent")).Should().Be("513");
+        page.Errors.Should().BeEmpty();
+
+        // Exercise a warmed engine too, without rebuilding the tree or borrowing the test runner's stack.
+        await page.EvaluateAsync("visited = 0; commitMutationEffects(root)");
+        (await page.EvaluateAsync<int>("visited")).Should().Be(513);
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    [Platform("MacOsX", Reason = "pthread_get_stacksize_np measures the native reservation on macOS.")]
+    public async Task TheProductionPageThreadHasMultiMegabyteNativeStackHeadroom()
+    {
+        await using var browser = new Browser();
+        var context = await browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        var bytes = await page.RunOnLoopAsync(_ => (ulong) NativeStackSize(NativeThreadSelf()));
+        TestContext.Progress.WriteLine($"Page thread native stack reservation: {bytes} bytes");
+        bytes.Should().BeGreaterThanOrEqualTo(8UL * 1024 * 1024);
+
+        await page.SetContentAsync("<title>replacement engine</title>");
+        (await page.RunOnLoopAsync(_ => (ulong) NativeStackSize(NativeThreadSelf()))).Should().Be(bytes);
+    }
+
+    [Test]
+    public async Task ExcessiveRecursionStillThrowsAndThePageRemainsUsable()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        (await page.RunOnLoopAsync(engine => engine.Options.Constraints.StackOverflowGuard)).Should().BeTrue();
+        await page.EvaluateAsync("function runaway() { return 1 + runaway(); }");
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var act = async () => await page.EvaluateAsync("runaway()");
+            (await act.Should().ThrowAsync<JavaScriptException>())
+                .WithMessage("Maximum call stack size exceeded");
+
+            (await page.EvaluateAsync<bool>(
+                """
+                (() => {
+                    try { runaway(); }
+                    catch (e) { return e instanceof RangeError && e.message === 'Maximum call stack size exceeded'; }
+                    return false;
+                })()
+                """)).Should().BeTrue();
+            (await page.EvaluateAsync<int>("[1, 2, 3].reduce((sum, value) => sum + value, 0)")).Should().Be(6);
+            page.Errors.Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task AnExplicitRecursionLimitStillRejectsBeforeNativeStackExhaustion()
+    {
+        var options = new BrowserOptions();
+        options.ConfigureEngine(o => o.Constraints.MaxRecursionDepth = 32);
+        await using var browser = new Browser(options);
+        var page = await browser.NewPageAsync();
+
+        var act = async () => await page.EvaluateAsync(
+            "function recurse(n) { return n === 0 ? 0 : 1 + recurse(n - 1); } recurse(256)");
+        await act.Should().ThrowAsync<RecursionDepthOverflowException>();
+
+        (await page.EvaluateAsync<int>("recurse(16)")).Should().Be(16);
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task SequentialPagesReleaseTheirThreads()
+    {
+        await using var browser = new Browser();
+        for (var iteration = 0; iteration < 32; iteration++)
+        {
+            var page = await browser.NewPageAsync();
+            var thread = await page.RunOnLoopAsync(_ => Thread.CurrentThread);
+            (await page.EvaluateAsync<int>("1 + 1")).Should().Be(2);
+
+            await page.CloseAsync();
+
+            // Close signals from the thread's finally; join also waits for the native thread to exit.
+            thread.Join(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            thread.IsAlive.Should().BeFalse();
+            browser.Contexts.SelectMany(context => context.Pages).Should().BeEmpty();
+        }
+    }
+
+    [DllImport("libSystem", EntryPoint = "pthread_self")]
+    private static extern nint NativeThreadSelf();
+
+    [DllImport("libSystem", EntryPoint = "pthread_get_stacksize_np")]
+    private static extern nuint NativeStackSize(nint thread);
+}


### PR DESCRIPTION
## Summary

Fixes #3884.

`PageLoop` used `new Thread(Run)`, inheriting a **536,576-byte** native stack on macOS arm64. Finite interpreter/framework traversals exhausted that stack; the existing guard correctly raised `RangeError`, but the browser host had not provisioned enough headroom.

Request an **8 MiB native stack** at the single production `PageLoop` constructor using `Thread(ThreadStart, int)`. .NET and the OS control reservation, rounding and commitment; macOS reports **8,400,896 bytes** on both tested runtimes. `maxStackSize` is a requested maximum stack size, not a promise of exactly that many available bytes or an eager resident allocation. No production pthread dependency, new public configuration, timeout increase, guard/recursion-limit change, error suppression or React/Swagger special case.

All public/context/CDP/direct-adapter page creation and page-based test fixtures converge here. Parser, worker and standalone engine-only DevTools threads remain separate and unchanged. Geometry work in #3885 stays independent.

## Changed files

- `Jint.Browser/Runtime/PageLoop.cs`: explicit stack reservation.
- `Jint.Tests.Browser/Runtime/PageStackTests.cs`: finite 513-node mutually recursive traversal from inline script/evaluation/timer, cold and warm; macOS native-size measurement across engine replacement; repeated excessive recursion and recovery; explicit recursion limit; deterministic joins for 32 sequential page threads.
- `Jint.Browser/Runtime/AGENTS.md`: rationale and shared-constructor contract.

## Validation

Release, macOS arm64, .NET 8.0.30 and 10.0.11. Fresh builds throughout; Browser/DevTools suites run sequentially with `NUnit.NumberOfTestWorkers=0` and `JINT_BROWSER_CLIENTS=1`.

| Coverage | net8 | net10 |
| --- | --- | --- |
| New regressions before fix | 3 finite-traversal cases and native-size case fail; 536,576 bytes | not run before fix |
| New regressions after fix | 7 pass, plus 5 fresh-process repetitions of all 7 | 7 pass |
| Exact Swagger UI 5.32.7 + 50,869-byte Orchard schema, original baseline Program.cs source-linked unchanged | **20/20 iterations**, two fresh processes | **20/20 iterations**, two fresh processes |
| Browser suite excluding WPT, real clients enabled | 1,711 pass, 9 skipped | 1,715 pass, 9 skipped |
| Full DevTools suite | 407 pass | 409 pass |
| Existing StackOverflowGuardTests + AgentInstructionFileTests | 28 pass | 28 pass |

One 10-page Swagger process per runtime ran before the broader suites, and a second after them. The 9 skips per Browser leg require an installed/published `JINT_BROWSER_TOOL`; in-process tool and real CDP client tests ran. WPT and other OS/architectures were not run locally. Exact Swagger assets/harness are the supplied #3880/#3884 artifacts, not duplicated in this PR. Its existing `.opblock-summary-control` click bypasses only the independent geometry defect; no stack workaround is used. The baseline's existing 30-second task budget is unchanged.

Commands below were run once per target framework (`net8.0`, then `net10.0`); only the focused net8 command was additionally repeated five times:

```sh
dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -f net8.0 --filter FullyQualifiedName~PageStackTests --logger 'console;verbosity=normal' -- NUnit.NumberOfTestWorkers=0
JINT_BROWSER_CLIENTS=1 dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -f net8.0 --filter 'FullyQualifiedName!~Jint.Tests.Browser.Wpt' --logger 'console;verbosity=normal' -- NUnit.NumberOfTestWorkers=0
JINT_BROWSER_CLIENTS=1 dotnet test Jint.Tests.DevTools/Jint.Tests.DevTools.csproj -c Release -f net8.0 --filter 'FullyQualifiedName!~Jint.Tests.Browser.Wpt' --logger 'console;verbosity=normal' -- NUnit.NumberOfTestWorkers=0
dotnet test Jint.Tests/Jint.Tests.csproj -c Release -f net8.0 --filter 'FullyQualifiedName~AgentInstructionFileTests|FullyQualifiedName~StackOverflowGuardTests' --logger 'console;verbosity=normal' -- NUnit.NumberOfTestWorkers=0 NUnit.DefaultTimeout=30000
```

The separate baseline project compile-links the original `Program.cs`, fixture server and resources unchanged, replaces the published Jint.Browser reference with this worktree's project, and keeps Microsoft.Playwright 1.62.0. Both it and the public-API resource probe use `dotnet run --project <scratch-project.csproj> -c Release -f <framework>`.

| Exact baseline input | SHA-256 |
| --- | --- |
| Original `Program.cs` | `3ad738b89e64c10eb3dd6f1e66444c1367bc9efc986864402cf5f2a762078938` |
| 50,869-byte Orchard schema | `e3396cef8f4d49580d4b63464c7d7dfc209a01b8f69bd506fc7e6c0d4e691be3` |
| Swagger UI 5.32.7 bundle | `dcc1ebdc8b581b2eeac3b7a4892002621b97d4b39d41822ee2ea1e034b6e053b` |

## Reservation versus residency

The separate source-referenced public-API resource probe creates 10 warm-up pages, 100 sequential pages, then 32 simultaneous pages. Each page executes finite 128-level recursion. It closes every page and joins every captured native thread. Measurements follow full GC/finalizer cycles. **142/142 threads exit on each runtime**. Process thread count stays 15 during sequential churn, becomes 47 with 32 live pages, then returns to 15.

| Process observation | net8 | net10 |
| --- | ---: | ---: |
| Warm baseline RSS, bytes | 97,796,096 | 95,797,248 |
| RSS after 20 sequential pages | 100,302,848 | 98,156,544 |
| RSS after 100 sequential pages | 100,417,536 | 98,189,312 |
| RSS with 32 live pages | 111,902,720 | 110,739,456 |
| RSS after closing those 32 pages | 102,465,536 | 102,334,464 |
| Extra virtual address space with 32 live pages | 257.5 MiB | 257.5 MiB |
| Extra RSS with 32 live pages, versus just before that batch | 10.95 MiB | 11.97 MiB |

After warm-up, 100 sequential pages add only 2.50 MiB RSS on net8 / 2.28 MiB on net10, almost entirely in the first 20; the next 80 add 0.11 / 0.03 MiB. There is no observed proportional 8 MiB/page resident growth. Virtual usage returns to its prior level after closing the 32 pages. RSS drops substantially but **does not return exactly to baseline**. These are observed process working-set measurements including engines and managed heaps, not an isolated stack-commit counter, a guarantee of identical commitment for all workloads, or a claim of zero retained runtime allocation.