### PR TITLE
Add isolated DOM binding comparison harness

### DIFF
--- a/.github/workflows/binding-comparison.yml
+++ b/.github/workflows/binding-comparison.yml
@@ -1,0 +1,52 @@
+name: Binding comparison verification
+
+on:
+  pull_request:
+    paths:
+      - 'Jint/**'
+      - 'Jint.SourceGenerators/**'
+      - 'Jint.Benchmark/**'
+      - 'Directory.*.props'
+      - 'Directory.*.targets'
+      - 'global.json'
+      - '.github/workflows/binding-comparison.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Jint/**'
+      - 'Jint.SourceGenerators/**'
+      - 'Jint.Benchmark/**'
+      - 'Directory.*.props'
+      - 'Directory.*.targets'
+      - 'global.json'
+      - '.github/workflows/binding-comparison.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Verify isolated binding lanes (no measurements)
+        run: python3 Jint.Benchmark/BindingComparison/run.py --output "${{ runner.temp }}/binding-verification"
+      - name: Check comparison failure handling
+        run: python3 -m unittest discover -s Jint.Benchmark/BindingComparison -p test_run.py
+      - name: Discover benchmark methods
+        run: |
+          dotnet run -c Release --project Jint.Benchmark/BindingComparison/Baseline -- --list flat
+          dotnet run -c Release --project Jint.Benchmark/BindingComparison/Candidate -- --list flat
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: binding-verification
+          path: ${{ runner.temp }}/binding-verification

--- a/Jint.Benchmark/BindingComparison/.gitignore
+++ b/Jint.Benchmark/BindingComparison/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+artifacts/
+BenchmarkDotNet.Artifacts/

--- a/Jint.Benchmark/BindingComparison/Baseline/Baseline.csproj
+++ b/Jint.Benchmark/BindingComparison/Baseline/Baseline.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="[1.8.0]" />
+    <PackageReference Include="BenchmarkDotNet" Version="[0.15.8]" />
+    <PackageReference Include="AngleSharp.Js" Version="[1.1.0]" />
+    <PackageReference Include="Jint" Version="[4.15.3]" />
+    <Compile Include="../Shared/*.cs" />
+    <Compile Include="../../JintBenchmarkConfig.cs" Link="Config/JintBenchmarkConfig.cs" />
+    <Compile Include="../../BenchmarkTopology.cs" Link="Config/BenchmarkTopology.cs" />
+    <Compile Include="../../MachineStateValidator.cs" Link="Config/MachineStateValidator.cs" />
+  </ItemGroup>
+</Project>

--- a/Jint.Benchmark/BindingComparison/Baseline/BindingSession.cs
+++ b/Jint.Benchmark/BindingComparison/Baseline/BindingSession.cs
@@ -1,0 +1,26 @@
+using AngleSharp;
+using AngleSharp.Scripting;
+using Jint;
+
+namespace BindingComparison;
+
+internal sealed class BindingSession : IDisposable
+{
+    internal const string Arm = "AngleSharp.Js reflection";
+    private readonly IBrowsingContext _context;
+    internal Engine Engine { get; }
+    private BindingSession()
+    {
+        var scripting = new JsScriptingService();
+        _context = BrowsingContext.New(Configuration.Default.With(scripting));
+        var document = _context.OpenAsync(request => request.Content(Workloads.Html)).GetAwaiter().GetResult();
+        Engine = scripting.GetOrCreateJint(document);
+    }
+    internal void Validate() { }
+    internal static BindingSession Create() => new();
+    public void Dispose()
+    {
+        Engine.Dispose();
+        _context.Dispose();
+    }
+}

