### PR TITLE
Construct FormData from browser forms

### DIFF
--- a/Jint.Browser/Events/FormSubmission.cs
+++ b/Jint.Browser/Events/FormSubmission.cs
@@ -241,7 +241,7 @@ internal static class FormSubmission
         _ => false,
     };
 
-    private static IHtmlFormElement? FormOwnerOf(IHtmlElement element) => element switch
+    internal static IHtmlFormElement? FormOwnerOf(IHtmlElement element) => element switch
     {
         IHtmlButtonElement button => button.Form,
         IHtmlInputElement input => input.Form,

--- a/Jint.Browser/Runtime/FormDataConstruction.cs
+++ b/Jint.Browser/Runtime/FormDataConstruction.cs
@@ -1,0 +1,87 @@
+using AngleSharp.Html.Dom;
+using Jint.Browser.Dom;
+using Jint.Browser.Events;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.WebApi.DomException;
+using Jint.WebApi.Files;
+
+namespace Jint.Browser.Runtime;
+
+/// <summary>
+/// https://xhr.spec.whatwg.org/#dom-formdata — the browser half of the FormData constructor.
+/// </summary>
+internal static class FormDataConstruction
+{
+    internal static void Install(PageRuntime runtime)
+    {
+        runtime.Engine._mainRealm.Intrinsics.FormData.ConstructFromForm =
+            (form, submitter, newTarget) => Construct(runtime, form, submitter, newTarget);
+    }
+
+    private static JsFormData Construct(PageRuntime runtime, JsValue formValue, JsValue submitterValue, JsValue newTarget)
+    {
+        var realm = runtime.Engine._mainRealm;
+        IHtmlFormElement? form = null;
+        if (!formValue.IsUndefined())
+        {
+            if (formValue is not DomNodeObject { Node: IHtmlFormElement candidate })
+            {
+                Throw.TypeError(realm, "FormData: form must be an HTMLFormElement");
+                return null!;
+            }
+
+            form = candidate;
+        }
+
+        IHtmlElement? submitter = null;
+        if (!submitterValue.IsNullOrUndefined())
+        {
+            if (submitterValue is not DomNodeObject { Node: IHtmlElement candidate })
+            {
+                Throw.TypeError(realm, "FormData: submitter must be an HTMLElement");
+                return null!;
+            }
+
+            submitter = candidate;
+        }
+
+        // WebIDL converts both arguments before creating the instance, even if the form is absent.
+        // Reading newTarget.prototype can run script; it precedes the constructor's entry-list steps.
+        var instance = realm.Intrinsics.FormData.CreateInstance(newTarget);
+        if (form is null)
+        {
+            return instance;
+        }
+
+        if (submitter is not null)
+        {
+            if (!FormSubmission.IsSubmitButton(submitter))
+            {
+                Throw.TypeError(realm, "FormData: submitter must be a submit button");
+            }
+
+            if (!ReferenceEquals(FormSubmission.FormOwnerOf(submitter), form))
+            {
+                var exception = realm.Intrinsics.DomException.CreateException(
+                    DomExceptionNames.NotFound, "The submitter is not owned by this form");
+                var location = runtime.Engine._lastSyntaxElement?.Location ?? default;
+                Throw.JavaScriptException(runtime.Engine, exception, in location);
+                return null!;
+            }
+        }
+
+        var entries = FormSubmitter.ConstructEntryList(runtime, form, submitter);
+        if (entries is null)
+        {
+            var exception = realm.Intrinsics.DomException.CreateException(
+                DomExceptionNames.InvalidState, "The form's entry list is already being constructed");
+            var location = runtime.Engine._lastSyntaxElement?.Location ?? default;
+            Throw.JavaScriptException(runtime.Engine, exception, in location);
+            return null!;
+        }
+
+        instance.Entries.AddRange(entries);
+        return instance;
+    }
+}

--- a/Jint.Browser/Runtime/FormSubmitter.cs
+++ b/Jint.Browser/Runtime/FormSubmitter.cs
@@ -98,6 +98,10 @@ internal static class FormSubmitter
         }
 
         var entries = ConstructEntryList(runtime, form, submitter);
+        if (entries is null)
+        {
+            return;
+        }
 
         // target=_blank opens a new page in a browser; there is no page-opening seam in this version, so
         // every target loads here and the page is told rather than left wondering.
@@ -164,10 +168,14 @@ internal static class FormSubmitter
     /// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set,
     /// including the <c>formdata</c> event a script may amend the result in.
     /// </summary>
