### PR TITLE
Add offline browser comparison harness for X4

### DIFF
--- a/Jint.slnx
+++ b/Jint.slnx
@@ -38,6 +38,7 @@
   <Project Path="Jint.Tests/Jint.Tests.csproj" />
   <Project Path="Jint/Jint.csproj" />
   <Project Path="docs/snippets/Jint.Documentation.Samples/Jint.Documentation.Samples.csproj" />
+  <Project Path="tools/browser-comparison/BrowserComparison.csproj" />
   <Project Path="tools/devtools-protocol/Jint.DevTools.ProtocolGenerator/Jint.DevTools.ProtocolGenerator.csproj" />
   <Project Path="tools/dom-bindings/Jint.Browser.BindingGenerator/Jint.Browser.BindingGenerator.csproj" />
 </Solution>

--- a/tools/browser-comparison/BrowserAdapter.cs
+++ b/tools/browser-comparison/BrowserAdapter.cs
@@ -1,0 +1,128 @@
+using System.Diagnostics;
+using PuppeteerSharp;
+
+namespace BrowserComparison;
+
+/// <summary>Owns fresh Jint/Chromium processes; only borrows an external Lightpanda connection.</summary>
+internal sealed class BrowserAdapter(AdapterOptions options) : IAsyncDisposable
+{
+    internal IBrowser? Browser { get; private set; }
+    internal Process? Process { get; private set; }
+    internal int? ProcessId { get; private set; }
+    private bool _disposed;
+
+    internal async Task StartAsync()
+    {
+        if (options.Kind == "chromium")
+        {
+            Browser = await Puppeteer.LaunchAsync(new LaunchOptions
+            {
+                ExecutablePath = options.Executable,
+                Headless = true,
+                DefaultViewport = null,
+                Args = options.Arguments ?? [],
+                Timeout = 30000,
+            });
+            Process = Browser.Process;
+        }
+        else
+        {
+            var endpoint = options.Endpoint;
+            if (options.Kind == "jint")
+            {
+                var start = new ProcessStartInfo(options.Executable!)
+                {
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                };
+                foreach (var argument in options.Arguments ?? [])
+                {
+                    start.ArgumentList.Add(argument);
+                }
+                start.ArgumentList.Add("serve");
+                start.ArgumentList.Add("--port");
+                start.ArgumentList.Add("0");
+                Process = System.Diagnostics.Process.Start(start)
+                    ?? throw new InvalidOperationException("Jint did not start.");
+                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                while (await Process.StandardOutput.ReadLineAsync(timeout.Token) is { } line)
+                {
+                    if (line.Trim().StartsWith("browser: ", StringComparison.Ordinal))
+                    {
+                        endpoint = line.Trim()["browser: ".Length..];
+                        break;
+                    }
+                }
+                if (endpoint is null)
+                {
+                    throw new InvalidOperationException("Jint exited without announcing a browser endpoint.");
+                }
+                // Drain subsequent diagnostics so a full pipe cannot stall the browser.
+                _ = DrainAsync(Process.StandardOutput);
+            }
+            else if (options.ProcessId is { } id)
+            {
+                Process = System.Diagnostics.Process.GetProcessById(id);
+            }
+            Browser = await Puppeteer.ConnectAsync(new ConnectOptions
+            {
+                BrowserWSEndpoint = endpoint,
+                DefaultViewport = null,
+            }).WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        ProcessId = Process?.Id;
+    }
+
+    private static async Task DrainAsync(StreamReader output)
+    {
+        try
+        {
+            while (await output.ReadLineAsync() is not null)
+            {
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // Process disposal closes the pipe after termination.
+        }
+        catch (IOException)
+        {
+            // The owned process may terminate while its output is draining.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        try
+        {
+            if (Browser is not null)
+            {
+                if (options.Kind == "chromium")
+                {
+                    await Browser.CloseAsync().WaitAsync(TimeSpan.FromSeconds(10));
+                }
+                else
+                {
+                    Browser.Disconnect();
+                }
+            }
+        }
+        finally
+        {
+            if (Process is not null)
+            {
+                if (options.Kind != "lightpanda" && !Process.HasExited)
+                {
+                    Process.Kill(entireProcessTree: true);
+                    await Process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(10));
+                }
+                Process.Dispose();
+            }
+        }
+    }
+}

--- a/tools/browser-comparison/BrowserComparison.csproj
+++ b/tools/browser-comparison/BrowserComparison.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="PuppeteerSharp" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <Using Remove="Acornima" />
+    <Using Remove="Acornima.Ast" />
+    <None Include="fixture.html" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tools/browser-comparison/Program.cs
+++ b/tools/browser-comparison/Program.cs
@@ -1,0 +1,175 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PuppeteerSharp;
+
+namespace BrowserComparison;
+
+internal static class Program
+{
+    private static readonly JsonSerializerOptions Json = new() { WriteIndented = true, PropertyNameCaseInsensitive = true };
+
+    internal static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            if (args.Length != 3 || args[0] != "--config" || args[2] is not ("--smoke" or "--collect"))
+            {
+                Console.Error.WriteLine("Usage: BrowserComparison --config config.json --smoke|--collect");
+                return 2;
+            }
+
+            var smoke = args[2] == "--smoke";
+            var config = JsonSerializer.Deserialize<Configuration>(await File.ReadAllTextAsync(args[1]), Json)
+                ?? throw new InvalidOperationException("Empty configuration.");
+            config.Validate();
+            var fixture = await File.ReadAllBytesAsync(Path.Combine(AppContext.BaseDirectory, "fixture.html"));
+            var builder = WebApplication.CreateSlimBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
+            await using var server = builder.Build();
+            server.MapGet("/fixture", async context =>
+            {
+                context.Response.ContentType = "text/html; charset=utf-8";
+                await context.Response.Body.WriteAsync(fixture);
+            });
+            await server.StartAsync();
+            var address = server.Services.GetRequiredService<IServer>().Features
+                .Get<IServerAddressesFeature>()!.Addresses.Single();
+            var results = new List<RunResult>();
+            // Alternate adapter order between rounds; every row still owns a new process/page.
+            for (var round = 0; round < (smoke ? 1 : config.Rounds); round++)
+            {
+                var adapters = round % 2 == 0 ? config.Adapters : config.Adapters.Reverse();
+                foreach (var adapter in adapters)
+                {
+                    results.Add(await RunAsync(adapter, round, address + "/fixture", smoke));
+                }
+            }
+
+            var report = new
+            {
+                SchemaVersion = 1,
+                Mode = smoke ? "smoke-no-measurements" : "raw-diagnostics-not-publication-quality",
+                RecordedAt = DateTimeOffset.UtcNow,
+                Environment = new { RuntimeInformation.FrameworkDescription, RuntimeInformation.OSDescription,
+                    Architecture = RuntimeInformation.ProcessArchitecture.ToString(), System.Environment.ProcessorCount },
+                HarnessVersion = typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+                PuppeteerVersion = typeof(Puppeteer).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+                FixtureSha256 = Convert.ToHexString(SHA256.HashData(fixture)),
+                AssertedResult = "100|4950|4950|Verified 100",
+                MemorySampleIntervalMilliseconds = ProcessMemorySampler.IntervalMilliseconds,
+                Scope = "CPU delta and OS peak working set for the explicitly named browser root PID only; excludes renderer/utility children, client and fixture server. OS peak is lifetime high-water mark, not a stage delta; sampled peak observes page work every 10 ms and can miss transients.",
+                Results = results,
+            };
+            Console.WriteLine(JsonSerializer.Serialize(report, Json));
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(exception);
+            return 1;
+        }
+    }
+
+    private static async Task<RunResult> RunAsync(AdapterOptions options, int round, string url, bool smoke)
+    {
+        var identity = await BinaryIdentity.ReadAsync(options);
+        await using var adapter = new BrowserAdapter(options);
+        var launch = Stopwatch.StartNew();
+        await adapter.StartAsync();
+        launch.Stop();
+        var browser = adapter.Browser!;
+        var version = await browser.GetVersionAsync().WaitAsync(TimeSpan.FromSeconds(30));
+        var agent = await browser.GetUserAgentAsync().WaitAsync(TimeSpan.FromSeconds(30));
+        var before = ProcessSnapshot.Read(adapter.Process);
+        await using var memory = new ProcessMemorySampler(adapter.Process);
+        var workload = Stopwatch.StartNew();
+        await using (var page = await browser.NewPageAsync().WaitAsync(TimeSpan.FromSeconds(30)))
+        {
+            await page.GoToAsync(url, new NavigationOptions { WaitUntil = [WaitUntilNavigation.Load], Timeout = 30000 });
+            var actual = await page.EvaluateExpressionAsync<string>("""
+                (() => {
+                    const items = [...document.querySelectorAll('#items li')];
+                    const total = items.reduce((sum, item) => sum + Number(item.dataset.value), 0);
+                    document.querySelector('h1').textContent = 'Verified ' + items.length;
+                    return [items.length, total, document.querySelector('#total').textContent,
+                        document.querySelector('h1').textContent].join('|');
+                })()
+                """).WaitAsync(TimeSpan.FromSeconds(30));
+            if (actual != "100|4950|4950|Verified 100")
+            {
+                throw new InvalidOperationException($"{options.Name}: workload assertion failed: {actual}");
+            }
+        }
+        workload.Stop();
+        await memory.DisposeAsync();
+        var after = ProcessSnapshot.Read(adapter.Process);
+        var teardown = Stopwatch.StartNew();
+        await adapter.DisposeAsync();
+        teardown.Stop();
+        return new RunResult(options.Name, options.Kind, round, identity, version, agent,
+            adapter.ProcessId, options.Kind == "lightpanda" ? "external-process-not-restarted" : "new-process-per-row",
+            smoke ? null : new Measurements(launch.Elapsed.TotalMilliseconds, workload.Elapsed.TotalMilliseconds,
+                teardown.Elapsed.TotalMilliseconds, before, after, memory.PeakBytes, memory.Samples, memory.UnavailableReason,
+                before?.CpuMilliseconds is { } start && after?.CpuMilliseconds is { } end ? end - start : null));
+    }
+}
+
+internal sealed record Configuration(int Rounds, AdapterOptions[] Adapters)
+{
+    internal void Validate()
+    {
+        if (Rounds is < 1 or > 100 || Adapters is not { Length: > 0 })
+        {
+            throw new ArgumentException("Require 1–100 rounds and at least one adapter.");
+        }
+        foreach (var adapter in Adapters)
+        {
+            adapter.Validate();
+        }
+        if (Adapters.Select(x => x.Name).Distinct(StringComparer.Ordinal).Count() != Adapters.Length)
+        {
+            throw new ArgumentException("Adapter names must be unique.");
+        }
+    }
+}
+
+internal sealed record AdapterOptions(string Name, string Kind, string? Executable = null,
+    string[]? Arguments = null, string? Endpoint = null, int? ProcessId = null, string? VersionLabel = null)
+{
+    internal void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(Name) || Kind is not ("jint" or "chromium" or "lightpanda"))
+        {
+            throw new ArgumentException("Each adapter requires a name and kind jint, chromium or lightpanda.");
+        }
+        if (Kind == "lightpanda")
+        {
+            if (!Uri.TryCreate(Endpoint, UriKind.Absolute, out var endpoint) || endpoint.Scheme is not ("ws" or "wss") || !endpoint.IsLoopback
+                || string.IsNullOrWhiteSpace(VersionLabel) || ProcessId is <= 0)
+            {
+                throw new ArgumentException("Lightpanda requires a loopback WebSocket endpoint and exact version label; optional processId must identify a local process.");
+            }
+        }
+        else if (Executable is null || !Path.IsPathFullyQualified(Executable) || !File.Exists(Executable))
+        {
+            throw new ArgumentException($"{Name}: executable must be an existing absolute path.");
+        }
+    }
+}
+
+internal sealed record RunResult(string Name, string Kind, int Round, BinaryIdentity Identity,
+    string BrowserVersion, string UserAgent, int? ProcessId, string Lifecycle, Measurements? Measurements);
+internal sealed record Measurements(double LaunchAndConnectMilliseconds, double PageWorkMilliseconds,
+    double TeardownMilliseconds, ProcessSnapshot? BeforeWork, ProcessSnapshot? AfterWork, long? SampledPeakWorkingSetBytes, int MemorySamples,
+    string? MemoryUnavailableReason, double? WorkCpuMilliseconds);