--- a/Jint.Benchmark/BindingComparison/Baseline/packages.lock.json
+++ b/Jint.Benchmark/BindingComparison/Baseline/packages.lock.json
@@ -1,0 +1,201 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.8.0, 1.8.0]",
+        "resolved": "1.8.0",
+        "contentHash": "vRW/0M11Jlfd7WkT5Kr0tXXmnWNVdxyII2S2b6AsgZCJEBGaXCUnti6nKIJTvAjmnmKcQbvn+SJ3lpt8dqoLIA=="
+      },
+      "AngleSharp.Js": {
+        "type": "Direct",
+        "requested": "[1.1.0, 1.1.0]",
+        "resolved": "1.1.0",
+        "contentHash": "5DGuaSi3hxoafNOpqJwqTz4/nIKpniwdF6z/AEf7diQNb5g3JMAR/IzL0JVxsR+3MHrtKNPF4r2BzWOIta0soA==",
+        "dependencies": {
+          "AngleSharp": "[1.8.0, 2.0.0)",
+          "Jint": "[4.15.3, 5.0.0)"
+        }
+      },
+      "BenchmarkDotNet": {
+        "type": "Direct",
+        "requested": "[0.15.8, 0.15.8]",
+        "resolved": "0.15.8",
+        "contentHash": "paCfrWxSeHqn3rUZc0spYXVFnHCF0nzRhG0nOLnyTjZYs8spsimBaaNmb3vwqvALKIplbYq/TF393vYiYSnh/Q==",
+        "dependencies": {
+          "BenchmarkDotNet.Annotations": "0.15.8",
+          "CommandLineParser": "2.9.1",
+          "Gee.External.Capstone": "2.3.0",
+          "Iced": "1.21.0",
+          "Microsoft.CodeAnalysis.CSharp": "4.14.0",
+          "Microsoft.Diagnostics.Runtime": "3.1.512801",
+          "Microsoft.Diagnostics.Tracing.TraceEvent": "3.1.21",
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Perfolizer": "[0.6.1]",
+          "System.Management": "9.0.5"
+        }
+      },
+      "Jint": {
+        "type": "Direct",
+        "requested": "[4.15.3, 4.15.3]",
+        "resolved": "4.15.3",
+        "contentHash": "xP7REb8EajnVlXvI0VdQx2PD/ddLZBjkR/vzQW9GYwm+GzvD181MgWqJvcTtV0xHViyRngHxSiDu1WGdkoluNA==",
+        "dependencies": {
+          "Acornima": "1.6.2"
+        }
+      },
+      "Acornima": {
+        "type": "Transitive",
+        "resolved": "1.6.2",
+        "contentHash": "laakpDHzMwHr5C8+q5RlRf0XJJshUvghNeo4xDerICrYR3iEuGvwfpauCmXuU3RE437XDaQO5ZxieWDpADuD+w=="
+      },
+      "BenchmarkDotNet.Annotations": {
+        "type": "Transitive",
+        "resolved": "0.15.8",
+        "contentHash": "hfucY0ycAsB0SsoaZcaAp9oq5wlWBJcylvEJb9pmvdYUx6PD6S4mDiYnZWjdjAlLhIpe/xtGCwzORfzAzPqvzA=="
+      },
+      "CommandLineParser": {
+        "type": "Transitive",
+        "resolved": "2.9.1",
+        "contentHash": "OE0sl1/sQ37bjVsPKKtwQlWDgqaxWgtme3xZz7JssWUzg5JpMIyHgCTY9MVMxOg48fJ1AgGT3tgdH5m/kQ5xhA=="
+      },
+      "Gee.External.Capstone": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "2ap/rYmjtzCOT8hxrnEW/QeiOt+paD8iRrIcdKX0cxVwWLFa1e+JDBNeECakmccXrSFeBQuu5AV8SNkipFMMMw=="
+      },
+      "Iced": {
+        "type": "Transitive",
+        "resolved": "1.21.0",
+        "contentHash": "dv5+81Q1TBQvVMSOOOmRcjJmvWcX3BZPZsIq31+RLc5cNft0IHAyNlkdb7ZarOWG913PyBoFDsDXoCIlKmLclg=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "PC3tuwZYnC+idaPuoC/AZpEdwrtX7qFpmnrfQkgobGIWiYmGi5MCRtl5mx6QrfMGQpK78X2lfIEoZDLg/qnuHg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "568a6wcTivauIhbeWcCwfWwIn7UV7MeHEBvFB2uzGIpM2OhJ4eM/FZ8KS0yhPoNxnSpjGzz7x7CIjTxhslojQA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[4.14.0]"
+        }
+      },
+      "Microsoft.Diagnostics.NETCore.Client": {
+        "type": "Transitive",
+        "resolved": "0.2.510501",
+        "contentHash": "juoqJYMDs+lRrrZyOkXXMImJHneCF23cuvO4waFRd2Ds7j+ZuGIPbJm0Y/zz34BdeaGiiwGWraMUlln05W1PCQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "6.0.0"
+        }
+      },
+      "Microsoft.Diagnostics.Runtime": {
+        "type": "Transitive",
+        "resolved": "3.1.512801",
+        "contentHash": "0lMUDr2oxNZa28D6NH5BuSQEe5T9tZziIkvkD44YkkCGQXPJqvFjLq5ZQq1hYLl3RjQJrY+hR0jFgap+EWPDTw==",
+        "dependencies": {
+          "Microsoft.Diagnostics.NETCore.Client": "0.2.410101"
+        }
+      },
+      "Microsoft.Diagnostics.Tracing.TraceEvent": {
+        "type": "Transitive",
+        "resolved": "3.1.21",
+        "contentHash": "/OrJFKaojSR6TkUKtwh8/qA9XWNtxLrXMqvEb89dBSKCWjaGVTbKMYodIUgF5deCEtmd6GXuRerciXGl5bhZ7Q==",
+        "dependencies": {
+          "Microsoft.Diagnostics.NETCore.Client": "0.2.510501",
+          "System.Reflection.TypeExtensions": "4.7.0"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ=="
+      },
+      "Perfolizer": {
+        "type": "Transitive",
+        "resolved": "0.6.1",
+        "contentHash": "CR1QmWg4XYBd1Pb7WseP+sDmV8nGPwvmowKynExTqr3OuckIGVMhvmN4LC5PGzfXqDlR295+hz/T7syA1CxEqA==",
+        "dependencies": {
+          "Pragmastat": "3.2.4"
+        }
+      },
+      "Pragmastat": {
+        "type": "Transitive",
+        "resolved": "3.2.4",
+        "contentHash": "I5qFifWw/gaTQT52MhzjZpkm/JPlfjSeO/DTZJjO7+hTKI+0aGRgOgZ3NN6D96dDuuqbIAZSeA5RimtHjqrA2A=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "9.0.5",
+        "contentHash": "cuzLM2MWutf9ZBEMPYYfd0DXwYdvntp7VCT6a/wvbKCa2ZuvGmW74xi+YBa2mrfEieAXqM4TNKlMmSnfAfpUoQ=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "9.0.5",
+        "contentHash": "n6o9PZm9p25+zAzC3/48K0oHnaPKTInRrxqFq1fi/5TPbMLjuoCm/h//mS3cUmSy+9AO1Z+qsC/Ilt/ZFatv5Q==",
+        "dependencies": {
+          "System.CodeDom": "9.0.5"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "VybpaOQQhqE6siHppMktjfGBw1GCwvCqiufqmP8F1nj7fTUNtW35LOEt3UZTEsECfo+ELAl/9o9nJx3U91i7vA=="
+      }
+    }
+  }
+}

