### PR TITLE
Run native browser tool builds only when publishing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,9 +26,6 @@ concurrency:
 
 jobs:
 
-  browser-tool:
-    uses: ./.github/workflows/browser-tool.yml
-
   test:
 
     name: ${{ matrix.os.name }}

--- a/Jint.Browser.Tool/AGENTS.md
+++ b/Jint.Browser.Tool/AGENTS.md
@@ -104,11 +104,13 @@ platform-specific Native AOT tool format. Installation requires the .NET 10 SDK,
   keeps the core engine's standing inventory visible, as in `Jint.AotExample`; the distribution workflow
   rejects diagnostics outside that core-engine inventory. This closed program's native run is not a
   general `IsAotCompatible` claim for the browser libraries.
-- **`browser-tool.yml` is reused by PR, build and release workflows.** Each of the six OS/architecture
+- **`browser-tool.yml` is reused by the build and release publishing workflows.** Each of the six OS/architecture
   legs packs a RID implementation and the selection manifest, installs from a source-mapped local feed,
   and runs `Tool/PublishedToolTests` against the installed executable. The tests cover extraction, scripts,
   CSS, XML, XPath, globalization, CDP and MCP. Set `JINT_BROWSER_TOOL` and `JINT_BROWSER_TOOL_VERSION` to
   reproduce; without them those process tests are skipped rather than passed.
+  Pull requests do not run this six-leg native distribution matrix; publishing workflows validate the
+  packages and executables before they are pushed.
   On Windows the SDK installs a **`.cmd` launcher**, not an `.exe` shim. The workflow checks that
   launcher's version and argument forwarding, then discovers the native `.exe` inside the installation
   for the process tests, so `cmd.exe` does not reparse their multiline JavaScript. The standalone download


### PR DESCRIPTION
The pull-request workflow currently invokes the six-platform native `jint-browser` packaging matrix on every change, although those artifacts are consumed only by publishing workflows.

Remove that reusable job from PR CI. The preview build and release workflows continue to invoke `browser-tool.yml`, install and test every RID package, and gate publication. Update the co-located agent guidance to match the new policy.

Validation:

- `actionlint -shellcheck='' .github/workflows/pr.yml .github/workflows/build.yml .github/workflows/release.yml .github/workflows/browser-tool.yml`
- Release `AgentInstructionFileTests`: 5/5 passed on .NET 8 and 5/5 passed on .NET 10
- `git diff --check`