--- a/tools/browser-comparison/Provenance.cs
+++ b/tools/browser-comparison/Provenance.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace BrowserComparison;
+
+internal sealed record BinaryIdentity(string? VersionLabel, string? Executable,
+    string[] Arguments, IReadOnlyDictionary<string, string> FileSha256)
+{
+    internal static async Task<BinaryIdentity> ReadAsync(AdapterOptions options)
+    {
+        var hashes = new Dictionary<string, string>(StringComparer.Ordinal);
+        var paths = new[] { options.Executable }.Concat(options.Arguments ?? []).Where(path => path is not null).Cast<string>().ToList();
+        // A framework-dependent Jint executable is identified by all neighboring managed dependencies,
+        // not just the dotnet host or entry assembly. Hash before starting any measured lifecycle.
+        if (options.Kind == "jint")
+        {
+            foreach (var entry in paths.ToArray())
+            {
+                if (File.Exists(entry))
+                {
+                    paths.AddRange(Directory.EnumerateFiles(Path.GetDirectoryName(Path.GetFullPath(entry))!, "*.dll"));
+                }
+            }
+        }
+        foreach (var path in paths.Distinct(StringComparer.Ordinal))
+        {
+            if (path is not null && File.Exists(path))
+            {
+                await using var file = File.OpenRead(path);
+                hashes[Path.GetFullPath(path)] = Convert.ToHexString(await SHA256.HashDataAsync(file));
+            }
+        }
+        return new BinaryIdentity(options.VersionLabel, options.Executable, options.Arguments ?? [], hashes);
+    }
+}
+
+/// <summary>
+/// Operating-system counters for one named PID. PeakWorkingSet64 is a lifetime high-water mark;
+/// subtracting two peaks would not produce a stage peak. Renderer children are deliberately not folded in.
+/// </summary>
+internal sealed record ProcessSnapshot(double? CpuMilliseconds, long? LifetimePeakWorkingSetBytes, string? UnavailableReason)
+{
+    internal static ProcessSnapshot? Read(Process? process)
+    {
+        if (process is null)
+        {
+            return null;
+        }
+        try
+        {
+            process.Refresh();
+            var peak = process.PeakWorkingSet64;
+            return new ProcessSnapshot(process.TotalProcessorTime.TotalMilliseconds, peak > 0 ? peak : null,
+                peak > 0 ? null : "The OS does not expose a positive lifetime peak working set for this PID.");
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception or PlatformNotSupportedException)
+        {
+            return new ProcessSnapshot(null, null, exception.Message);
+        }
+    }
+}
+
+/// <summary>Observed PID working-set maximum during page work, not an OS high-water guarantee.</summary>
+internal sealed class ProcessMemorySampler : IAsyncDisposable
+{
+    internal const int IntervalMilliseconds = 10;
+    private readonly Process? _process;
+    private readonly CancellationTokenSource _stop = new();
+    private readonly Task _sampling;
+    private bool _disposed;
+    internal long? PeakBytes { get; private set; }
+    internal int Samples { get; private set; }
+    internal string? UnavailableReason { get; private set; }
+
+    internal ProcessMemorySampler(Process? process)
+    {
+        _process = process;
+        Sample();
+        _sampling = ObserveAsync();
+    }
+
+    private void Sample()
+    {
+        if (_process is null)
+        {
+            return;
+        }
+        try
+        {
+            _process.Refresh();
+            var bytes = _process.WorkingSet64;
+            if (bytes > 0)
+            {
+                PeakBytes = Math.Max(PeakBytes ?? 0, bytes);
+                Samples++;
+            }
+            else
+            {
+                UnavailableReason = "The OS returned no positive working-set value.";
+            }
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception or PlatformNotSupportedException)
+        {
+            UnavailableReason = exception.Message;
+        }
+    }
+
+    private async Task ObserveAsync()
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(IntervalMilliseconds));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(_stop.Token))
+            {
+                Sample();
+            }
+        }
+        catch (OperationCanceledException) when (_stop.IsCancellationRequested)
+        {
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        await _stop.CancelAsync();
+        await _sampling;
+        Sample();
+        _stop.Dispose();
+    }
+}