--- a/Jint.Benchmark/BindingComparison/Candidate/BindingSession.cs
+++ b/Jint.Benchmark/BindingComparison/Candidate/BindingSession.cs
@@ -1,0 +1,90 @@
+// Explicitly use the public, non-contract representation diagnostic to assert this spike stays shaped.
+#pragma warning disable JINT0001
+
+using AngleSharp;
+using AngleSharp.Dom;
+using Jint;
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace BindingComparison;
+
+/// <summary>A deliberately narrow public-API spike, not the generated Jint.Browser binding surface.</summary>
+internal sealed class BindingSession : IDisposable
+{
+    internal const string Arm = "main hand-shaped Node/Element/Document";
+    private readonly IBrowsingContext _context;
+    private readonly Dictionary<INode, ObjectInstance> _wrappers = new(ReferenceEqualityComparer.Instance);
+    private readonly ObjectInstance _nodePrototype;
+    private readonly ObjectInstance _elementPrototype;
+    private readonly ObjectInstance _documentPrototype;
+    internal Engine Engine { get; } = new();
+
+    private static readonly JsObjectShape NodeShape = new JsObjectShape.Builder()
+        .Accessor("nodeType", static (t, _) => (int) State(t).Node.NodeType)
+        .Accessor("nodeName", static (t, _) => State(t).Node.NodeName)
+        .Build();
+    private static readonly JsObjectShape ElementShape = new JsObjectShape.Builder()
+        .Accessor("id", static (t, _) => ((IElement) State(t).Node).Id ?? "")
+        .Method("getAttribute", static (t, a) => ((IElement) State(t).Node).GetAttribute(a[0].AsString()) is { } value ? value : JsValue.Null, length: 1)
+        .Method("setAttribute", static (t, a) =>
+        {
+            ((IElement) State(t).Node).SetAttribute(a[0].AsString(), a[1].AsString());
+            return JsValue.Undefined;
+        }, length: 2)
+        .Build();
+    private static readonly JsObjectShape DocumentShape = new JsObjectShape.Builder()
+        .Accessor("documentElement", static (t, _) =>
+        {
+            var state = State(t);
+            return state.Session.Wrap(((IDocument) state.Node).DocumentElement);
+        })
+        .Method("getElementById", static (t, a) =>
+        {
+            var state = State(t);
+            return state.Session.Wrap(((IDocument) state.Node).GetElementById(a[0].AsString()));
+        }, length: 1)
+        .Build();
+    private static readonly JsObjectShape InstanceShape = new JsObjectShape.Builder().Build();
+
+    private BindingSession()
+    {
+        _context = BrowsingContext.New(Configuration.Default);
+        var document = _context.OpenAsync(request => request.Content(Workloads.Html)).GetAwaiter().GetResult();
+        _nodePrototype = NodeShape.Instantiate(Engine);
+        _elementPrototype = ElementShape.Instantiate(Engine, _nodePrototype);
+        _documentPrototype = DocumentShape.Instantiate(Engine, _nodePrototype);
+        Engine.SetValue("document", Wrap(document));
+    }
+    internal void Validate()
+    {
+        // Materialize a descriptor without invoking a getter on the prototype. Validation happens in
+        // GlobalSetup, so neither forcing this layout nor the diagnostic enters a measured operation.
+        _nodePrototype.GetOwnProperty("nodeType");
+        _elementPrototype.GetOwnProperty("id");
+        _documentPrototype.GetOwnProperty("documentElement");
+        foreach (var prototype in new[] { _nodePrototype, _elementPrototype, _documentPrototype })
+        {
+            if (Engine.Diagnostics.GetObjectRepresentation(prototype) != ObjectRepresentation.SharedBuiltinLayout)
+                throw new InvalidOperationException("The candidate prototype did not engage the shared shape lane.");
+        }
+    }
+    private static HostState State(JsValue receiver) => (HostState) JsObjectShape.GetHostState(receiver.AsObject())!;
+    private JsValue Wrap(INode? node)
+    {
+        if (node is null) return JsValue.Null;
+        if (_wrappers.TryGetValue(node, out var existing)) return existing;
+        var prototype = node is IDocument ? _documentPrototype : node is IElement ? _elementPrototype : _nodePrototype;
+        var wrapper = InstanceShape.Instantiate(Engine, prototype);
+        JsObjectShape.SetHostState(wrapper, new HostState(this, node));
+        _wrappers.Add(node, wrapper);
+        return wrapper;
+    }
+    private sealed record HostState(BindingSession Session, INode Node);
+    internal static BindingSession Create() => new();
+    public void Dispose()
+    {
+        Engine.Dispose();
+        _context.Dispose();
+    }
+}

--- a/Jint.Benchmark/BindingComparison/Candidate/Candidate.csproj
+++ b/Jint.Benchmark/BindingComparison/Candidate/Candidate.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="[1.8.0]" />
+    <PackageReference Include="BenchmarkDotNet" Version="[0.15.8]" />
+    <ProjectReference Include="../../../Jint/Jint.csproj" />
+    <Compile Include="../Shared/*.cs" />
+    <Compile Include="../../JintBenchmarkConfig.cs" Link="Config/JintBenchmarkConfig.cs" />
+    <Compile Include="../../BenchmarkTopology.cs" Link="Config/BenchmarkTopology.cs" />
+    <Compile Include="../../MachineStateValidator.cs" Link="Config/MachineStateValidator.cs" />
+  </ItemGroup>
+</Project>

