### PR TITLE
Return early for detached ChildNode siblings

### DIFF
--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -354,6 +354,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.after");
+                    if (self.Target.Parent is null) { return global::Jint.Native.JsValue.Undefined; }
                     self.Target.After(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "CharacterData.after")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
@@ -368,6 +369,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("CharacterData.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.ICharacterData>(thisObj, "CharacterData.before");
+                    if (self.Target.Parent is null) { return global::Jint.Native.JsValue.Undefined; }
                     self.Target.Before(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "CharacterData.before")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
@@ -1290,6 +1292,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.after");
+                    if (self.Target.Parent is null) { return global::Jint.Native.JsValue.Undefined; }
                     self.Target.After(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "DocumentType.after")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
@@ -1297,6 +1300,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("DocumentType.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentType>(thisObj, "DocumentType.before");
+                    if (self.Target.Parent is null) { return global::Jint.Native.JsValue.Undefined; }
                     self.Target.Before(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "DocumentType.before")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
@@ -1344,6 +1348,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Element.after", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.after");
+                    if (self.Target.Parent is null) { return global::Jint.Native.JsValue.Undefined; }
                     self.Target.After(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Element.after")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
@@ -1377,6 +1382,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Element.before", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.before");
+                    if (self.Target.Parent is null) { return global::Jint.Native.JsValue.Undefined; }
                     self.Target.Before(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Element.before")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)

--- a/Jint.Tests.Browser/DomIndexedNodeTests.cs
+++ b/Jint.Tests.Browser/DomIndexedNodeTests.cs
@@ -158,4 +158,27 @@ public sealed class DomIndexedNodeTests
         fixture.Text("(() => { const f = new DocumentFragment(); f.append('in a fragment'); return f.textContent; })()")
             .Should().Be("in a fragment");
     }
+
+    [Test]
+    public void BeforeAndAfterReturnWhenTheReceiverHasNoParent()
+    {
+        using var fixture = DomTestFixture.Create("<p>attached</p>");
+
+        fixture.Text(
+            """
+            (() => {
+              const detached = [
+                document.createElement('div'),
+                document.createTextNode('text'),
+                document.implementation.createDocumentType('html', '', '')
+              ];
+              for (const node of detached) {
+                node.before('before', document.createElement('i'));
+                node.after('after', document.createElement('b'));
+              }
+              return detached.every(node => node.parentNode === null) ? 'returned' : 'inserted';
+            })()
+            """)
+            .Should().Be("returned", "DOM returns before converting arguments when the receiver has no parent");
+    }
 }

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
@@ -847,12 +847,22 @@ internal sealed class ModelBuilder
             DomName = domName,
             Kind = MemberKind.Operation,
             Length = DeclaredLength(method),
-            Body = Bind(model, qualified) + (method.ReturnType.FullName == "System.Void"
+            Body = Bind(model, qualified) + DetachedChildGuard(declaring, method) + (method.ReturnType.FullName == "System.Void"
                 ? body + "; return global::Jint.Native.JsValue.Undefined;"
                 : "return " + body + ";"),
             Origin = declaring.Name + "." + method.Name,
         });
     }
+
+    /// <summary>
+    /// DOM §4.2.7 returns before converting arguments when <c>before</c> or <c>after</c>'s receiver has no
+    /// parent. AngleSharp instead enters its insertion helper and raises a not-found exception, so the
+    /// generated binding performs the standard's early return before calling it.
+    /// </summary>
+    private static string DetachedChildGuard(Type declaring, MethodInfo method)
+        => declaring.FullName == "AngleSharp.Dom.IChildNode" && method.Name is "Before" or "After"
+            ? "if (self.Target.Parent is null) { return global::Jint.Native.JsValue.Undefined; }\n"
+            : "";
 
     private void BuildPropertyAsOperation(InterfaceModel model, Type declaring, PropertyInfo property, string domName, string qualified)
     {


### PR DESCRIPTION
The generated `ChildNode.before` and `after` bodies converted and moved arguments before checking whether the receiver had a parent. DOM §4.2.7 requires an immediate return when the parent is null, so a detached element, text node, or doctype must leave every supplied node untouched.

Teach the binding generator to emit that early return before union conversion and regenerate the checked-in binding. Together with #3872’s `(Node or DOMString)` support, this completes the two behaviors tracked by #3769.

Validation:

- `dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release --filter 'FullyQualifiedName~DomIndexedNodeTests|FullyQualifiedName~DomBindingsStalenessTests'` (11 passed on each of net8.0 and net10.0)
- Exact `ChildNode-before.html` and `ChildNode-after.html` triage remains at the post-#3872 baseline; their remaining position-switching failures have a different cause.

Fixes #3769.