--- a/tools/browser-comparison/README.md
+++ b/tools/browser-comparison/README.md
@@ -1,0 +1,98 @@
+# Offline browser comparison harness
+
+This is the harness portion of [#3575 X4](https://github.com/sebastienros/jint/issues/3575), tracked in
+[#3902](https://github.com/sebastienros/jint/issues/3902). One PuppeteerSharp client runs the same offline
+load/evaluate/assert workload against **AngleSharp + Jint**, Chromium, and optionally an existing local
+Lightpanda endpoint. It downloads nothing and reads no Lightpanda source.
+
+This tool produces smoke results or raw diagnostics, **not publication-quality benchmark comparisons**.
+Read [the benchmark instructions](../../Jint.Benchmark/AGENTS.md) before collecting or quoting numbers.
+The process counters deliberately cover one identified PID; Chromium renderer/utility children are absent,
+so the memory and CPU records cannot support a whole-browser efficiency comparison.
+
+## Run a smoke check
+
+Build the Jint browser executable in Release, copy `example.json`, and replace its absolute paths. A
+standalone published `jint-browser` works too: give its path as `executable` and omit `arguments`. The
+harness appends `serve --port 0`; do not include those arguments yourself. Chromium must already be installed.
+No browser-fetcher or package download is performed by the harness.
+
+```sh
+dotnet build Jint.Browser.Tool/Jint.Browser.Tool.csproj -c Release -f net10.0
+dotnet run --project tools/browser-comparison/BrowserComparison.csproj -c Release -- \
+  --config /absolute/path/to/local-config.json --smoke
+```
+
+Smoke runs each adapter once and exits nonzero for a launch, connection, navigation, evaluation, assertion,
+or teardown failure. It writes JSON provenance and `measurements: null`, with no elapsed/CPU/memory figures.
+A single-adapter configuration is useful when Chromium is unavailable. Missing required binaries are an
+error, never an implicit skip. Browser and fixture server processes are disposed even if assertions fail.
+Every operation has a bounded timeout. Jint's existing page/script budgets remain in force.
+
+The fixture contains no external resources: a loopback server delivers one checked-in document. Its script
+builds 100 elements and computes a checksum. The common workload navigates until `load`, reads DOM values,
+mutates a heading, and asserts the exact result `100|4950|4950|Verified 100`. There is no browser-specific
+workload substitution. This small DOM smoke fixture is a starting workload, not a representative web corpus.
+
+For optional Lightpanda, add an adapter such as:
+
+```json
+{
+  "name": "lightpanda",
+  "kind": "lightpanda",
+  "endpoint": "ws://127.0.0.1:9222/EXACT_BROWSER_ENDPOINT",
+  "versionLabel": "EXACT_RELEASE_OR_COMMIT",
+  "processId": 12345
+}
+```
+
+Use the actual browser WebSocket endpoint. The endpoint must be local because it navigates to the same
+loopback fixture server. `processId` is optional; without it, process counters are null. If supplied, it must
+identify the browser's local root process; the harness cannot prove that a socket belongs to that PID.
+The endpoint is borrowed: the harness closes only its own page, disconnects, and never terminates Lightpanda.
+Its lifecycle is marked `external-process-not-restarted`; its startup and state are **not** comparable to the
+fresh Jint/Chromium processes. Record the exact external build using `versionLabel`.
+
+## Boundaries and provenance
+
+Each row launches a new owned Jint/Chromium process. There is no warmup, pooling, reused page, or claim of
+steady-state performance. Multiple diagnostic rounds alternate adapter order to expose order effects; they
+do not replace BenchmarkDotNet's machine controls, launch analysis, or the paired statistical methodology.
+The fixture server and PuppeteerSharp client live in the harness process, outside the browser PID.
+
+| Record | Included |
+| --- | --- |
+| Launch/connect elapsed | Process launch (owned adapters), endpoint discovery, PuppeteerSharp connect; Lightpanda is connect-only |
+| Page-work elapsed | New page, navigation to `load`, evaluation, result assertion, page disposal |
+| Teardown elapsed | Chromium close; Jint disconnect and forced process-tree termination; Lightpanda disconnect only |
+| Work CPU | `TotalProcessorTime` difference for the named PID across page work; excludes startup and children |
+| OS peak working set | OS lifetime high-water mark before/after page work; includes prior startup/state, is not a stage delta or managed allocation count |
+
+| Sampled working-set peak | Maximum observed every 10 ms during page work, plus boundary samples; can miss short-lived peaks, with sample count recorded |
+
+Binary hashing and browser-version queries happen outside page work. The report contains OS, architecture,
+.NET version, harness informational version, pinned PuppeteerSharp informational version, fixture SHA-256,
+browser-reported version, browser user agent, command arguments, executable hash, and hashes for Jint's
+neighboring managed DLLs. Browser-reported versions plus binary hashes identify what ran; `versionLabel`
+can additionally record a checkout SHA, distribution label, flags, or external build. Keep configurations
+free of secrets because arguments are recorded. The ephemeral debugging endpoint is not emitted.
+
+Unsupported/inaccessible process counters retain a reason rather than becoming zero. In particular, an OS
+lifetime-peak counter returning zero is unavailable; the independent sampled maximum still works when
+current working-set readings are supported. Sampling runs in the harness and contributes observation overhead. A borrowed endpoint
+without a local PID has null snapshots. Root-only counters do not include the harness, fixture server,
+Chromium renderers, GPU process, utility processes, or the sum of a process tree's peaks.
+
+## Collect raw diagnostics
+
+```sh
+dotnet run --project tools/browser-comparison/BrowserComparison.csproj -c Release -- \
+  --config /absolute/path/to/local-config.json --collect > local-diagnostics.json
+```
+
+`rounds` must be between 1 and 100. `--collect` is explicit and labels its output
+`raw-diagnostics-not-publication-quality`. Run it on a dedicated idle machine. This harness does not change
+CPU affinity, power plans, GC settings, or tiered compilation, and does not enforce the benchmark project's
+idle-machine guard. Do not quote these raw observations as comparative benchmark results. Full process-tree
+accounting, lifecycle-matched external browser launches, representative workloads, machine controls, and
+repeatable statistical analysis remain X4 follow-up work.

--- a/tools/browser-comparison/example.json
+++ b/tools/browser-comparison/example.json
@@ -1,0 +1,18 @@
+{
+  "rounds": 6,
+  "adapters": [
+    {
+      "name": "jint",
+      "kind": "jint",
+      "executable": "/absolute/path/to/dotnet",
+      "arguments": ["/absolute/path/to/artifacts/bin/Jint.Browser.Tool/release_net10.0/Jint.Browser.Tool.dll"],
+      "versionLabel": "main at FULL_COMMIT_SHA; framework-dependent Release"
+    },
+    {
+      "name": "chromium",
+      "kind": "chromium",
+      "executable": "/absolute/path/to/chromium",
+      "versionLabel": "installed Chromium build"
+    }
+  ]
+}

--- a/tools/browser-comparison/fixture.html
+++ b/tools/browser-comparison/fixture.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Offline browser comparison</title>
+<main><h1>Inventory</h1><ul id="items"></ul><output id="total"></output></main>
+<script>
+const list = document.getElementById('items');
+for (let index = 0; index < 100; index++) {
+    const item = document.createElement('li');
+    item.dataset.value = String(index);
+    item.textContent = 'Item ' + index;
+    list.appendChild(item);
+}
+document.getElementById('total').textContent = String(
+    [...list.children].reduce((sum, item) => sum + Number(item.dataset.value), 0));
+</script>


### PR DESCRIPTION
Add the bounded harness portion of #3575 X4: one offline PuppeteerSharp load/evaluate/assert workload against fresh Jint and Chromium processes, plus an optional borrowed local Lightpanda endpoint. The harness records binary/dependency hashes, reported versions, explicit lifecycle boundaries, PID CPU deltas, OS lifetime peak working set where available, and a separately labeled sampled working-set peak. Smoke mode asserts behavior with measurement values omitted.

Fixes #3902. This does not complete X4 or make a performance claim. Counters are explicitly scoped to the named root PID and exclude Chromium renderer/utility children, so they cannot support whole-browser CPU/memory comparisons. External endpoints are labeled as reused and are never terminated. Documentation identifies the remaining process-tree, lifecycle, representative-workload and statistical work. The project is included in the solution build.

Validation:
- Release harness and Jint tool builds pass without warnings.
- Common smoke workload passes with the freshly built Jint tool and installed Chromium; JSON contains null measurements.
- Borrowed-endpoint lifecycle probe using an explicitly labeled Jint stand-in passes and leaves the externally owned process running. No Lightpanda binary was available, so actual Lightpanda compatibility is not claimed.
- Diagnostic-path smoke verifies nonnegative CPU deltas, positive sampled peaks, PID/hash provenance and explicit unavailable OS-peak reasons. Values were kept in temporary local files and are not published.
- Invalid binary configuration fails explicitly without emitting a success report.

The optional browser-session API failure discovered during implementation is tracked separately in #3905.