--- a/Jint.Benchmark/BindingComparison/Candidate/packages.lock.json
+++ b/Jint.Benchmark/BindingComparison/Candidate/packages.lock.json
@@ -1,0 +1,188 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.8.0, 1.8.0]",
+        "resolved": "1.8.0",
+        "contentHash": "vRW/0M11Jlfd7WkT5Kr0tXXmnWNVdxyII2S2b6AsgZCJEBGaXCUnti6nKIJTvAjmnmKcQbvn+SJ3lpt8dqoLIA=="
+      },
+      "BenchmarkDotNet": {
+        "type": "Direct",
+        "requested": "[0.15.8, 0.15.8]",
+        "resolved": "0.15.8",
+        "contentHash": "paCfrWxSeHqn3rUZc0spYXVFnHCF0nzRhG0nOLnyTjZYs8spsimBaaNmb3vwqvALKIplbYq/TF393vYiYSnh/Q==",
+        "dependencies": {
+          "BenchmarkDotNet.Annotations": "0.15.8",
+          "CommandLineParser": "2.9.1",
+          "Gee.External.Capstone": "2.3.0",
+          "Iced": "1.21.0",
+          "Microsoft.CodeAnalysis.CSharp": "4.14.0",
+          "Microsoft.Diagnostics.Runtime": "3.1.512801",
+          "Microsoft.Diagnostics.Tracing.TraceEvent": "3.1.21",
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Perfolizer": "[0.6.1]",
+          "System.Management": "9.0.5"
+        }
+      },
+      "Acornima": {
+        "type": "Transitive",
+        "resolved": "1.8.0",
+        "contentHash": "ZtcK7lu5LZZH5qDWfeUdBn/WXChWQjGdpB9sSFOJPyqnODGSMS1wqBoONP7GXzQRPHKoV8byWZT4EeBPI69ODQ=="
+      },
+      "BenchmarkDotNet.Annotations": {
+        "type": "Transitive",
+        "resolved": "0.15.8",
+        "contentHash": "hfucY0ycAsB0SsoaZcaAp9oq5wlWBJcylvEJb9pmvdYUx6PD6S4mDiYnZWjdjAlLhIpe/xtGCwzORfzAzPqvzA=="
+      },
+      "CommandLineParser": {
+        "type": "Transitive",
+        "resolved": "2.9.1",
+        "contentHash": "OE0sl1/sQ37bjVsPKKtwQlWDgqaxWgtme3xZz7JssWUzg5JpMIyHgCTY9MVMxOg48fJ1AgGT3tgdH5m/kQ5xhA=="
+      },
+      "Gee.External.Capstone": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "2ap/rYmjtzCOT8hxrnEW/QeiOt+paD8iRrIcdKX0cxVwWLFa1e+JDBNeECakmccXrSFeBQuu5AV8SNkipFMMMw=="
+      },
+      "Iced": {
+        "type": "Transitive",
+        "resolved": "1.21.0",
+        "contentHash": "dv5+81Q1TBQvVMSOOOmRcjJmvWcX3BZPZsIq31+RLc5cNft0IHAyNlkdb7ZarOWG913PyBoFDsDXoCIlKmLclg=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "PC3tuwZYnC+idaPuoC/AZpEdwrtX7qFpmnrfQkgobGIWiYmGi5MCRtl5mx6QrfMGQpK78X2lfIEoZDLg/qnuHg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.14.0",
+        "contentHash": "568a6wcTivauIhbeWcCwfWwIn7UV7MeHEBvFB2uzGIpM2OhJ4eM/FZ8KS0yhPoNxnSpjGzz7x7CIjTxhslojQA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[4.14.0]"
+        }
+      },
+      "Microsoft.Diagnostics.NETCore.Client": {
+        "type": "Transitive",
+        "resolved": "0.2.510501",
+        "contentHash": "juoqJYMDs+lRrrZyOkXXMImJHneCF23cuvO4waFRd2Ds7j+ZuGIPbJm0Y/zz34BdeaGiiwGWraMUlln05W1PCQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "6.0.0"
+        }
+      },
+      "Microsoft.Diagnostics.Runtime": {
+        "type": "Transitive",
+        "resolved": "3.1.512801",
+        "contentHash": "0lMUDr2oxNZa28D6NH5BuSQEe5T9tZziIkvkD44YkkCGQXPJqvFjLq5ZQq1hYLl3RjQJrY+hR0jFgap+EWPDTw==",
+        "dependencies": {
+          "Microsoft.Diagnostics.NETCore.Client": "0.2.410101"
+        }
+      },
+      "Microsoft.Diagnostics.Tracing.TraceEvent": {
+        "type": "Transitive",
+        "resolved": "3.1.21",
+        "contentHash": "/OrJFKaojSR6TkUKtwh8/qA9XWNtxLrXMqvEb89dBSKCWjaGVTbKMYodIUgF5deCEtmd6GXuRerciXGl5bhZ7Q==",
+        "dependencies": {
+          "Microsoft.Diagnostics.NETCore.Client": "0.2.510501",
+          "System.Reflection.TypeExtensions": "4.7.0"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ=="
+      },
+      "Perfolizer": {
+        "type": "Transitive",
+        "resolved": "0.6.1",
+        "contentHash": "CR1QmWg4XYBd1Pb7WseP+sDmV8nGPwvmowKynExTqr3OuckIGVMhvmN4LC5PGzfXqDlR295+hz/T7syA1CxEqA==",
+        "dependencies": {
+          "Pragmastat": "3.2.4"
+        }
+      },
+      "Pragmastat": {
+        "type": "Transitive",
+        "resolved": "3.2.4",
+        "contentHash": "I5qFifWw/gaTQT52MhzjZpkm/JPlfjSeO/DTZJjO7+hTKI+0aGRgOgZ3NN6D96dDuuqbIAZSeA5RimtHjqrA2A=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "9.0.5",
+        "contentHash": "cuzLM2MWutf9ZBEMPYYfd0DXwYdvntp7VCT6a/wvbKCa2ZuvGmW74xi+YBa2mrfEieAXqM4TNKlMmSnfAfpUoQ=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "9.0.5",
+        "contentHash": "n6o9PZm9p25+zAzC3/48K0oHnaPKTInRrxqFq1fi/5TPbMLjuoCm/h//mS3cUmSy+9AO1Z+qsC/Ilt/ZFatv5Q==",
+        "dependencies": {
+          "System.CodeDom": "9.0.5"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "VybpaOQQhqE6siHppMktjfGBw1GCwvCqiufqmP8F1nj7fTUNtW35LOEt3UZTEsECfo+ELAl/9o9nJx3U91i7vA=="
+      },
+      "jint": {
+        "type": "Project",
+        "dependencies": {
+          "Acornima": "[1.8.0, )"
+        }
+      }
+    }
+  }
+}

