### PR TITLE
Isolate secondary documents from page viewport state

### DIFF
--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -908,14 +908,14 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.elementFromPoint", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.elementFromPoint");
-                    return global::Jint.Browser.Layout.LayoutMembers.ElementFromPoint(self.Realm, args);
+                    return global::Jint.Browser.Layout.LayoutMembers.ElementFromPoint(self.Realm, self.Target, args);
                 }),
                 length: 2)
             .Method("elementsFromPoint",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.elementsFromPoint", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.elementsFromPoint");
-                    return global::Jint.Browser.Layout.LayoutMembers.ElementsFromPoint(self.Realm, args);
+                    return global::Jint.Browser.Layout.LayoutMembers.ElementsFromPoint(self.Realm, self.Target, args);
                 }),
                 length: 2)
             .Accessor("embeds",
@@ -1003,7 +1003,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.hasFocus", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.hasFocus");
-                    return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Events.BrowserEventRealm.Of(self.Realm.Engine).DocumentHasFocus);
+                    return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Events.FocusController.HasFocus(global::Jint.Browser.Events.BrowserEventRealm.Of(self.Realm.Engine), self.Target));
                 }),
                 length: 0)
             .Accessor("head",
@@ -1016,7 +1016,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.hidden", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.hidden");
-                    return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine) is { } page && page.VisibilityState != "visible");
+                    return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine, self.Target) is not { } page || page.VisibilityState != "visible");
                 }))
             .Accessor("images",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.images", static (thisObj, args) =>
@@ -1215,7 +1215,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.visibilityState", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.visibilityState");
-                    return global::Jint.Native.JsString.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine)?.VisibilityState ?? "visible");
+                    return global::Jint.Native.JsString.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine, self.Target)?.VisibilityState ?? "hidden");
                 }))
             .Method("write",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.write", static (thisObj, args) =>

--- a/Jint.Browser/Events/BrowserEventRealm.cs
+++ b/Jint.Browser/Events/BrowserEventRealm.cs
@@ -16,9 +16,11 @@ namespace Jint.Browser.Events;
 /// </summary>
 /// <remarks>
 /// <para>
-/// One engine is one document — a navigation builds a new engine — so per-engine and per-document coincide,
-/// which is what lets the focused element live here rather than beside the AngleSharp document. It is stored
-/// in a <see cref="ConditionalWeakTable{TKey,TValue}"/> keyed on the engine for the reason
+/// One engine displays one document — a navigation builds a new engine — so the displayed document's state
+/// can live here rather than beside the AngleSharp document. The same engine may still wrap inert documents
+/// made by <c>DOMParser</c> and DOM factories; focus entry points verify the receiver belongs to the displayed
+/// document before reading or changing this state. It is stored in a
+/// <see cref="ConditionalWeakTable{TKey,TValue}"/> keyed on the engine for the reason
 /// <see cref="Dom.DomRealm"/> gives: <c>Engine.HostDefined</c> belongs to the embedder.
 /// </para>
 /// <para>

--- a/Jint.Browser/Events/FocusController.cs
+++ b/Jint.Browser/Events/FocusController.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Jint.Browser.Dom;
+using Jint.Browser.Runtime;
 using Jint.Native;
 using Jint.WebApi.Events;
 
@@ -38,6 +39,11 @@ internal static class FocusController
     /// </summary>
     internal static IElement? ActiveElement(BrowserEventRealm realm, IDocument document)
     {
+        if (PageRuntime.Find(realm.Engine, document) is null)
+        {
+            return document.Body;
+        }
+
         var focused = realm.FocusedElement;
 
         // A focused element removed from the tree stops being the active element, which is what HTML's
@@ -63,7 +69,7 @@ internal static class FocusController
     /// </remarks>
     internal static void Focus(DomRealm dom, IElement element)
     {
-        if (!IsFocusable(element))
+        if (PageRuntime.Find(dom.Engine, element) is null || !IsFocusable(element))
         {
             return;
         }
@@ -87,6 +93,11 @@ internal static class FocusController
     /// </summary>
     internal static void Blur(DomRealm dom, IElement element)
     {
+        if (PageRuntime.Find(dom.Engine, element) is null)
+        {
+            return;
+        }
+
         var realm = BrowserEventRealm.Of(dom.Engine);
 
         if (!ReferenceEquals(realm.FocusedElement, element))
@@ -97,6 +108,12 @@ internal static class FocusController
         realm.FocusedElement = null;
         RunFocusUpdateSteps(dom, element, next: null);
     }
+
+    /// <summary>
+    /// Whether <paramref name="document"/> is the displayed document and its viewport has focus.
+    /// </summary>
+    internal static bool HasFocus(BrowserEventRealm realm, IDocument document)
+        => PageRuntime.Find(realm.Engine, document) is not null && realm.DocumentHasFocus;
 
     /// <summary>
     /// https://html.spec.whatwg.org/multipage/interaction.html#focus-update-steps, reduced to the two chains a

--- a/Jint.Browser/Layout/LayoutMembers.cs
+++ b/Jint.Browser/Layout/LayoutMembers.cs
@@ -23,6 +23,11 @@ namespace Jint.Browser.Layout;
 /// it is the honest one: there is no window for a box to be measured against.
 /// </para>
 /// <para>
+/// <b>The node must belong to the displayed document.</b> A page realm can also wrap documents made by
+/// <c>DOMParser</c> and DOM factories. They have no browsing context, so their nodes answer the same zeros,
+/// empty lists and null hit tests as a binding with no page and cannot read or move this page's scroll.
+/// </para>
+/// <para>
 /// <b>Only the scrolling element scrolls.</b> <c>scrollTop</c> on <c>document.scrollingElement</c> is the
 /// page's virtual scroll offset and writing it scrolls the page; on anything else it reads zero and a write
 /// is ignored, because no element here has content larger than its own box. <c>scrollLeft</c> is zero
@@ -44,18 +49,18 @@ internal static class LayoutMembers
     /// </remarks>
     internal static JsValue ClientRects(DomRealm realm, IElement element)
     {
-        return Layout(realm)?.ClientBoxOf(element) is { } box
+        return Layout(realm, element)?.ClientBoxOf(element) is { } box
             ? DomRects.List(realm, DomRects.Of(realm.Engine, box))
             : DomRects.List(realm);
     }
 
     /// <summary>https://drafts.csswg.org/cssom-view/#dom-element-clientwidth.</summary>
     internal static JsValue ClientWidth(DomRealm realm, IElement element)
-        => JsNumber.Create(IsScrollingElement(element) ? Viewport(realm).Width : Round(ClientBox(realm, element).Width));
+        => JsNumber.Create(IsScrollingElement(element) ? Viewport(realm, element).Width : Round(ClientBox(realm, element).Width));
 
     /// <summary>https://drafts.csswg.org/cssom-view/#dom-element-clientheight.</summary>
     internal static JsValue ClientHeight(DomRealm realm, IElement element)
-        => JsNumber.Create(IsScrollingElement(element) ? Viewport(realm).Height : Round(ClientBox(realm, element).Height));
+        => JsNumber.Create(IsScrollingElement(element) ? Viewport(realm, element).Height : Round(ClientBox(realm, element).Height));
 
     /// <summary>https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth.</summary>
     /// <remarks>Horizontal overflow is not measured by the synthetic model.</remarks>
@@ -70,18 +75,18 @@ internal static class LayoutMembers
             return JsNumber.Create(Round(ClientBox(realm, element).Height));
         }
 
-        var layout = Layout(realm);
+        var layout = Layout(realm, element);
         return JsNumber.Create(layout is null ? 0 : Round(Math.Max(layout.ContentHeight, layout.ViewportHeight)));
     }
 
     /// <summary>https://drafts.csswg.org/cssom-view/#dom-element-scrolltop.</summary>
     internal static JsValue ScrollTop(DomRealm realm, IElement element)
-        => JsNumber.Create(IsScrollingElement(element) && PageOf(realm) is { } page ? page.Layout.ScrollY : 0);
+        => JsNumber.Create(IsScrollingElement(element) && PageOf(realm, element) is { } page ? page.Layout.ScrollY : 0);
 
     /// <summary>The other half of <see cref="ScrollTop"/>: writing it scrolls the page.</summary>
     internal static JsValue SetScrollTop(DomRealm realm, IElement element, JsValue[] arguments)
     {
-        if (IsScrollingElement(element) && PageOf(realm) is { } page)
+        if (IsScrollingElement(element) && PageOf(realm, element) is { } page)
         {
             page.Layout.ScrollTo(TypeConverter.ToNumber(arguments.At(0)));
         }
@@ -111,7 +116,7 @@ internal static class LayoutMembers
     /// </remarks>
     internal static JsValue ScrollIntoView(DomRealm realm, IElement element, JsValue[] arguments)
     {
-        PageOf(realm)?.Layout.ScrollIntoView(element, Block(arguments));
+        PageOf(realm, element)?.Layout.ScrollIntoView(element, Block(arguments));
         return JsValue.Undefined;
     }
 
@@ -126,7 +131,7 @@ internal static class LayoutMembers
     /// <summary>https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetleft.</summary>
     internal static JsValue OffsetLeft(DomRealm realm, IElement element)
     {
-        if (Layout(realm) is not { } layout || layout.DocumentBoxOf(element) is not { } box)
+        if (Layout(realm, element) is not { } layout || layout.DocumentBoxOf(element) is not { } box)
         {
             return JsNumber.PositiveZero;
         }
@@ -142,7 +147,7 @@ internal static class LayoutMembers
     /// </summary>
     internal static JsValue OffsetTop(DomRealm realm, IElement element)
     {
-        if (Layout(realm) is not { } layout || layout.DocumentBoxOf(element) is not { } box)
+        if (Layout(realm, element) is not { } layout || layout.DocumentBoxOf(element) is not { } box)
         {
             return JsNumber.PositiveZero;
         }
@@ -162,7 +167,7 @@ internal static class LayoutMembers
     /// </remarks>
     internal static JsValue OffsetParent(DomRealm realm, IElement element)
     {
-        if (Layout(realm)?.DocumentBoxOf(element) is null)
+        if (Layout(realm, element)?.DocumentBoxOf(element) is null)
         {
             return JsValue.Null;
         }
@@ -171,9 +176,9 @@ internal static class LayoutMembers
     }
 
     /// <summary>https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint.</summary>
-    internal static JsValue ElementFromPoint(DomRealm realm, JsValue[] arguments)
+    internal static JsValue ElementFromPoint(DomRealm realm, IDocument document, JsValue[] arguments)
     {
-        var hit = Layout(realm)?.ElementFromPoint(Coordinate(arguments, 0), Coordinate(arguments, 1));
+        var hit = Layout(realm, document)?.ElementFromPoint(Coordinate(arguments, 0), Coordinate(arguments, 1));
         return hit is null ? JsValue.Null : realm.WrapNode(hit);
     }
 
@@ -181,11 +186,11 @@ internal static class LayoutMembers
     /// https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint — the hit element and every
     /// rendered ancestor above it, innermost first.
     /// </summary>
-    internal static JsValue ElementsFromPoint(DomRealm realm, JsValue[] arguments)
+    internal static JsValue ElementsFromPoint(DomRealm realm, IDocument document, JsValue[] arguments)
     {
         var hits = new List<INode>();
 
-        if (Layout(realm) is { } layout &&
+        if (Layout(realm, document) is { } layout &&
             layout.ElementFromPoint(Coordinate(arguments, 0), Coordinate(arguments, 1)) is { } hit)
         {
             for (IElement? element = hit; element is not null; element = element.ParentElement)
@@ -209,7 +214,7 @@ internal static class LayoutMembers
     /// thing whose <c>scrollTop</c> moves the window.
     /// </remarks>
     internal static JsValue ScrollingElement(DomRealm realm, IDocument document)
-        => realm.WrapNodeValue(document.DocumentElement);
+        => PageOf(realm, document) is null ? JsValue.Null : realm.WrapNodeValue(document.DocumentElement);
 
     /// <summary>The element whose <c>scrollTop</c> is the page's own scroll offset.</summary>
     internal static bool IsScrollingElement(IElement element)
@@ -226,14 +231,14 @@ internal static class LayoutMembers
 
     /// <summary>The element's viewport-relative box, or the empty one when it has none.</summary>
     private static FlatBox ClientBox(DomRealm realm, IElement element)
-        => Layout(realm)?.ClientBoxOf(element) ?? FlatBox.Empty;
+        => Layout(realm, element)?.ClientBoxOf(element) ?? FlatBox.Empty;
 
-    /// <summary>The layout of the page this realm belongs to, or <see langword="null"/> when there is none.</summary>
-    private static FlatLayout? Layout(DomRealm realm) => PageOf(realm)?.Layout.Current();
+    /// <summary>The layout of the page <paramref name="node"/> belongs to, or <see langword="null"/>.</summary>
+    private static FlatLayout? Layout(DomRealm realm, INode node) => PageOf(realm, node)?.Layout.Current();
 
-    private static PageRuntime? PageOf(DomRealm realm) => PageRuntime.Find(realm.Engine);
+    private static PageRuntime? PageOf(DomRealm realm, INode node) => PageRuntime.Find(realm.Engine, node);
 
-    private static Viewport Viewport(DomRealm realm) => PageOf(realm)?.Viewport ?? new Viewport(0, 0);
+    private static Viewport Viewport(DomRealm realm, INode node) => PageOf(realm, node)?.Viewport ?? new Viewport(0, 0);
 
     /// <summary>
     /// CSSOM View declares every one of these <c>long</c>, so the box's <c>double</c> is rounded exactly as

--- a/Jint.Tests.Browser/Events/FocusTests.cs
+++ b/Jint.Tests.Browser/Events/FocusTests.cs
@@ -72,6 +72,59 @@ public sealed class FocusTests
     }
 
     /// <summary>
+    /// A document made inside a page's realm has no browsing context of its own. Its focus and visibility
+    /// queries therefore cannot observe or replace the state of the document the page is displaying.
+    /// </summary>
+    [Test]
+    public async Task InertDocumentsDoNotReadOrChangeTheDisplayedDocumentsFocusAndVisibility()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<input id='page'>");
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              const pageInput = document.getElementById('page');
+              pageInput.focus();
+
+              const parsed = new DOMParser().parseFromString('<input id="other">', 'text/html');
+              const constructed = document.implementation.createHTMLDocument('other');
+              constructed.body.innerHTML = '<input id="other">';
+
+              const answers = [];
+              for (const other of [parsed, constructed]) {
+                const input = other.getElementById('other');
+                const seen = [];
+                input.addEventListener('focus', () => seen.push('focus'));
+                input.addEventListener('blur', () => seen.push('blur'));
+
+                answers.push([
+                  other.activeElement.tagName,
+                  other.hasFocus(),
+                  other.visibilityState,
+                  other.hidden,
+                ].join(':'));
+
+                input.focus();
+                input.blur();
+                answers.push(other.activeElement.tagName + ':' + seen.join(','));
+              }
+
+              answers.push([
+                document.activeElement.id,
+                document.hasFocus(),
+                document.visibilityState,
+                document.hidden,
+              ].join(':'));
+              return answers.join('|');
+            })()
+            """)).Should().Be(
+            "BODY:false:hidden:true|BODY:|BODY:false:hidden:true|BODY:|page:true:visible:false");
+        page.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
     /// Focusability without a rendering: the element's own kind, or a <c>tabindex</c> content attribute.
     /// AngleSharp's <c>TabIndex</c> cannot decide it — it answers 0 for every element, including a bare
     /// <c>&lt;div&gt;</c>, where HTML says −1.

--- a/Jint.Tests.Browser/Layout/FlatLayoutTests.cs
+++ b/Jint.Tests.Browser/Layout/FlatLayoutTests.cs
@@ -262,6 +262,57 @@ public class FlatLayoutTests
         (await page.EvaluateAsync<double>("document.getElementById('r3').scrollTop")).Should().Be(0);
     }
 
+    /// <summary>
+    /// Documents made inside the page's realm have no viewport or layout. Their CSSOM View members must not
+    /// borrow the displayed document's boxes or virtual scroll offset.
+    /// </summary>
+    [Test]
+    public async Task InertDocumentsDoNotReadOrChangeTheDisplayedDocumentsLayout()
+    {
+        await using var browser = new global::Jint.Browser.Browser(
+            new BrowserOptions { Viewport = new Viewport(800, 64) });
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Rows(20));
+
+        (await page.EvaluateAsync<string>(
+            """
+            (() => {
+              window.scrollTo(0, 48);
+              const parsed = new DOMParser().parseFromString('<main><button>other</button></main>', 'text/html');
+              const constructed = document.implementation.createHTMLDocument('other');
+              constructed.body.innerHTML = '<main><button>other</button></main>';
+
+              const answers = [];
+              for (const other of [parsed, constructed]) {
+                const element = other.querySelector('main');
+                const rect = element.getBoundingClientRect();
+                answers.push([
+                  other.elementFromPoint(10, 10) === null,
+                  other.elementsFromPoint(10, 10).length,
+                  other.scrollingElement === null,
+                  element.getClientRects().length,
+                  rect.x, rect.y, rect.width, rect.height,
+                  element.clientWidth, element.clientHeight,
+                  element.scrollWidth, element.scrollHeight,
+                  element.scrollTop, element.scrollLeft,
+                  element.offsetWidth, element.offsetHeight,
+                  element.offsetTop, element.offsetLeft,
+                  element.offsetParent === null,
+                ].join(':'));
+
+                other.documentElement.scrollTop = 200;
+                element.scrollIntoView();
+              }
+
+              answers.push(window.scrollY);
+              return answers.join('|');
+            })()
+            """)).Should().Be(
+            "true:0:true:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:true|" +
+            "true:0:true:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:true|48");
+        page.Errors.Should().BeEmpty();
+    }
+
     [Test]
     public async Task ScrollIntoViewBringsAnElementsRowToTheTop()
     {

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -483,7 +483,7 @@
         "global::Jint.Browser.Events.FocusController.Focus(self.Realm, self.Target);",
         "return global::Jint.Native.JsValue.Undefined;"
       ],
-      "reason": "AngleSharp's DoFocus never assigns IDocument.ActiveElement, so its focus() would move nothing. FocusOptions' one member is preventScroll, which nothing here could honour or violate."
+      "reason": "AngleSharp's DoFocus never assigns IDocument.ActiveElement, so its focus() would move nothing. FocusOptions' one member is preventScroll, which nothing here could honour or violate. The focusing steps stop when the element's document is not the one this runtime displays."
     },
     {
       "interface": "HTMLElement",
@@ -493,7 +493,7 @@
         "global::Jint.Browser.Events.FocusController.Blur(self.Realm, self.Target);",
         "return global::Jint.Native.JsValue.Undefined;"
       ],
-      "reason": "The other half of focus(), for the same reason."
+      "reason": "The other half of focus(), including the same displayed-document ownership check."
     },
     {
       "interface": "Document",
@@ -504,16 +504,16 @@
         "var element = global::Jint.Browser.Events.FocusController.ActiveElement(global::Jint.Browser.Events.BrowserEventRealm.Of(self.Realm.Engine), self.Target);",
         "return element is null ? global::Jint.Native.JsValue.Null : self.Realm.WrapNode(element);"
       ],
-      "reason": "AngleSharp never assigns IDocument.ActiveElement - not on DoFocus, not on parse - so the generated accessor answers null for the whole life of a document, where HTML says the body element."
+      "reason": "AngleSharp never assigns IDocument.ActiveElement - not on DoFocus, not on parse - so the generated accessor answers null for the whole life of a document, where HTML says the body element. Reading an inert document must not clear the displayed document's focus."
     },
     {
       "interface": "Document",
       "member": "hasFocus",
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.hasFocus\");",
-        "return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Events.BrowserEventRealm.Of(self.Realm.Engine).DocumentHasFocus);"
+        "return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Events.FocusController.HasFocus(global::Jint.Browser.Events.BrowserEventRealm.Of(self.Realm.Engine), self.Target));"
       ],
-      "reason": "AngleSharp's HasFocus() reports a window-level flag DoFocus sets and nothing clears, which is not HTML's 'is the document's viewport focused'."
+      "reason": "AngleSharp's HasFocus() reports a window-level flag DoFocus sets and nothing clears, which is not HTML's 'is the document's viewport focused'. Only the document displayed by this runtime owns that viewport; DOMParser and constructed documents answer false."
     },
     {
       "interface": "Document",
@@ -521,9 +521,9 @@
       "kind": "attribute",
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.visibilityState\");",
-        "return global::Jint.Native.JsString.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine)?.VisibilityState ?? \"visible\");"
+        "return global::Jint.Native.JsString.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine, self.Target)?.VisibilityState ?? \"hidden\");"
       ],
-      "reason": "AngleSharp has no visibility state at all - there is no IDocument member for it - and a page reads it to decide whether to animate, poll or reconnect. Emulation.setFocusEmulationEnabled is what moves it."
+      "reason": "AngleSharp has no visibility state at all - there is no IDocument member for it - and a page reads it to decide whether to animate, poll or reconnect. Emulation.setFocusEmulationEnabled moves the displayed document; a document without that browsing context is hidden."
     },
     {
       "interface": "Document",
@@ -531,9 +531,9 @@
       "kind": "attribute",
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.hidden\");",
-        "return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine) is { } page && page.VisibilityState != \"visible\");"
+        "return global::Jint.Native.JsBoolean.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine, self.Target) is not { } page || page.VisibilityState != \"visible\");"
       ],
-      "reason": "The boolean half of visibilityState, and the one most feature detection actually reads. AngleSharp has neither."
+      "reason": "The boolean half of visibilityState, and the one most feature detection actually reads. AngleSharp has neither; a document without the page's browsing context is hidden."
     },
     {
       "interface": "HTMLFormElement",
@@ -768,9 +768,9 @@
       "length": 2,
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.elementFromPoint\");",
-        "return global::Jint.Browser.Layout.LayoutMembers.ElementFromPoint(self.Realm, args);"
+        "return global::Jint.Browser.Layout.LayoutMembers.ElementFromPoint(self.Realm, self.Target, args);"
       ],
-      "reason": "The flat model's hit test, which is the same one DOM.getNodeForLocation and a mouse event at a coordinate go through - so a client that clicks the centre of a box it read is told the same element was hit."
+      "reason": "The flat model's hit test, which is the same one DOM.getNodeForLocation and a mouse event at a coordinate go through - so a client that clicks the centre of a box it read is told the same element was hit. The bound document must own that model; inert documents have no viewport to hit."
     },
     {
       "interface": "Document",
@@ -779,9 +779,9 @@
       "length": 2,
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.elementsFromPoint\");",
-        "return global::Jint.Browser.Layout.LayoutMembers.ElementsFromPoint(self.Realm, args);"
+        "return global::Jint.Browser.Layout.LayoutMembers.ElementsFromPoint(self.Realm, self.Target, args);"
       ],
-      "reason": "The hit element and every rendered ancestor above it, innermost first. Boxes nest exactly as the tree does in this model, so the list is the ancestor chain rather than a second hit test."
+      "reason": "The hit element and every rendered ancestor above it, innermost first. Boxes nest exactly as the tree does in this model, so the list is the ancestor chain rather than a second hit test. An inert document has no layout and answers an empty list."
     },
     {
       "interface": "Document",
@@ -791,7 +791,7 @@
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.scrollingElement\");",
         "return global::Jint.Browser.Layout.LayoutMembers.ScrollingElement(self.Realm, self.Target);"
       ],
-      "reason": "The one element whose scrollTop moves the window, which is how a client finds the page's own scroll offset. Standards mode always: it is the document element."
+      "reason": "The one element whose scrollTop moves the window, which is how a client finds the page's own scroll offset. Standards mode always: it is the displayed document's document element; a document with no browsing context answers null."
     },
     {
       "interface": "Document",


### PR DESCRIPTION
Fixes #3956.

Document and element viewport hooks now use page focus, visibility, hit-testing, layout, and scrolling state only when the bound node belongs to the document displayed by `PageRuntime`. Secondary documents created by `DOMParser`, `new Document()`, or `DOMImplementation` return inert results and cannot clear page focus, return page nodes, expose page visibility, or read and move the page scroll offset.

The binding overrides and generated output pass the target document into the affected handwritten helpers. Existing displayed-page behavior stays unchanged, and no `PageRuntime`, document URL, or cookie-jar ownership helper changes in this PR, preserving #3952's browsing-context cookie semantics.

Release validation on both net8.0 and net10.0:

- `FocusTests|FlatLayoutTests|DomBindingsStalenessTests`: 42/42 per framework.
- `ChildFrameTests|DocumentHostHookTests`: 20/20 per framework.
- Focus-emulation visibility regression: 1/1 per framework.
- Generator update mode leaves the tree clean; `git diff --check` passes.

The separate `Document.getSelection()` ownership leak found during this work is tracked by #3959.
