### PR TITLE
Fix CDP navigation commit ordering for admin POST clicks

### DIFF
--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -27,6 +27,16 @@ target/runtime split and the manifest are there and none of it is repeated here.
   document's first inline script. `DocumentParsed` is the commit, with the runtime: it is the first moment
   there is a tree, so it is where anything that watches a document arms itself, and why the mutation bridge
   needs no field remembering an engine from before the parse.
+- **Frame commit is not engine creation.** Publish `lifecycleEvent(init)` and `frameNavigated` at
+  `DocumentParsed`, before fulfilling the host's commit signal. Publishing the frame before the parse
+  releases Playwright's click barrier while a parser-blocking script can still hide the success DOM.
+  Context replacement and new-document scripts still happen at `DocumentCreated`. Buffer navigation and
+  history notices raised during that parse until after its frame commit, or that commit consumes the next
+  navigation or masks its URL. Chromium can commit a streaming document earlier; Jint's commit is the
+  parsed-document boundary, not a promise to await unrelated later redirects or asynchronous scripts.
+  Input delivered during the parse must await publication of notices it creates before replying, without
+  blocking the loop. A failed parse discards its history notices, still publishes queued cross-document
+  requests, and fails waiting input replies; none may leak into the next document's commit.
 - **Every command runs on the page loop**, so it may touch the DOM directly — and one that waits
   (`Page.navigate`) waits by `await`ing, never by blocking: the loop it is on runs the commit it waits for.
 - **`DOM` and `Input` are where a client stops evaluating and starts driving.** A node reaches a client as a

--- a/Jint.Browser/DevTools/InputDomain.cs
+++ b/Jint.Browser/DevTools/InputDomain.cs
@@ -65,6 +65,7 @@ internal sealed class InputDomain : InputDomainBase
     /// </remarks>
     protected override ValueTask<EmptyResult> DispatchMouseEventAsync(DispatchMouseEventRequest parameters, CommandContext context)
     {
+        var pending = _target.PendingNavigationCount;
         if (PageRuntime.Find(_target.Runtime.Engine) is { } runtime)
         {
             InputDispatcher.DispatchMouse(runtime, new MouseInput(
@@ -79,7 +80,7 @@ internal sealed class InputDomain : InputDomainBase
                 parameters.DeltaY ?? 0));
         }
 
-        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+        return CompleteAsync(pending);
     }
 
     /// <summary>
@@ -96,6 +97,7 @@ internal sealed class InputDomain : InputDomainBase
     /// </remarks>
     protected override ValueTask<EmptyResult> DispatchKeyEventAsync(DispatchKeyEventRequest parameters, CommandContext context)
     {
+        var pending = _target.PendingNavigationCount;
         if (PageRuntime.Find(_target.Runtime.Engine) is { } runtime)
         {
             InputDispatcher.DispatchKey(
@@ -111,7 +113,7 @@ internal sealed class InputDomain : InputDomainBase
                 KeyKind(parameters.Type));
         }
 
-        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+        return CompleteAsync(pending);
     }
 
     /// <summary>
@@ -120,12 +122,23 @@ internal sealed class InputDomain : InputDomainBase
     /// </summary>
     protected override ValueTask<EmptyResult> InsertTextAsync(InsertTextRequest parameters, CommandContext context)
     {
+        var pending = _target.PendingNavigationCount;
         if (PageRuntime.Find(_target.Runtime.Engine) is { } runtime)
         {
             InputDispatcher.InsertText(runtime, parameters.Text);
         }
 
-        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+        return CompleteAsync(pending);
+    }
+
+    private async ValueTask<EmptyResult> CompleteAsync(int pending)
+    {
+        if (_target.NavigationPublicationAfter(pending) is { } published)
+        {
+            await published.ConfigureAwait(false);
+        }
+
+        return EmptyResult.Instance;
     }
 
     /// <summary>

--- a/Jint.Browser/DevTools/PageDomain.Events.cs
+++ b/Jint.Browser/DevTools/PageDomain.Events.cs
@@ -10,23 +10,26 @@ namespace Jint.Browser.DevTools;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>The order is Chrome's, taken from the recordings rather than from the specification.</b> For a
+/// <b>The lifecycle follows Chrome's recorded sequence, at this parser's commit boundary.</b> For a
 /// renderer-initiated cross-document navigation it is <c>frameRequestedNavigation</c>,
 /// <c>frameStartedNavigating</c>, <c>frameStartedLoading</c>,
-/// <c>lifecycleEvent(init)</c>, <c>frameNavigated</c>, then the engine swap the base target performs
+/// the engine swap the base target performs
 /// (<c>Runtime.executionContextsCleared</c> and <c>executionContextCreated</c>),