--- a/Jint.Benchmark/BindingComparison/Directory.Build.props
+++ b/Jint.Benchmark/BindingComparison/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+    <RestorePackagesWithLockFile Condition="'$(MSBuildProjectName)' == 'Baseline' Or '$(MSBuildProjectName)' == 'Candidate'">true</RestorePackagesWithLockFile>
+    <RestoreLockedMode Condition="'$(MSBuildProjectName)' == 'Baseline' Or '$(MSBuildProjectName)' == 'Candidate'">true</RestoreLockedMode>
+  </PropertyGroup>
+</Project>

--- a/Jint.Benchmark/BindingComparison/Directory.Packages.props
+++ b/Jint.Benchmark/BindingComparison/Directory.Packages.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- This experiment deliberately has two incompatible dependency graphs. -->
+  <PropertyGroup><ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally></PropertyGroup>
+</Project>

--- a/Jint.Benchmark/BindingComparison/README.md
+++ b/Jint.Benchmark/BindingComparison/README.md
@@ -1,0 +1,90 @@
+# DOM binding comparison spike
+
+This is the reproducible harness for [#3575 D0.3](https://github.com/sebastienros/jint/issues/3575),
+tracked by [#3898](https://github.com/sebastienros/jint/issues/3898). It contains no performance results.
+An idle-machine paired run and an evidence-based conclusion are still needed to complete D0.3.
+
+Two **separate executables** use the same offline AngleSharp DOM and the same prepared JavaScript:
+
+| Arm | Binding | Interpreter | DOM |
+| --- | --- | --- | --- |
+| Baseline | AngleSharp.Js 1.1.0 reflection | NuGet Jint 4.15.3 | AngleSharp 1.8.0 |
+| Candidate | Hand-shaped Node/Element/Document prototypes, public APIs only | This checkout's Jint | AngleSharp 1.8.0 |
+
+Each project has its own dependency graph and enforced lock file (use `dotnet restore -p:RestoreLockedMode=false`
+only when deliberately updating that project's pins). Exact direct package pins deliberately bypass
+central package management for this experiment; the Jint project reference retains its normal repository
+configuration. The baseline's incompatible Jint version never loads into the candidate process.
+`Jint.Benchmark.csproj` excludes these sources; run these projects separately.
+
+The candidate is a deliberately small binding spike: two Node attributes, one Element attribute and two
+operations, one Document attribute and one operation, and identity-preserving wrappers. It asserts that
+its prototypes use the shared shape representation. It does **not** implement WebIDL conversion and
+error semantics, the complete DOM prototype family, Window, or the production generated browser binding.
+
+## Verify without measuring
+
+From the repository root, with Python 3 and the repository's .NET SDK:
+
+```sh
+python3 Jint.Benchmark/BindingComparison/run.py --output /tmp/binding-verification
+python3 -m unittest discover -s Jint.Benchmark/BindingComparison -p test_run.py
+```
+
+`--dotnet /absolute/path/to/dotnet` selects a particular SDK executable, including for child builds.
+Choose a new output directory per run. Every invocation freshly builds in Release. Verification runs the
+actual benchmark methods with two independent cold instances and repeated calls to independently warmed
+instances for each workload. It checks 24 results per arm against independent expected values, then
+rejects differences in workload hashes, runtime, architecture, OS, or DOM/BDN assembly identity.
+
+| Workload | What it exercises | Expected checksum |
+| --- | --- | --- |
+| NodeRead | Document and Element inherited Node getters | 13000 |
+| ElementReadWrite | Alternating attribute writes, reads and `id` | 8500 |
+| DocumentLookup | `getElementById`, wrapper identity, `documentElement` | 5000 |
+| InterpreterControl | Integer loop without DOM calls | 3500 |
+
+The fixed 1000-iteration workloads reset their state each invocation. Alternating attribute values make
+a missing setter fail. The control exposes interpreter differences; it is not a correction factor that
+can be subtracted from other rows. `verification.json` records the runtime, SDK, git head and dirty state,
+assembly informational versions and SHA-256 hashes, and the HTML/script hash. Logs are retained on failure.
+No clocks are sampled and no timing claims are produced by verification. The `Binding comparison verification`
+workflow runs these checks on relevant pull requests and main pushes; CI never measures performance.
+
+List the benchmark methods without running them:
+
+```sh
+dotnet run -c Release --project Jint.Benchmark/BindingComparison/Baseline -- --list flat
+dotnet run -c Release --project Jint.Benchmark/BindingComparison/Candidate -- --list flat
+```
+
+## Collect measurements later
+
+Read [the benchmark instructions](../AGENTS.md) before measuring. On an otherwise idle machine:
+
+```sh
+python3 Jint.Benchmark/BindingComparison/run.py --measure --rounds 6 --output /tmp/binding-paired
+```
+
+The driver verifies first, selects the repository's **gate** configuration (three BDN launches, idle
+validation, normal production tiering), and collects alternating baseline/candidate then
+candidate/baseline rounds. It refuses an idle-check override and preserves each round's raw BDN CSV,
+logs, memory diagnostics and provenance. An absent, duplicate, failed or incomplete report fails the run.
+It does not calculate or publish a ratio. Pair rows by method and workload within each round, and analyze
+paired differences with confidence intervals as described in [measure-paired.ps1](../measure-paired.ps1).
+That script's worktree runner is not directly interchangeable with these two project runners.
+After an interrupted measurement, follow the power-plan restoration instructions in the benchmark guide.
+
+**Cold** includes DOM parsing, engine and binding setup, first prepared-script execution and disposal on
+every operation; script parsing is excluded. Process initialization, first-ever reflection and static
+shape construction are warmed by BDN: this is document-cold, not process startup.
+**Warm** excludes DOM/engine setup, script parsing and disposal, and warms each engine only with its own
+row's workload. Checksums are checked inside both methods and memory diagnostics cover both lanes.
+
+These arms differ in interpreter/parser version and binding surface. In particular, baseline cold setup
+builds its complete Window/DOM environment while the candidate builds three small prototypes. A cold
+ratio cannot be presented as equivalent-browser startup savings, and a warm ratio cannot isolate the
+causal effect of shapes. Use the control, report all provenance, and describe these as end-to-end costs
+of the two explicitly defined embedding paths. Comparing the production generated bindings or attributing
+a pure binding speedup requires another matched experiment. No numbers from a busy machine or a short job
+belong in a PR or release note.

--- a/Jint.Benchmark/BindingComparison/Shared/Comparison.cs
+++ b/Jint.Benchmark/BindingComparison/Shared/Comparison.cs
@@ -1,0 +1,149 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Jint;
+using Jint.Benchmark;
+
+namespace BindingComparison;
+
+internal static class Program
+{
+    public static int Main(string[] args)
+    {
+        if (args.SequenceEqual(new[] { "--verify" }))
+        {
+            var results = new List<object>();
+            foreach (var workload in Enum.GetValues<Workload>())
+            {
+                // Two cold instances and repeated warm calls catch state accumulating between invocations.
+                for (var instance = 0; instance < 2; instance++)
+                {
+                    var benchmark = new BindingBenchmark { Workload = workload };
+                    benchmark.SetupCold();
+                    results.Add(new { workload = workload.ToString(), instance, lane = "cold", checksum = benchmark.Cold() });
+                    benchmark.SetupWarm();
+                    try
+                    {
+                        for (var call = 0; call < 2; call++)
+                            results.Add(new { workload = workload.ToString(), instance, lane = "warm", checksum = benchmark.Warm() });
+                    }
+                    finally { benchmark.Cleanup(); }
+                }
+            }
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                arm = BindingSession.Arm,
+                runtime = RuntimeInformation.FrameworkDescription,
+                os = RuntimeInformation.OSDescription,
+                architecture = RuntimeInformation.ProcessArchitecture.ToString(),
+                assemblies = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(a => new[] { "Jint", "AngleSharp", "AngleSharp.Js", "Acornima", "BenchmarkDotNet" }.Contains(a.GetName().Name))
+                    .OrderBy(a => a.GetName().Name)
+                    .Select(a => new { name = a.GetName().Name, version = a.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+                        sha256 = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(a.Location))) }),
+                workloadSha256 = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
+                    Workloads.Html + string.Join("\n", Enum.GetValues<Workload>().Select(Workloads.Script))))),
+                results
+            }));
+            return 0;
+        }
+        var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, JintBenchmarkConfig.Create());
+        return summaries.Any(s => s.HasCriticalValidationErrors || s.Reports.Any(r => !r.Success)) ? 1 : 0;
+    }
+}
+
+public enum Workload { NodeRead, ElementReadWrite, DocumentLookup, InterpreterControl }
+
+internal static class Workloads
+{
+    internal const int Iterations = 1000;
+    internal const string Html = "<!doctype html><html><head></head><body><div id='target' data-value='abc'>text</div></body></html>";
+    internal static string Script(Workload workload)
+    {
+        var body = workload switch
+        {
+            Workload.InterpreterControl => "sum += i & 7;",
+            Workload.NodeRead => "sum += document.nodeType + element.nodeType + element.nodeName.length;",
+            Workload.ElementReadWrite => "element.setAttribute('data-value', i % 2 === 0 ? 'a' : 'abcd'); sum += element.getAttribute('data-value').length + element.id.length;",
+            Workload.DocumentLookup => "sum += document.getElementById('target') === element ? 1 : 0; sum += document.documentElement.nodeName.length;",
+            _ => throw new ArgumentOutOfRangeException(nameof(workload))
+        };
+        var setup = workload == Workload.InterpreterControl ? "" : "var element = document.getElementById('target');";
+        return $$"""
+            (function () {
+                {{setup}}
+                var sum = 0;
+                for (var i = 0; i < {{Iterations}}; i++) { {{body}} }
+                return sum;
+            })()
+            """;
+    }
+    internal static void Check(Workload workload, double actual)
+    {
+        // Independent arithmetic from the fixed HTML, not computed by either binding arm.
+        var expected = workload switch
+        {
+            Workload.NodeRead => Iterations * (9 + 1 + 3),
+            Workload.ElementReadWrite => Iterations / 2 * (1 + 4 + 6 + 6),
+            Workload.DocumentLookup => Iterations * (1 + 4),
+            Workload.InterpreterControl => Iterations / 8 * 28,
+            _ => throw new ArgumentOutOfRangeException(nameof(workload))
+        };
+        if (actual != expected) throw new InvalidOperationException($"{workload}: expected {expected}, got {actual}.");
+    }
+}
+
+/// <summary>
+/// Cold includes a new DOM, engine, bindings, first execution and disposal; it excludes script parsing.
+/// Warm owns a separate engine per workload and excludes setup, parsing and disposal. Only that workload
+/// warms it. These are public embedding APIs in both executables, with no InternalsVisibleTo access.
+/// The cold lane is document-cold within a warmed process, not process startup or first-ever reflection.
+/// </summary>
+[MemoryDiagnoser]
+public class BindingBenchmark
+{
+    private BindingSession? _warm;
+    private Prepared<Acornima.Ast.Script> _script;
+    [ParamsAllValues] public Workload Workload { get; set; }
+
+    [GlobalSetup(Target = nameof(Cold))]
+    public void SetupCold()
+    {
+        _script = Engine.PrepareScript(Workloads.Script(Workload));
+        using var probe = BindingSession.Create();
+        probe.Validate();
+    }
+
+    [GlobalSetup(Target = nameof(Warm))]
+    public void SetupWarm()
+    {
+        SetupCold();
+        _warm = BindingSession.Create();
+        _warm.Validate();
+        for (var i = 0; i < 10; i++) Workloads.Check(Workload, _warm.Engine.Evaluate(_script).AsNumber());
+    }
+
+    [Benchmark]
+    public double Cold()
+    {
+        using var session = BindingSession.Create();
+        var value = session.Engine.Evaluate(_script).AsNumber();
+        Workloads.Check(Workload, value);
+        return value;
+    }
+
+    [Benchmark]
+    public double Warm()
+    {
+        var value = _warm!.Engine.Evaluate(_script).AsNumber();
+        Workloads.Check(Workload, value);
+        return value;
+    }
+
+    [GlobalCleanup(Target = nameof(Warm))]
+    public void Cleanup() => _warm?.Dispose();
+}

