### PR TITLE
Reject incomplete browser WPT census measurements

### DIFF
--- a/Jint.Tests.Browser/Wpt/AGENTS.md
+++ b/Jint.Tests.Browser/Wpt/AGENTS.md
@@ -206,6 +206,10 @@ failures, and it leaves the raised numbers in the diff.
 
 Like the engine lane's, the measured half is opt-in — totalling the table means running every document — and
 Windows-only, because a `TIMEOUT` is an outcome a loaded machine can produce on its own.
+**A harness error invalidates the census**, including a timeout after some subtests have reported. The census
+retains the document's failure and refuses to render or rewrite a measured table; it cannot count the empty
+results of a failed outcome as zero registrations or silently retry it. The unmeasured inventory check still
+works, because its document counts do not depend on a report.
 
 ### Adding a suite
 

--- a/Jint.Tests.Browser/Wpt/WptBrowserCensus.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserCensus.cs
@@ -24,8 +24,8 @@ namespace Jint.Tests.Browser.Wpt;
 /// <para>
 /// <b>Three equalities and a ceiling.</b> <c>Documents</c> and <c>Synthesized</c> are read off the embedded
 /// corpus, and <c>Tests</c> counts <i>registrations</i> — a document registers its cases as its scripts run,
-/// and a document that reports at all reports every one of them, because a document that cannot is a harness
-/// error its own suite already fails on. <c>Not passing</c> is the only column that counts <i>outcomes</i>,
+/// and a document that cannot finish is a harness error that invalidates the measured census as well as its
+/// own suite. <c>Not passing</c> is the only column that counts <i>outcomes</i>,
 /// so a rise fails as a regression naming the suite and the size of it, a fall fails as staleness, and
 /// <see cref="UpdateVariable"/><c>=update</c> lowers that figure and refuses to raise it. A check satisfiable
 /// by re-baselining a bad run is not a ceiling, it is a suggestion.
@@ -53,10 +53,7 @@ internal static class WptBrowserCensus
     private const string TableHeader = "| Suite | Documents | Synthesized | Tests | Not passing |";
     private const string TableDivider = "| --- | --- | --- | --- | --- |";
 
-    private static readonly ConcurrentDictionary<string, Counts> _observed = new(StringComparer.Ordinal);
-
-    /// <summary>What one case contributed to its suite's row.</summary>
-    private readonly record struct Counts(int Tests, int NotPassing);
+    private static readonly Measurements _observed = new();
 
     /// <summary>One line of the table, as the corpus and the run make it.</summary>
     [StructLayout(LayoutKind.Auto)]
@@ -81,18 +78,60 @@ internal static class WptBrowserCensus
     /// outcome comes back through — so the census sees the whole lane without the theories knowing it exists,
     /// and re-running one document simply overwrites its own entry.
     /// </summary>
-    internal static void Record(string path, WptBrowserOutcome outcome)
+    internal static void Record(string path, WptBrowserOutcome outcome) => _observed.Record(path, outcome);
+
+    /// <summary>
+    /// Per-document counts, including failed reports. A harness error is an invalid measurement, never a
+    /// successful observation of zero registrations. Keep it until rendering so the document's own runner
+    /// can still report its original outcome, and the census cannot silently retry or rewrite that failure.
+    /// </summary>
+    internal sealed class Measurements
     {
-        var notPassing = 0;
-        foreach (var result in outcome.Results)
+        private readonly ConcurrentDictionary<string, Counts> _counts = new(StringComparer.Ordinal);
+
+        private readonly record struct Counts(int Tests, int NotPassing, string? HarnessError);
+
+        internal bool ContainsKey(string path) => _counts.ContainsKey(path);
+
+        internal void Record(string path, WptBrowserOutcome outcome)
         {
-            if (!result.Passed)
+            var notPassing = 0;
+            foreach (var result in outcome.Results)
             {
-                notPassing++;
+                if (!result.Passed)
+                {
+                    notPassing++;
+                }
             }
+
+            _counts[path] = new Counts(outcome.Results.Count, notPassing, outcome.HarnessError);
         }
 
-        _observed[path] = new Counts(outcome.Results.Count, notPassing);
+        internal IReadOnlyDictionary<string, (int Tests, int NotPassing)> CompleteCounts()
+        {
+            var counts = new Dictionary<string, (int, int)>(StringComparer.Ordinal);
+            var errors = new List<string>();
+            foreach (var (path, observed) in _counts)
+            {
+                if (observed.HarnessError is { } error)
+                {
+                    errors.Add($"{path}: {error}");
+                }
+
+                counts[path] = (observed.Tests, observed.NotPassing);
+            }
+
+            if (errors.Count > 0)
+            {
+                errors.Sort(StringComparer.Ordinal);
+                throw new InvalidOperationException(
+                    "The web-platform-tests browser census is incomplete because these documents produced harness errors:\n"
+                    + string.Join("\n", errors)
+                    + "\nNo table can be rendered or rewritten from this run. Resolve the harness failures before measuring again.");
+            }
+
+            return counts;
+        }
     }
 
     /// <summary>
@@ -126,8 +165,12 @@ internal static class WptBrowserCensus
     /// comparison by rendering whatever the README already claims for them, so a caller that has not run the
     /// lane can still hold the two derived columns.
     /// </summary>