+/// <c>lifecycleEvent(init)</c>, <c>frameNavigated</c>,
 /// <c>lifecycleEvent(commit)</c>, <c>domContentEventFired</c> + <c>lifecycleEvent(DOMContentLoaded)</c>,
 /// <c>loadEventFired</c> + <c>lifecycleEvent(load)</c>, <c>frameStoppedLoading</c>, and — once the network
 /// has been quiet for half a second — <c>lifecycleEvent(networkAlmostIdle)</c> and
 /// <c>lifecycleEvent(networkIdle)</c>. <c>Jint.Tests.Browser</c> pins it.
 /// </para>
 /// <para>
-/// One divergence from the recording, and it comes from where the commit is announced: Chrome interleaves
-/// <c>frameNavigated</c> between <c>executionContextsCleared</c> and <c>executionContextCreated</c>, and here
-/// both the frame and the engine swap are one <see cref="Jint.Browser.Runtime.IPageObserver.DocumentCreated"/>
-/// call — the moment the next document's engine exists and nothing of it has been parsed — so
-/// <c>frameNavigated</c> is emitted just before the swap rather than inside it. Every other relative order is
-/// the recording's.
+/// The contexts precede <c>frameNavigated</c> here, whereas Chrome interleaves that event between context
+/// destruction and creation. The engine must exist before scripts run, but this parser's commit is
+/// <see cref="IPageObserver.DocumentParsed"/>: announcing a committed frame at engine creation would let
+/// clients finish a click before the response's DOM exists. <c>init</c> belongs to that commit too, not to
+/// the fetch that can still fail or overlap the outgoing document's lifecycle.
+/// Chrome can commit a streaming document before its parse finishes; this browser's host navigation
+/// contract instead commits the parsed document. Neither commit promises completion of unrelated later
+/// script navigations or of deferred and asynchronous work.
 /// </para>
 /// <para>
 /// <b>A lifecycle event goes out only while <c>setLifecycleEventsEnabled</c> is on</b>, which is the
@@ -91,10 +94,9 @@ internal sealed partial class PageDomain
         }));
 
         EmitDetached(ProtocolPageEvents.FrameStartedLoading(new FrameStartedLoadingEvent { FrameId = _target.FrameId }));
-        Lifecycle(Init, loaderId);
     }
 
-    /// <summary>The document has committed: its URL is settled and nothing of it has been parsed.</summary>
+    /// <summary>The document has committed and its parsed tree is observable.</summary>
     internal void FrameNavigated(string url, string loaderId)
     {
         if (!IsEnabled)
@@ -102,6 +104,7 @@ internal sealed partial class PageDomain
             return;
         }
 