--- a/Jint.Benchmark/BindingComparison/run.py
+++ b/Jint.Benchmark/BindingComparison/run.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Verify both dependency graphs, optionally collect alternating BDN rounds (no ratio claims)."""
+import argparse
+import csv
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parent
+ARMS = ("Baseline", "Candidate")
+EXPECTED = {"NodeRead": 13000, "ElementReadWrite": 8500, "DocumentLookup": 5000, "InterpreterControl": 3500}
+
+
+def compare(baseline, candidate):
+    for key in ("runtime", "os", "architecture", "workloadSha256"):
+        if baseline[key] != candidate[key]:
+            raise ValueError(f"Different {key}: comparison is invalid")
+    for report in (baseline, candidate):
+        expected = [dict(workload=workload, instance=instance,
+                         lane="cold" if call == 0 else "warm", checksum=checksum)
+                    for workload, checksum in EXPECTED.items()
+                    for instance in range(2) for call in range(3)]
+        if report["results"] != expected:
+            raise ValueError(f"Incomplete or incorrect checksums: {report['arm']}")
+    for name in ("AngleSharp", "BenchmarkDotNet"):
+        def assembly(report):
+            return next(a for a in report["assemblies"] if a["name"] == name)
+        if assembly(baseline) != assembly(candidate):
+            raise ValueError(f"Different {name} assemblies: comparison is invalid")
+
+
+def validate_csv(path):
+    with path.open(encoding="utf-8-sig", newline="") as stream:
+        sample = stream.read(4096)
+        stream.seek(0)
+        dialect = csv.Sniffer().sniff(sample, delimiters=",;") if sample else csv.excel
+        rows = list(csv.DictReader(stream, dialect=dialect))
+    expected = {(method, workload) for method in ("Cold", "Warm") for workload in EXPECTED}
+    actual = {(row.get("Method"), row.get("Workload")) for row in rows}
+    if actual != expected or len(rows) != len(expected):
+        raise ValueError(f"Missing, duplicate or unexpected benchmark rows: {path}")
+    if any(row.get("Mean", "").strip() in ("", "NA", "N/A", "?") for row in rows):
+        raise ValueError(f"Failed benchmark measurement: {path}")
+
+
+def run(dotnet, arm, args, log, environment):
+    command = [dotnet, "run", "-c", "Release", "--project", str(ROOT / arm), "--", *args]
+    with log.open("w", encoding="utf-8") as stream:
+        subprocess.run(command, cwd=ROOT / arm, stdout=stream, stderr=subprocess.STDOUT,
+                       env=environment, check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dotnet", default="dotnet", help="SDK executable (also used by BDN child builds)")
+    parser.add_argument("--output", type=Path, required=True, help="New directory for logs and provenance")
+    parser.add_argument("--measure", action="store_true", help="Collect gate-mode measurements on an idle machine")
+    parser.add_argument("--rounds", type=int, default=6, help="Alternating paired rounds (minimum 6)")
+    args = parser.parse_args()
+    if args.measure and args.rounds < 6:
+        parser.error("measurements require at least six paired rounds")
+    environment = os.environ.copy()
+    if args.measure:
+        if environment.get("JINT_BENCH_SKIP_IDLE_CHECK") in ("1", "true"):
+            parser.error("remove JINT_BENCH_SKIP_IDLE_CHECK for measurements")
+        environment["JINT_BENCH_MODE"] = "gate"
+    if Path(args.dotnet).is_absolute():
+        environment["PATH"] = str(Path(args.dotnet).parent) + os.pathsep + environment.get("PATH", "")
+        environment["DOTNET_ROOT"] = str(Path(args.dotnet).parent)
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    provenance = {}
+    for arm in ARMS:
+        log = output / f"{arm}.verify.log"
+        run(args.dotnet, arm, ["--verify"], log, environment)
+        reports = [json.loads(line) for line in log.read_text().splitlines() if line.startswith('{"arm":')]
+        if len(reports) != 1:
+            raise ValueError(f"Expected exactly one verification report: {log}")
+        provenance[arm] = reports[0]
+    compare(provenance["Baseline"], provenance["Candidate"])
+    provenance["gitHead"] = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
+    provenance["gitStatus"] = subprocess.check_output(["git", "status", "--porcelain"], cwd=ROOT, text=True)
+    provenance["sdk"] = subprocess.check_output([args.dotnet, "--version"], env=environment, text=True).strip()
+    (output / "verification.json").write_text(json.dumps(provenance, indent=2) + "\n")
+    print(f"Verified both arms: 24 checksums each; provenance in {output}", flush=True)
+    if args.measure:
+        for round_index in range(args.rounds):
+            order = ARMS if round_index % 2 == 0 else tuple(reversed(ARMS))
+            for arm in order:
+                directory = output / f"round-{round_index + 1}" / arm
+                directory.mkdir(parents=True)
+                print(f"Collecting round {round_index + 1}: {arm}", flush=True)
+                run(args.dotnet, arm, ["--filter", "*BindingBenchmark*", "--artifacts", str(directory)],
+                    directory / "run.log", environment)
+                csv_files = list((directory / "results").glob("*-report.csv"))
+                if len(csv_files) != 1:
+                    raise ValueError(f"Expected one BDN report: {directory}")
+                validate_csv(csv_files[0])
+        print("Complete paired raw artifacts saved. Analyze paired differences and confidence intervals before making claims.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, OSError, csv.Error, subprocess.CalledProcessError) as error:
+        print(f"Comparison failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/Jint.Benchmark/BindingComparison/test_run.py
+++ b/Jint.Benchmark/BindingComparison/test_run.py
@@ -1,0 +1,52 @@
+"""Failures must never turn an empty or contaminated comparison into a successful report."""
+import copy
+import csv
+from pathlib import Path
+import tempfile
+import unittest
+import run
+
+
+def report():
+    return dict(arm="fixture", runtime="runtime", os="os", architecture="arch", workloadSha256="hash",
+                assemblies=[dict(name=name, sha256="hash") for name in ("AngleSharp", "BenchmarkDotNet")],
+                results=[dict(workload=workload, instance=instance, lane="cold" if call == 0 else "warm", checksum=value)
+                         for workload, value in run.EXPECTED.items() for instance in range(2) for call in range(3)])
+
+
+class ComparisonTests(unittest.TestCase):
+    def test_matching_reports(self):
+        run.compare(report(), report())
+
+    def test_rejects_missing_wrong_or_different_work(self):
+        for mutation in (lambda r: r["results"].pop(),
+                         lambda r: r["results"][0].update(checksum=0),
+                         lambda r: r.update(workloadSha256="different"),
+                         lambda r: r["assemblies"][0].update(sha256="different")):
+            candidate = copy.deepcopy(report())
+            mutation(candidate)
+            with self.assertRaises(ValueError):
+                run.compare(report(), candidate)
+
+    def test_csv_requires_every_successful_row_once(self):
+        rows = [dict(Method=method, Workload=workload, Mean="1.5 μs")
+                for method in ("Cold", "Warm") for workload in run.EXPECTED]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.csv"
+            for mode in ("valid", "empty", "missing", "duplicate", "failed"):
+                data = copy.deepcopy(rows)
+                if mode == "empty": data.clear()
+                if mode == "missing": data.pop()
+                if mode == "duplicate": data.append(data[0])
+                if mode == "failed": data[0]["Mean"] = "NA"
+                with path.open("w", newline="") as stream:
+                    writer = csv.DictWriter(stream, fieldnames=("Method", "Workload", "Mean"))
+                    writer.writeheader()
+                    writer.writerows(data)
+                if mode == "valid": run.validate_csv(path)
+                else:
+                    with self.assertRaises(ValueError): run.validate_csv(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Jint.Benchmark/Jint.Benchmark.csproj
+++ b/Jint.Benchmark/Jint.Benchmark.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup><Compile Remove="BindingComparison/**/*.cs" /></ItemGroup>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
D0.3 in #3575 had no reproducible comparison of AngleSharp.Js reflection bindings and a hand-shaped DOM prototype. This adds separate, locked baseline and candidate executables sharing the same AngleSharp 1.8.0 DOM and prepared-script workloads. Verification exercises the actual cold/warm benchmark methods, checks 24 results per arm, asserts candidate shape engagement, and records dependency/runtime/workload provenance.

A paired collector reuses the repository's BenchmarkDotNet gate configuration and alternates both arms across at least six rounds. It rejects mismatched verification and missing, duplicate or failed measurement rows. A correctness-only CI workflow keeps the standalone projects compiled. Documentation explains the interpreter-version and binding-surface differences, especially why a small prototype's cold result cannot represent equivalent browser startup savings.

Validation: both isolated Release runners pass all 24 checksums; both BDN method lists succeed; the existing Jint.Benchmark project builds in Release with zero warnings/errors; all three Python report-validation tests pass; `git diff --check` passes. Local SDK: 10.0.400, runtime .NET 10.0.11. No timing measurements were collected or claimed. The paired measurement collector has not been run; D0.3's idle-machine measurement and conclusion remain outstanding.

Closes #3898. Part of #3575.