-    internal static List<FormDataEntry> ConstructEntryList(PageRuntime runtime, IHtmlFormElement form, IElement? submitter)
+    internal static List<FormDataEntry>? ConstructEntryList(PageRuntime runtime, IHtmlFormElement form, IElement? submitter)
     {
+        if (!runtime.SubmittingForms.Add(form))
+        {
+            return null;
+        }
+
         var entries = new List<FormDataEntry>();
-        runtime.SubmittingForms.Add(form);
 
         try
         {

--- a/Jint.Browser/Runtime/WindowInstaller.cs
+++ b/Jint.Browser/Runtime/WindowInstaller.cs
@@ -91,6 +91,8 @@ internal static class WindowInstaller
         var realm = engine._mainRealm;
         var global = realm.GlobalObject;
 
+        FormDataConstruction.Install(runtime);
+
         // https://html.spec.whatwg.org/multipage/nav-history-apis.html#named-access-on-the-window-object —
         // WebIDL's named properties object sits between the interface prototype object and its parent, which
         // is what makes named access a *miss* path: `document`, `alert` and every other name the global owns

--- a/Jint.Tests.Browser/Forms/FormDataConstructorTests.cs
+++ b/Jint.Tests.Browser/Forms/FormDataConstructorTests.cs
@@ -1,0 +1,189 @@
+using Jint.Tests.Browser.Navigation;
+
+namespace Jint.Tests.Browser.Forms;
+
+public sealed class FormDataConstructorTests
+{
+    [Test]
+    public async Task ReadsTheFormEntryList()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/form.html", "<form><input name='query' value='hello'></form>"));
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+
+        (await fixture.Page.EvaluateAsync<string>(
+            "new FormData(document.querySelector('form')).get('query')")).Should().Be("hello");
+    }
+
+    [Test]
+    public async Task UsesSuccessfulControlsAndAssociatedControlsInTreeOrder()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/form.html", """
+            <input form='f' name='duplicate' value='before'>
+            <form id='f'>
+              <input name='duplicate' value='inside'>
+              <input name='off' disabled value='excluded'>
+              <input value='unnamed'>
+              <fieldset disabled><input name='fieldset' value='excluded'>
+                <legend><input name='legend' value='included'></legend>
+              </fieldset>
+              <input type='checkbox' name='checked' checked>
+              <input type='checkbox' name='unchecked'>
+              <input type='radio' name='radio' value='off'>
+              <input type='radio' name='radio' value='on' checked>
+              <select name='many' multiple>
+                <option value='a' selected>a</option><option value='b' selected>b</option>
+                <option value='disabled' disabled selected>excluded</option>
+              </select>
+              <input type='submit' name='inputButton' value='excluded'>
+              <button name='button' value='excluded'>submit</button>
+              <datalist><input name='suggestion' value='excluded'></datalist>
+            </form>
+            <input form='f' name='duplicate' value='after'>
+            """));
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+
+        (await fixture.Page.EvaluateAsync<string>(
+            "JSON.stringify([...new FormData(document.querySelector('form'))])"))
+            .Should().Be("""[["duplicate","before"],["duplicate","inside"],["legend","included"],["checked","on"],["radio","on"],["many","a"],["many","b"],["duplicate","after"]]""");
+    }
+
+    [TestCase("button")]
+    [TestCase("input")]
+    public async Task IncludesOnlyTheChosenSubmitter(string tag)
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/form.html", """
+            <form id='f'><input name='query' value='hello'>
+              <button name='action' value='button'>submit</button>
+              <input type='submit' name='action' value='input'>
+            </form>
+            """));
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+
+        (await fixture.Page.EvaluateAsync<string>(
+            "new FormData(document.querySelector('form'), document.querySelector('" +
+            (tag == "input" ? "input[type=submit]" : tag) + "')).get('action')"))
+            .Should().Be(tag);
+    }
+
+    [TestCase("null", "undefined", "TypeError")]
+    [TestCase("{}", "undefined", "TypeError")]
+    [TestCase("document.body", "undefined", "TypeError")]
+    [TestCase("document.querySelector('form')", "{}", "TypeError")]
+    [TestCase("document.querySelector('form')", "document.body", "TypeError")]
+    [TestCase("document.querySelector('form')", "document.querySelector('input')", "TypeError")]
+    [TestCase("document.querySelector('form')", "document.querySelector('#other')", "NotFoundError")]
+    [TestCase("undefined", "{}", "TypeError")]
+    public async Task ValidatesFormAndSubmitter(string form, string submitter, string error)
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/form.html", "<form><input></form><form><button id='other'>submit</button></form>"));
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+
+        (await fixture.Page.EvaluateAsync<string>(
+            "(() => { try { new FormData(" + form + ", " + submitter + "); return 'no error'; } " +
+            "catch (e) { return [e.name, e instanceof " +
+            (error == "TypeError" ? "TypeError" : "DOMException") + "].join('|'); } })()"))
+            .Should().Be(error + "|true");
+    }
+
+    [Test]
+    public async Task OmittedFormAndNullSubmitterKeepAnEmptyOrUnsubmittedEntryList()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/form.html", "<form><input name='query' value='hello'><button name='submit'>submit</button></form>"));
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+
+        (await fixture.Page.EvaluateAsync<string>("""
+            JSON.stringify([
+              [...new FormData()], [...new FormData(undefined, document.body)],
+              [...new FormData(document.querySelector('form'), null)],
+              [...new FormData(document.querySelector('form'), undefined)]
+            ])
+            """)).Should().Be("""[[],[],[["query","hello"]],[["query","hello"]]]""");
+    }
+
+    [Test]
+    public async Task FormDataEventAmendsAnIndependentResultAndGuardsOnlyItsOwnForm()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/form.html", """
+            <form id='f'><input name='query' value='hello' required><button>submit</button></form>
+            <form id='g'><input name='other' value='world'></form>
+            """));
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+
+        (await fixture.Page.EvaluateAsync<string>("""
+            (() => {
+              const form = document.querySelector('#f');
+              const log = [];
+              let eventData;
+              form.addEventListener('submit', () => log.push('submit'));
+              form.addEventListener('invalid', () => log.push('invalid'), true);
+              document.addEventListener('formdata', e => log.push('bubble:' + e.target.id));
+              form.addEventListener('formdata', e => {
+                log.push([e.bubbles, e.cancelable, e.isTrusted, e.formData instanceof FormData].join(':'));
+                eventData = e.formData;
+                eventData.set('query', 'amended');
+                for (let i = 0; i < 2; i++) {
+                  try { new FormData(form); }
+                  catch (error) { log.push(error.name + ':' + (error instanceof DOMException)); }
+                }
+                form.submit();
+                form.requestSubmit();
+                log.push(new FormData(document.querySelector('#g')).get('other'));
+              }, { once: true });
+              const data = new FormData(form);
+              eventData.set('query', 'too late');
+              log.push(data !== eventData, data.get('query'));
+              log.push(new FormData(form).get('query'));
+              return log.join('|');
+            })()
+            """)).Should().Be("true:false:true:true|InvalidStateError:true|InvalidStateError:true|bubble:g|world|bubble:f|true|amended|bubble:f|hello");
+    }
+
+    [Test]
+    public async Task SubclassAndPrototypeGetterRunBeforeEntryConstruction()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/form.html", "<form><input name='query' value='hello'></form>"));
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+
+        (await fixture.Page.EvaluateAsync<string>("""
+            (() => {
+              const form = document.querySelector('form');
+              const log = [];
+              form.addEventListener('formdata', () => log.push('event'));
+              class Derived extends FormData {}
+              const subclass = new Derived(form);
+              log.push(subclass instanceof Derived, subclass instanceof FormData, subclass.get('query'));
+              const target = new Proxy(function() {}, { get(target, key) {
+                if (key === 'prototype') { log.push('prototype'); return FormData.prototype; }
+                return target[key];
+              }});
+              const data = Reflect.construct(FormData, [form], target);
+              log.push(data.get('query'));
+              return log.join('|');
+            })()
+            """)).Should().Be("event|true|true|hello|prototype|event|hello");
+    }
+
+    [Test]
+    public async Task FileInputsProduceRealmFilesAndTheResultSerializesAsARequestBody()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server.MapHtml(
+            "/form.html", "<form><input name='query' value='hello'><input type='file' name='upload'></form>"));
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+
+        (await fixture.Page.EvaluateAndAwaitAsync<string>("""
+            (async () => {
+              const data = new FormData(document.querySelector('form'));
+              const file = data.get('upload');
+              const copy = await new Response(data).formData();
+              return [file instanceof File, file.name, file.size, file.type, copy.get('query')].join('|');
+            })()
+            """)).Should().Be("true||0|application/octet-stream|hello");
+    }
+}

--- a/Jint/WebApi/Files/FormDataConstructor.cs
+++ b/Jint/WebApi/Files/FormDataConstructor.cs
@@ -15,10 +15,9 @@ namespace Jint.WebApi.Files;
 /// </summary>
 /// <remarks>
 /// The IDL constructor is <c>constructor(optional HTMLFormElement form, optional HTMLElement? submitter = null)</c>,
-/// and neither argument can mean anything here: there is no DOM, so there is no form to scrape an entry
-/// list from. Rather than ignore an argument a script passed in earnest — which would hand back a silently
-/// empty <c>FormData</c> — a non-<c>undefined</c> first argument raises a <c>TypeError</c>. That is the
-/// shape WinterTC's Minimum Common Web Platform API describes for a runtime without a DOM.
+/// supplied forms are delegated to the browser's entry-list builder when it installs one for this realm.
+/// Without that connection, a non-<c>undefined</c> first argument raises a <c>TypeError</c>, preserving
+/// WinterTC's Minimum Common Web Platform API behavior for a runtime without a DOM.
 /// </remarks>
 internal sealed class FormDataConstructor : Constructor
 {
@@ -39,6 +38,10 @@ internal sealed class FormDataConstructor : Constructor
 
     internal FormDataPrototype PrototypeObject { get; }
 
+    // The browser installs this on its own realm's constructor; workers and standalone engines retain
+    // the no-DOM behavior. The engine assembly never needs a reference to a DOM type.
+    internal Func<JsValue, JsValue, JsValue, JsFormData>? ConstructFromForm { get; set; }
+
     /// <summary>
     /// https://xhr.spec.whatwg.org/#dom-formdata
     /// </summary>
@@ -49,16 +52,24 @@ internal sealed class FormDataConstructor : Constructor
             Throw.TypeError(_realm, $"Constructor {GetOwnFunctionNameForMessage()} requires 'new'");
         }
 
+        if (ConstructFromForm is { } construct)
+        {
+            return construct(arguments.At(0), arguments.At(1), newTarget);
+        }
+
         if (!arguments.At(0).IsUndefined())
         {
             Throw.TypeError(_realm, "FormData constructor: the form argument is not supported, there is no DOM");
         }
 
-        return OrdinaryCreateFromConstructor(
+        return CreateInstance(newTarget);
+    }
+
+    internal JsFormData CreateInstance(JsValue newTarget)
+        => OrdinaryCreateFromConstructor(
             newTarget,
             static intrinsics => intrinsics.FormData.PrototypeObject,
             static (Engine engine, Realm _, object? _) => new JsFormData(engine),
             state: null);
-    }
 }
 #endif

--- a/docs/packages/jint-browser/input-and-forms.md
+++ b/docs/packages/jint-browser/input-and-forms.md
@@ -31,4 +31,10 @@ Methods that name an element return `false` when no suitable target exists.
 
 `SubmitFormAsync("#form")` runs validation, `submit`, entry-list construction, `formdata`, and GET or POST submission. It returns `null` when nothing matched, validation failed, or submission was cancelled.
 
+Page scripts can use `new FormData(form, submitter)` to read the same entry list without submitting or
+validating the form. The optional submitter must be a submit button owned by that form. A bubbling
+`formdata` event lets listeners amend the entries; constructing another `FormData` for that same form
+inside the listener throws `InvalidStateError`. Standalone engines and workers keep the no-DOM
+`FormData()` constructor.
+
 Input uses a deterministic synthetic box model, not visual layout. See [Limitations](./limitations).


### PR DESCRIPTION
A browser page currently throws the standalone no-DOM TypeError for `new FormData(form)`. Connect its FormData intrinsic to the existing shared form-entry builder so the constructor reads successful controls, validates an optional submitter and fires the same `formdata` event as submission. The constructing-entry-list guard now reports failure to the constructor and remains exception-safe for the outer submission.

The hook is internal and belongs only to the page's principal-realm constructor. Standalone engines and workers retain their no-DOM behavior. Tests cover associated and duplicate controls, submitter types/ownership, event mutation and reentrancy, subclass/prototype order, and File/Response serialization. The constructor uses the existing shared builder; its independently reproduced gaps remain tracked in #3933 and #3934.

Fixes #3931.

Validation of implementation commit `2eb407edae62fb4c9f4dfa86a66e7e8c627cd5cd`, fresh Release with SDK10.0.400. Current head `13b38993974826b077d531c07a39c5df6664a3c1` only merges the subsequent documentation/workflow-only `main` changes:

- Browser form/form-event selection: 33 passed per TFM (net8.0/net10.0).
- Core FormData/multipart/WebIDL and pinned formdata WPT selection: 66 passed per TFM.
- Full solution build: zero warnings/errors, all Jint TFMs.
- Full browser suite: 2,137 passed net10.0; 2,133 passed net8.0; 37 expected skips each.
- Unchanged X4 event-form cold/warm correctness smoke: `100|query-99|query-99`; no measurements. Fixture SHA256 `3132B26B6EDB0222706E511D1E68A5D3B518B5737A66BB72439F444B5F2964F7`, automation SHA256 `73FB41FFDCFD95447BCA62C5D59474021C84BA063D975B5B631F99F8256CD02E`.