+        Lifecycle(Init, loaderId);
         EmitDetached(ProtocolPageEvents.FrameNavigated(new FrameNavigatedEvent
         {
             Frame = Frame(url, loaderId),

--- a/Jint.Browser/DevTools/PageDomain.cs
+++ b/Jint.Browser/DevTools/PageDomain.cs
@@ -66,10 +66,9 @@ internal sealed partial class PageDomain : PageDomainBase, IDetachableDomain
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Chrome answers there too, which is why every client that wants the load waits for a lifecycle event
-    /// afterwards rather than for this reply. Waiting here for the parse would make <c>Page.navigate</c> and
-    /// <c>Page.lifecycleEvent</c> say the same thing and leave a client with no way to ask for the earlier
-    /// one.
+    /// A client that wants the load waits for its lifecycle event rather than just this reply. Unlike
+    /// Chromium's streaming commit, this browser's commit follows the parse; deferred and asynchronous
+    /// work still belongs to the later lifecycle phases. Frame publication precedes this reply.
     /// </para>
     /// <para>
     /// <b>A status is not a failure.</b> A <c>404</c> navigates and its body is the document, so it answers a

--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Jint.Browser.Runtime;
 using Jint.DevTools;
 using Jint.DevTools.Domains;
+using Jint.DevTools.Protocol;
 using Jint.DevTools.Session;
 using Jint.Runtime;
 
@@ -35,6 +36,18 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     private readonly Action<PageTarget>? _closed;
 
     private PageDomain[] _domains = [];
+    private string? _uncommittedUrl;
+    private List<PendingNavigation>? _pendingNavigations;
+    private TaskCompletionSource? _navigationPublished;
+
+    /// <summary>How many navigation notices the current parse has deferred, read on the loop.</summary>
+    internal int PendingNavigationCount => _pendingNavigations?.Count ?? 0;
+
+    /// <summary>Keep an action's reply behind any navigation notices it queued during the parse.</summary>
+    internal Task? NavigationPublicationAfter(int previousCount)
+        => PendingNavigationCount > previousCount
+            ? (_navigationPublished ??= new(TaskCreationOptions.RunContinuationsAsynchronously)).Task
+            : null;
 
     private PageTarget(Page page, string? browserContextId, bool waitForDebuggerOnStart, Action<PageTarget>? closed)
         : base(
@@ -244,6 +257,17 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     /// <inheritdoc/>
     void IPageObserver.NavigationRequested(string url, PageNavigationReason reason)
     {
+        if (_uncommittedUrl is not null)
+        {
+            (_pendingNavigations ??= []).Add(new PendingNavigation(url, LoaderId: null, reason));
+            return;
+        }
+
+        NavigationRequested(url, reason);
+    }
+
+    private void NavigationRequested(string url, PageNavigationReason reason)
+    {
         foreach (var domain in Snapshot())
         {
             domain.NavigationRequested(url, reason);
@@ -261,20 +285,15 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
 
     /// <inheritdoc/>
     /// <remarks>
-    /// The order here is the whole of a commit as a client sees it: <c>frameNavigated</c> first, because the
-    /// document's URL is settled and nothing of it has been parsed; then the engine swap, which is what
-    /// clears every handle and announces the new execution context; then the bindings the base class
-    /// re-installs, and finally the client's own new-document scripts — every one of which has to be in place
-    /// before the document's first inline script runs.
+    /// The engine swap clears handles and installs the new contexts, bindings and new-document scripts
+    /// before the first inline script runs. It is not yet the navigation commit: the parser has not made
+    /// the document observable. Announcing the frame here would release a client's click navigation barrier
+    /// while the parser can still be blocked before the response's body.
     /// </remarks>
     void IPageObserver.DocumentCreated(PageRuntime runtime, string loaderId)
     {
+        _uncommittedUrl = runtime.DocumentUrl;
         Publish(title: null, runtime.DocumentUrl);
-
-        foreach (var domain in Snapshot())
-        {
-            domain.FrameNavigated(runtime.DocumentUrl, loaderId);
-        }
 
         // Before the swap, because the swap is what tells every DOM domain to announce documentUpdated and a
         // client that acted on it must find the identifiers already gone rather than resolving one more time.
@@ -286,10 +305,69 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
 
     /// <inheritdoc/>
     /// <remarks>
-    /// The first moment the document exists and the parse is over, which is when a client's view of the tree
-    /// can start being kept current. Idempotent, and a no-op while nobody has enabled the <c>DOM</c> domain.
+    /// Arms the node tracker and publishes the frame commit after the parser has produced the document.
     /// </remarks>
-    void IPageObserver.DocumentParsed(PageRuntime runtime, string loaderId) => Nodes.Watch(runtime);
+    void IPageObserver.DocumentParsed(PageRuntime runtime, string loaderId)
+    {
+        Nodes.Watch(runtime);
+
+        foreach (var domain in Snapshot())
+        {
+            domain.FrameNavigated(_uncommittedUrl ?? runtime.DocumentUrl, loaderId);
+        }
+
+        _uncommittedUrl = null;
+
+        // Scripts can already have requested the next navigation or moved within this document. Publish
+        // those after this commit, or a client's navigation barrier consumes this frame for the next one.
+        if (_pendingNavigations is { } pending)
+        {
+            _pendingNavigations = null;
+            foreach (var navigation in pending)
+            {
+                if (navigation.LoaderId is { } sameDocumentLoader)
+                {
+                    SameDocumentNavigated(navigation.Url, sameDocumentLoader);
+                }
+                else
+                {
+                    NavigationRequested(navigation.Url, navigation.Reason);
+                }
+            }
+        }
+
+        _navigationPublished?.TrySetResult();
+        _navigationPublished = null;
+    }
+
+    /// <inheritdoc/>
+    void IPageObserver.DocumentLoadFinished()
+    {
+        if (_uncommittedUrl is null)
+        {
+            return;
+        }
+
+        _uncommittedUrl = null;
+        var pending = _pendingNavigations;
+        _pendingNavigations = null;
+
+        // A failed parse must not replay its history changes over the next document. Cross-document
+        // requests are still queued on the page, however, and their clients must hear about them.
+        if (pending is not null)
+        {
+            foreach (var navigation in pending)
+            {
+                if (navigation.LoaderId is null)
+                {
+                    NavigationRequested(navigation.Url, navigation.Reason);
+                }
+            }
+        }
+
+        _navigationPublished?.TrySetException(new ProtocolException("The document failed to commit during the input action."));
+        _navigationPublished = null;
+    }
 
     /// <inheritdoc/>
     void IPageObserver.Phase(NavigationPhase phase, string loaderId)
@@ -305,6 +383,17 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     {
         Publish(title: null, url);
 
+        if (_uncommittedUrl is not null)
+        {
+            (_pendingNavigations ??= []).Add(new PendingNavigation(url, loaderId, default));
+            return;
+        }
+
+        SameDocumentNavigated(url, loaderId);
+    }
+
+    private void SameDocumentNavigated(string url, string loaderId)
+    {
         foreach (var domain in Snapshot())
         {
             domain.SameDocumentNavigated(url, loaderId);
@@ -364,6 +453,8 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     }
 
     private PageDomain[] Snapshot() => Volatile.Read(ref _domains);
+
+    private readonly record struct PendingNavigation(string Url, string? LoaderId, PageNavigationReason Reason);
 }
 
 /// <summary>What a client decided about the next dialog the page opens.</summary>

--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -831,25 +831,32 @@ public sealed partial class Page
         // where a protocol target replaces its engine, re-installs the bindings a client added and runs the
         // scripts it asked to be evaluated on every new document -- all of which have to be in place before
         // the first inline script of the document runs.
-        _observer?.DocumentCreated(runtime, loaderId);
-
-        // Before the parse, and the order is load-bearing rather than tidy. Every phase signal a caller of
-        // NavigateAsync may be awaiting is raised *inside* the parse, so signalling afterwards would let a
-        // navigation the caller has already finished awaiting satisfy a WaitForNavigationAsync armed on the
-        // line after it — the wait would answer for the wrong navigation and the page would still be showing
-        // the previous document. Waking here means every waiter is woken before any caller can arm one.
-        // What a woken waiter then posts queues behind this request, so it still observes the parsed document.
-        SignalNavigation();
-
-        var load = PageDocument.Load(runtime, html, url, phase =>
+        try
         {
-            onPhase?.Invoke(phase);
-            Reached(runtime, phase, loaderId);
-        });
+            _observer?.DocumentCreated(runtime, loaderId);
 
-        _load = load;
-        _mainFrame = Frame.Build(this, load.Document, url);
-        return null;
+            // Before the parse, and the order is load-bearing rather than tidy. Every phase signal a caller of
+            // NavigateAsync may be awaiting is raised *inside* the parse, so signalling afterwards would let a
+            // navigation the caller has already finished awaiting satisfy a WaitForNavigationAsync armed on the
+            // line after it — the wait would answer for the wrong navigation and the page would still be showing
+            // the previous document. Waking here means every waiter is woken before any caller can arm one.
+            // What a woken waiter then posts queues behind this request, so it still observes the parsed document.
+            SignalNavigation();
+
+            var load = PageDocument.Load(runtime, html, url, phase =>
+            {
+                Reached(runtime, phase, loaderId);
+                onPhase?.Invoke(phase);
+            });
+
+            _load = load;
+            _mainFrame = Frame.Build(this, load.Document, url);
+            return null;
+        }
+        finally
+        {
+            _observer?.DocumentLoadFinished();
+        }
     }
 
     /// <summary>Tells the watcher how far the load got, and arms the quiet period once it is loaded.</summary>

--- a/Jint.Browser/Runtime/AGENTS.md
+++ b/Jint.Browser/Runtime/AGENTS.md
@@ -339,7 +339,8 @@ the first call. Everything a client is told about a page is one of its calls; no
   document did not change. Each is prefixed per page, so two pages never mint the same.
 - **`Phase` is the driver's three, composed with the caller's.** `LoadInto` wraps whatever `onPhase` a
   navigation passed, so a watcher hears `Committed`, `DomContentLoaded` and `Loaded` at exactly the points
-  `WaitUntilState` answers at — on the loop, because that is where the driver raises them.
+  `WaitUntilState` answers at — on the loop, because that is where the driver raises them. Notify the
+  observer before completing the caller's phase signal, so its continuation cannot outrun publication.
 - **`DialogOpening` runs before the host's own `Page.DialogOpened` handler and `DialogClosed` after it.** A
   watcher answers from a decision it already holds — the page has no thread to block, and the thread a
   protocol client's answer would arrive on is the one inside the script that called `alert` — and the host,

--- a/Jint.Browser/Runtime/IPageObserver.cs
+++ b/Jint.Browser/Runtime/IPageObserver.cs
@@ -79,6 +79,12 @@ internal interface IPageObserver
     {
     }
 
+    /// <summary>The document load left the parser, including when it failed before committing.</summary>
+    /// <remarks>Runs on the page loop, in the load's cleanup path; it does not imply success.</remarks>
+    void DocumentLoadFinished()
+    {
+    }
+
     /// <summary>The load reached one of its three points.</summary>
     /// <param name="phase">How far it got.</param>
     /// <param name="loaderId">The document that reached it.</param>

--- a/Jint.Tests.Browser/DevTools/PageDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/PageDomainTests.cs
@@ -22,7 +22,157 @@ namespace Jint.Tests.Browser.DevTools;
 public class PageDomainTests
 {
     [Test]
-    public async Task ANavigationEmitsChromesEventsInChromesOrder()
+    public async Task AFrameCommitsOnlyWhenItsParsedDocumentIsObservable()
+    {
+        using var release = new ManualResetEventSlim();
+        var requested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var server = new LoopbackServer();
+        server.MapHtml("/next", "<!doctype html><head><script src='/gate.js'></script></head><body>Saved</body>");
+        server.Map("/gate.js", _ =>
+        {
+            requested.TrySetResult();
+            release.Wait(TimeSpan.FromSeconds(30));
+            return LoopbackResponse.Script("");
+        });
+
+        await using var session = await PageSession.CreateAsync(Options(server));
+        var attachment = await session.OpenPageAsync();
+        await session.EnablePageAsync(attachment);
+        var navigating = session.ResultAsync("Page.navigate", $$"""{"url":"{{server.Url("/next")}}"}""", attachment);
+        try
+        {
+            await requested.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            session.EventsOf("Page.frameNavigated", attachment).Should().BeEmpty(
+                "creating an engine before a parser-blocking script is not a committed document");
+            session.EventsOf("Page.lifecycleEvent", attachment).Should().BeEmpty(
+                "init belongs to the document commit, not to its fetch");
+            navigating.IsCompleted.Should().BeFalse();
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        var response = await navigating;
+        var committed = await session.EventAsync("Page.frameNavigated", sessionId: attachment);
+        committed.GetProperty("frame").GetProperty("loaderId").GetString().Should()
+            .Be(response.GetProperty("loaderId").GetString());
+        (await session.EvaluateAsync("document.body.textContent", attachment)).GetProperty("value").GetString()
+            .Should().Be("Saved");
+    }
+
+    [TestCase("location.href = '/next'", "Page.frameRequestedNavigation")]
+    [TestCase("history.pushState(null, '', '#saved')", "Page.navigatedWithinDocument")]
+    public async Task AParserScriptsNavigationIsPublishedAfterItsOwnDocumentCommit(string script, string expectedEvent)
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/start", "<!doctype html><body><script>" + script + "</script>Start</body>");
+        server.MapHtml("/next", "<!doctype html><body>Next</body>");
+        await using var session = await PageSession.CreateAsync(Options(server));
+        var attachment = await session.OpenPageAsync();
+        await session.EnablePageAsync(attachment);
+
+        await session.ResultAsync("Page.navigate", $$"""{"url":"{{server.Url("/start")}}"}""", attachment);
+        var notice = await session.EventAsync(expectedEvent, sessionId: attachment);
+
+        session.Ordinal("Page.frameNavigated").Should().BeLessThan(session.Ordinal(expectedEvent),
+            "the parser's next navigation must not be satisfied or overwritten by its own document's commit");
+        var first = await session.EventAsync("Page.frameNavigated", sessionId: attachment);
+        first.GetProperty("frame").GetProperty("url").GetString().Should().Be(server.Url("/start"));
+        if (expectedEvent == "Page.frameRequestedNavigation")
+        {
+            var next = await session.EventAsync("Page.frameNavigated", index: 1, sessionId: attachment);
+            next.GetProperty("frame").GetProperty("url").GetString().Should().Be(server.Url("/next"));
+            next.GetProperty("frame").GetProperty("loaderId").GetString().Should()
+                .NotBe(first.GetProperty("frame").GetProperty("loaderId").GetString());
+            session.Ordinal(expectedEvent).Should().BeLessThan(session.Ordinal("Page.frameNavigated", index: 1));
+        }
+        else
+        {
+            notice.GetProperty("url").GetString().Should().Be(server.Url("/start#saved"));
+            (await session.EvaluateAsync("location.href", attachment)).GetProperty("value").GetString()
+                .Should().Be(notice.GetProperty("url").GetString());
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task AFailedParseDoesNotPublishItsHistoryOverTheNextDocument(bool scriptNavigates)
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/bad", "<!doctype html><script>history.pushState(null, '', '#stale');"
+            + (scriptNavigates ? "location.href = '/good';" : "") + "</script>"
+            + string.Concat(Enumerable.Repeat("<p>too many</p>", 100)));
+        server.MapHtml("/good", "<!doctype html><body>Good</body>");
+        await using var session = await PageSession.CreateAsync(Options(server), new BrowserOptions { MaxDomNodes = 40 });
+        var attachment = await session.OpenPageAsync();
+        await session.EnablePageAsync(attachment);
+
+        var failed = await session.ResultAsync("Page.navigate", $$"""{"url":"{{server.Url("/bad")}}"}""", attachment);
+        failed.GetProperty("errorText").GetString().Should().NotBeNullOrEmpty();
+        if (!scriptNavigates)
+        {
+            await session.ResultAsync("Page.navigate", $$"""{"url":"{{server.Url("/good")}}"}""", attachment);
+        }
+
+        session.EventsOf("Page.navigatedWithinDocument", attachment).Should().BeEmpty();
+        var committed = await session.EventAsync("Page.frameNavigated", sessionId: attachment);
+        committed.GetProperty("frame").GetProperty("url").GetString().Should().Be(server.Url("/good"));
+        session.EventsOf("Page.frameRequestedNavigation", attachment).Should().HaveCount(scriptNavigates ? 1 : 0);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task AnInputNavigationDuringTheParseIsPublishedBeforeTheInputReply(bool parseFails)
+    {
+        using var release = new ManualResetEventSlim();
+        var requested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var server = new LoopbackServer();
+        server.MapHtml("/parsing", """
+            <!doctype html><body><form action="/next" onsubmit="window.submitted = true">
+              <input><button>Go</button></form><script src="/gate.js"></script></body>
+            """ + (parseFails ? string.Concat(Enumerable.Repeat("<p>too many</p>", 100)) : ""));
+        server.MapHtml("/next", "<!doctype html><body>Next</body>");
+        server.Map("/gate.js", _ =>
+        {
+            requested.TrySetResult();
+            release.Wait(TimeSpan.FromSeconds(30));
+            return LoopbackResponse.Script("");
+        });
+        await using var session = await PageSession.CreateAsync(Options(server), new BrowserOptions { MaxDomNodes = 40 });
+        var attachment = await session.OpenPageAsync();
+        await session.EnablePageAsync(attachment);
+        var navigating = session.ResultAsync("Page.navigate", $$"""{"url":"{{server.Url("/parsing")}}"}""", attachment);
+        Task<System.Text.Json.JsonElement> input;
+        try
+        {
+            await requested.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await session.EvaluateAsync("document.querySelector('input').focus()", attachment);
+            input = session.SendAsync("Input.dispatchKeyEvent",
+                """{"type":"keyDown","key":"Enter","code":"Enter"}""", attachment);
+            (await session.EvaluateAsync("window.submitted", attachment)).GetProperty("value").GetBoolean().Should().BeTrue();
+            input.IsCompleted.Should().BeFalse("the input reply must not overtake its buffered navigation signal");
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        var navigation = await navigating;
+        navigation.TryGetProperty("errorText", out _).Should().Be(parseFails);
+        var reply = await input;
+        reply.TryGetProperty("error", out var error).Should().Be(parseFails,
+            "a failed parse must answer the input instead of leaving it waiting or reporting success");
+        if (parseFails)
+        {
+            error.GetProperty("code").GetInt32().Should().Be(-32000);
+            error.GetProperty("message").GetString().Should().Contain("failed to commit");
+        }
+        session.EventsOf("Page.frameRequestedNavigation", attachment).Should().ContainSingle();
+    }
+
+    [Test]
+    public async Task ANavigationEmitsTheLifecycleInOrderAtTheParsedDocumentCommit()
     {
         using var server = new LoopbackServer();
         server.MapHtml("/one", "<html><head><title>One</title></head><body><p>one</p></body></html>");
@@ -35,10 +185,10 @@ public class PageDomainTests
 
         await session.EventAsync("Page.frameStoppedLoading", sessionId: attachment);
 
-        // The order the recordings show, which is what a client's own bookkeeping is written against.
+        // Context creation precedes the parsed-document commit in this browser, unlike Chromium streaming.
         session.Ordinal("Page.frameStartedNavigating").Should().BeLessThan(session.Ordinal("Page.frameStartedLoading"));
         session.Ordinal("Page.frameStartedLoading").Should().BeLessThan(session.Ordinal("Page.frameNavigated"));
-        session.Ordinal("Page.frameNavigated").Should().BeLessThan(session.Ordinal("Runtime.executionContextsCleared"));
+        session.Ordinal("Runtime.executionContextsCleared").Should().BeLessThan(session.Ordinal("Page.frameNavigated"));
         session.Ordinal("Runtime.executionContextsCleared").Should().BeLessThan(session.Ordinal("Page.domContentEventFired"));
         session.Ordinal("Page.domContentEventFired").Should().BeLessThan(session.Ordinal("Page.loadEventFired"));
         session.Ordinal("Page.loadEventFired").Should().BeLessThan(session.Ordinal("Page.frameStoppedLoading"));
@@ -56,12 +206,12 @@ public class PageDomainTests
         names.Should().ContainInOrder("init", "commit", "DOMContentLoaded", "load");
 
         var loaderIds = lifecycle
-            .Where(p => p.GetProperty("name").GetString() != "init")
             .Select(p => p.GetProperty("loaderId").GetString())
             .Distinct()
             .ToArray();
 
         loaderIds.Should().HaveCount(1, "every signal of one document carries one loader identifier");
+        loaderIds[0].Should().Be(navigated.GetProperty("frame").GetProperty("loaderId").GetString());
     }
 
     [Test]

--- a/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
+++ b/Jint.Tests.Browser/DevTools/PlaywrightCourseTests.cs
@@ -358,6 +358,93 @@ public class PlaywrightCourseTests
         await page.CloseAsync();
     }
 
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task PlaywrightClickCommitsTheParsedPostRedirectBeforeReturning(bool delegated)
+    {
+        using var release = new ManualResetEventSlim();
+        var scriptRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var lane = await ClientLane.OpenAsync(server =>
+        {
+            server.MapHtml("/admin-post/index.html", """
+                <!doctype html><html><body>
+                <form method="post" action="/save" enctype="multipart/form-data" class="no-multisubmit">
+                  <input name="GroupId" value="settings" type="hidden">
+                  <label><input id="allow" name="AllowAnonymous" type="checkbox" value="true">Allow anonymous</label>
+                  <button type="submit" class="btn save">Save</button>
+                  <input name="__RequestVerificationToken" value="fixture-token" type="hidden">
+                  <input name="AllowAnonymous" value="false" type="hidden">
+                </form>
+                <a id="enable" href="/save" data-url-af="UnsafeUrl">Enable</a>
+                <script src="/vendor/jquery-3.7.1/jquery.min.js"></script>
+                <script>
+                  $("body").on("click", "a[data-url-af]", function () {
+                    var form = $('<form method="post">').attr("action", this.href);
+                    form.append($("input[name=__RequestVerificationToken]").first().clone());
+                    form.css({ position: "absolute", left: "-9999em" });
+                    $("body").append(form);
+                    form.submit();
+                    return false;
+                  });
+                  $("body").on("submit", "form.no-multisubmit", function (event) {
+                    if ($(this).hasClass("submitting")) event.preventDefault();
+                    $(this).addClass("submitting");
+                  });
+                </script>
+                </body></html>
+                """);
+            server.Map("/save", _ => LoopbackResponse.Redirect(302, "/saved"));
+            server.MapHtml("/saved", """
+                <!doctype html><html><head><script src="/parse-gate.js"></script></head>
+                <body><div class="message-success">Settings saved</div></body></html>
+                """);
+            server.Map("/parse-gate.js", _ =>
+            {
+                scriptRequested.TrySetResult();
+                release.Wait(TimeSpan.FromSeconds(30));
+                return LoopbackResponse.Script("");
+            });
+        });
+        var page = await lane.NewPageAsync("admin-post");
+        if (!delegated)
+        {
+            await page.Locator("#allow").CheckAsync();
+        }
+
+        var clicking = page.Locator(delegated ? "#enable" : ".save").ClickAsync();
+        try
+        {
+            await scriptRequested.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            (await page.EvaluateAsync<string>("() => document.readyState")).Should().Be("loading");
+            clicking.IsCompleted.Should().BeFalse(
+                "the redirected bytes arrived, but the parser has not committed an observable document");
+        }
+        finally
+        {
+            release.Set();
+        }
+
+        await clicking;
+        page.Url.Should().Be(lane.Server.Url("/saved"));
+        (await page.EvaluateAsync<string>("() => document.querySelector('.message-success')?.textContent"))
+            .Should().Be("Settings saved");
+        await page.WaitForLoadStateAsync(LoadState.Load);
+        var post = lane.Server.Received.Single(request => request.Method == "POST");
+        post.Body.Should().Contain("fixture-token");
+        if (!delegated)
+        {
+            post.Header("Content-Type").Should().StartWith("multipart/form-data; boundary=");
+            post.Body.Should().Contain("name=\"AllowAnonymous\"\r\n\r\ntrue")
+                .And.Contain("name=\"AllowAnonymous\"\r\n\r\nfalse");
+        }
+
+        lane.Server.Received.Single(request => request.Path == "/saved").Method.Should().Be("GET");
+        foreach (var host in lane.Pages.Contexts.SelectMany(context => context.Pages))
+        {
+            host.Errors.Should().BeEmpty();
+        }
+    }
+
     [Test]
     public async Task PlaywrightClickSubmitsAJQueryDelegatedHiddenForm()
     {


### PR DESCRIPTION
Fixes #3881. (#3880 is the separate Swagger rendering issue.)

## Root cause

`PageTarget.DocumentCreated` announced `Page.frameNavigated` as soon as the replacement engine existed, before the parser had produced the response DOM. Playwright 1.62's click navigation barrier could therefore finish while a parser-blocking script still held up the success document. On the real Orchard settings page, the captured trace had roughly eight seconds between this early frame event and Jint's actual parser commit. The normal five-second `.message-success` assertion expired in that gap despite a valid multipart POST → 302 → GET 200.

This differs from #3755: the early `frameRequestedNavigation` signal was already present, and the existing ordinary POST, delegated jQuery hidden-form, and nested-admin-form controls passed.

## Changes

- Publish `lifecycleEvent(init)` and `frameNavigated` at `DocumentParsed`, retaining early engine/context replacement and new-document scripts.
- Publish observer events before completing the host navigation phase signal.
- Publish parser-initiated navigation and history notices after their own frame commit, so that commit cannot consume a later navigation or overwrite its URL.
- Keep replies to input delivered during parsing behind navigation notices that input creates, without blocking the page loop.
- On failed parses, discard stale history notices, preserve queued cross-document requests, and explicitly fail waiting input commands. Cancellation alone is not sufficient: the transport treats it as abandonment and does not send a response.

No Orchard test changes, URL/application special cases, sleeps, or increased test timeouts.

## CDP comparison and regression evidence

Both standalone settings-save and delegated feature-enable flows were driven through **Microsoft.Playwright 1.62.0 `ConnectOverCDPAsync`**, against Jint and real Chromium. Protocol traces were captured locally; raw authenticated Orchard traces are deliberately not published.

| Boundary | Before | After |
| --- | --- | --- |
| Fetch start | `frameStartedNavigating`, `frameStartedLoading`, premature `init` | Start events only |
| Replacement engine creation | Premature `frameNavigated`, then contexts | Context replacement/new-document scripts |
| Parsed document commit | `commit` | `init`, `frameNavigated`, deferred navigation notices, `commit` |
| Later phases | DCL, load, stopped, idle | DCL, load, stopped, idle |

Chromium associates frame/lifecycle initialization with document commit rather than fetch start. Its streaming parser can commit earlier than Jint's parsed-document boundary; the difference is documented. A separate gated Chromium control confirmed that a click is **not** a promise to await unrelated later script redirects or all asynchronous work, and no such assertion was added.

Restoring the old frame-publication point made all three gated regressions fail, including both actual Playwright click variants. Coverage also checks distinct loaders for parser-triggered navigation, `pushState` ordering, failed-parse recovery into both host- and script-requested navigations, and parser-gated input reply/error ordering.

Live isolated Orchard validation at normal timeouts: **4 settings saves**, alternating checked/unchecked state and asserting `.message-success` at the default 5 seconds; **4 disable-confirm/re-enable cycles**, asserting enable-click completion, normal `NetworkIdle`, and the resulting disable button. Additionally, **20 paired standalone iterations (40 clicks and late load waits)** passed without diagnostic lifecycle callbacks. No post-fix late-load wait failure was reproduced.

## Validation

All commands used fresh Release builds and ran sequentially, with `NUnit.NumberOfTestWorkers=0`.

| Selection | net8.0 | net10.0 |
| --- | ---: | ---: |
| Focused lifecycle/input/Playwright controls | 35 passed | 35 passed |
| Complete Navigation + Browser DevTools namespaces | 248 passed | 248 passed |
| Complete `Jint.Tests.DevTools` | 407 passed | 409 passed |
| Final strengthened `PageDomainTests` loader assertions | 23 passed | 23 passed |
| `AgentInstructionFileTests` | — | 5 passed |

```sh
# Each framework was run separately, sequentially.
for framework in net8.0 net10.0; do
  JINT_BROWSER_CLIENTS=1 dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -f "$framework" --filter 'FullyQualifiedName~PageDomainTests|FullyQualifiedName~PlaywrightClick|FullyQualifiedName~PlaywrightSavesANestedAdminForm|FullyQualifiedName~InputDuringNavigationTests' --logger 'console;verbosity=minimal' -- NUnit.NumberOfTestWorkers=0
done
for framework in net8.0 net10.0; do
  JINT_BROWSER_CLIENTS=1 dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -f "$framework" --filter 'FullyQualifiedName~Jint.Tests.Browser.Navigation|FullyQualifiedName~Jint.Tests.Browser.DevTools' --logger 'console;verbosity=minimal' -- NUnit.NumberOfTestWorkers=0
done
for framework in net8.0 net10.0; do
  dotnet test Jint.Tests.DevTools/Jint.Tests.DevTools.csproj -c Release -f "$framework" --logger 'console;verbosity=minimal' -- NUnit.NumberOfTestWorkers=0
done
for framework in net8.0 net10.0; do
  JINT_BROWSER_CLIENTS=1 dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -f "$framework" --filter 'FullyQualifiedName~PageDomainTests' --logger 'console;verbosity=minimal' -- NUnit.NumberOfTestWorkers=0
done
dotnet test Jint.Tests/Jint.Tests.csproj -c Release -f net10.0 --filter 'FullyQualifiedName~AgentInstructionFileTests' --logger 'console;verbosity=minimal' -- NUnit.NumberOfTestWorkers=0 NUnit.DefaultTimeout=30000
```

Limits: this does not turn Jint into a streaming Chromium parser, eliminate the cost of parsing large admin pages, or validate the entire Orchard functional suite/WPT corpus. It aligns CDP publication with Jint's existing host commit boundary and preserves subsequent navigation ordering.