-    internal static string Render(bool measured, IReadOnlyList<string>? readmeLines = null)
+    internal static string Render(bool measured, IReadOnlyList<string>? readmeLines = null) =>
+        Render(measured, _observed, readmeLines);
+
+    internal static string Render(bool measured, Measurements measurements, IReadOnlyList<string>? readmeLines = null)
     {
+        var observations = measured ? measurements.CompleteCounts() : null;
         var claimed = measured ? null : ParseClaimedCounts(readmeLines ?? ReadReadme().Split('\n'));
         var rows = new List<Row>();
 
@@ -151,7 +194,7 @@ internal static class WptBrowserCensus
 
                 if (measured)
                 {
-                    var counts = _observed[path];
+                    var counts = observations![path];
                     tests += counts.Tests;
                     notPassing += counts.NotPassing;
                 }

--- a/Jint.Tests.Browser/Wpt/WptBrowserCensusTests.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserCensusTests.cs
@@ -19,6 +19,63 @@ namespace Jint.Tests.Browser.Wpt;
 /// </remarks>
 public class WptBrowserCensusTests
 {
+    [TestCase(1, "ERROR")]
+    [TestCase(2, "TIMEOUT")]
+    [TestCase(3, "PRECONDITION_FAILED")]
+    public void AHarnessFailureAfterAReportedTestInvalidatesTheCensus(int status, string statusName)
+    {
+        const string path = "dom/nodes/NodeList-static-length-getter-tampered-1.html";
+        var collector = new WptBrowserCollector();
+        collector.Add("""{"kind":"result","name":"registered test","status":0,"message":""}""");
+        collector.Add($$"""{"kind":"completion","status":{{status}},"message":"incomplete document","count":1}""");
+        collector.IsComplete.Should().BeTrue();
+        collector.Results.Should().HaveCount(1);
+
+        var measurements = new WptBrowserCensus.Measurements();
+        measurements.Record(path, collector.Outcome(budgetFailure: null));
+        measurements.ContainsKey(path).Should().BeTrue("a failed report must not be silently retried by the census");
+
+        Action render = () => WptBrowserCensus.Render(measured: true, measurements);
+        render.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{path}: the harness reported {statusName}: incomplete document*No table can be rendered or rewritten*");
+    }
+
+    [Test]
+    public void ADriverFailureBeforeRegistrationInvalidatesTheCensus()
+    {
+        var measurements = new WptBrowserCensus.Measurements();
+        measurements.Record("dom/nodes/document.html", WptBrowserOutcome.Failed("the driver deadline expired"));
+
+        Action render = () => WptBrowserCensus.Render(measured: true, measurements);
+        render.Should().Throw<InvalidOperationException>()
+            .WithMessage("*dom/nodes/document.html: the driver deadline expired*No table can be rendered or rewritten*");
+    }
+
+    [Test]
+    public void TheUnmeasuredInventoryDoesNotRequireSuccessfulReports()
+    {
+        var measurements = new WptBrowserCensus.Measurements();
+        measurements.Record("dom/nodes/document.html", WptBrowserOutcome.Failed("the driver deadline expired"));
+        var stated = WptBrowserCensus.ReadmeTable();
+
+        var inventory = WptBrowserCensus.Render(measured: false, measurements);
+        WptBrowserCensus.Reconcile(inventory, stated, countsIncluded: false).Should().BeNull();
+    }
+
+    [Test]
+    public void CompleteReportsCountPassingAndExcludedFailuresAndReplaceOnlyTheirOwnObservation()
+    {
+        var measurements = new WptBrowserCensus.Measurements();
+        measurements.Record("first.html", WptBrowserOutcome.Failed("incomplete first run"));
+        measurements.Record("second.html", new WptBrowserOutcome([new("failure", 1, "assertion failed")], null));
+        measurements.Record("first.html", new WptBrowserOutcome([new("pass", 0, "")], null));
+
+        var counts = measurements.CompleteCounts();
+        counts.Should().HaveCount(2);
+        counts["first.html"].Should().Be((1, 0));
+        counts["second.html"].Should().Be((1, 1));
+    }
+
     /// <summary>
     /// The table must name every suite the lane runs, and its <c>Documents</c> and <c>Synthesized</c> columns
     /// must be what the corpus actually holds.


### PR DESCRIPTION
Fixes #3936.

A browser WPT harness failure previously became an empty outcome that the census counted as zero registrations. For the one-test NodeList document, a Windows timeout therefore changed the reported `dom/nodes` count from 4,802 to 4,801 and prompted a baseline rewrite.

Retain each document's harness error and reject measured rendering or updating when any report is incomplete, with the failing paths and reasons. Preserve normal test counts, explicit replacement observations, original runner outcomes, and the unmeasured inventory check. No timeout, exclusion, or census baseline changes.

Deterministic regressions cover harness ERROR, TIMEOUT, and PRECONDITION_FAILED after a reported passing test; a driver failure before registration; valid pass/failure counts and replacement observations; and inventory checks with failed reports.

Validation of implementation commit `bc485bab37463c031dacb36ee4b4ff9bcae2b855`:

- Fresh Release Browser census tests plus the unchanged affected NodeList WPT document: 21 passed, 1 skipped on each of .NET 8 and .NET 10.
- Fresh Release instruction-file guardians: 5 passed on each framework.
- `git diff --check` passed.

Current head `943a4a1b2782b3d3e56f49199c93c3f84f0ad3e1` merges green #3908 from `main`; the census implementation files are unchanged. Fresh Release `WptBrowserCensusTests` on this head pass 20 with the one expected Windows-only skip on each framework.

Validation ran on macOS. The full measured census is Windows-only and was not run locally; its opt-in test was skipped. The Windows timeout did not reproduce locally, so this change fixes invalid census accounting without claiming to fix the underlying timeout.
