### PR TITLE
Isolate secondary document selections

### DIFF
--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -996,7 +996,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.getSelection", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.getSelection");
-                    return global::Jint.Browser.Dom.Views.DomViewMembers.GetSelection(self.Realm);
+                    return global::Jint.Browser.Dom.Views.DomViewMembers.GetSelection(self.Realm, self.Target);
                 }),
                 length: 0)
             .Method("hasFocus",

--- a/Jint.Browser/Dom/Views/DomViewMembers.cs
+++ b/Jint.Browser/Dom/Views/DomViewMembers.cs
@@ -151,15 +151,13 @@ internal static class DomViewMembers
 
     /// <summary>https://w3c.github.io/selection-api/#dom-document-getselection.</summary>
     /// <remarks>
-    /// The page's selection, whichever document the call was made on: a selection belongs to a document's
-    /// browsing context, and a document a <c>DOMParser</c> produced has none. So
-    /// <c>parsed.getSelection()</c> answers the page's rather than a second empty one, where a browser gives
-    /// the parsed document its own. Nothing can select inside a parsed document, so the difference is what
-    /// the object is rather than what it holds.
+    /// A selection belongs to a document's browsing context. A document made by <c>DOMParser</c>,
+    /// <c>new Document()</c> or <c>DOMImplementation</c> has none, so its answer is <c>null</c> rather than
+    /// the selection of the displayed document that happens to share its engine.
     /// </remarks>
-    internal static JsValue GetSelection(DomRealm realm)
+    internal static JsValue GetSelection(DomRealm realm, IDocument document)
     {
-        var runtime = PageRuntime.Find(realm.Engine);
+        var runtime = PageRuntime.Find(realm.Engine, document);
         return runtime is null ? JsValue.Null : runtime.Views.Selection;
     }
 

--- a/Jint.Tests.Browser/Views/SelectionTests.cs
+++ b/Jint.Tests.Browser/Views/SelectionTests.cs
@@ -26,6 +26,33 @@ public sealed class SelectionTests
     }
 
     [Test]
+    public async Task SecondaryDocumentsHaveNoSelection()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<p id='page'>page text</p>");
+
+        (await page.EvaluateAsync<string>("""
+            (() => {
+              const pageSelection = window.getSelection();
+              pageSelection.selectAllChildren(document.getElementById('page'));
+
+              const parsed = new DOMParser().parseFromString('<p>parsed</p>', 'text/html');
+              const implemented = document.implementation.createHTMLDocument('implemented');
+              const constructed = new Document();
+
+              return [
+                parsed.getSelection() === null,
+                implemented.getSelection() === null,
+                constructed.getSelection() === null,
+                pageSelection.toString(),
+                pageSelection === document.getSelection(),
+              ].join('|');
+            })()
+            """)).Should().Be("true|true|true|page text|true");
+    }
+
+    [Test]
     public async Task AnEmptySelectionAnswersTheEmptyState()
     {
         await using var browser = new Browser();

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -386,9 +386,9 @@
       "length": 0,
       "body": [
         "var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, \"Document.getSelection\");",
-        "return global::Jint.Browser.Dom.Views.DomViewMembers.GetSelection(self.Realm);"
+        "return global::Jint.Browser.Dom.Views.DomViewMembers.GetSelection(self.Realm, self.Target);"
       ],
-      "reason": "Selection API §3: document.getSelection() answers the same object window.getSelection() does. AngleSharp has no Selection at all, so the interface is the runtime's."
+      "reason": "Selection API §3: document.getSelection() answers its browsing context's selection, or null when the document has no browsing context. AngleSharp has no Selection at all, so the displayed document's interface is the runtime's."
     },
     {
       "interface": "TreeWalker",


### PR DESCRIPTION
`Document.getSelection()` selected page state by engine alone, so documents created by `DOMParser`, `DOMImplementation`, or `new Document()` exposed the displayed page's selection. The binding now passes its bound `IDocument` and returns the page selection only when that exact document is displayed; secondary documents return `null` as required by the Selection API.

The regression seeds the displayed selection, verifies all three secondary-document paths return `null`, and confirms the displayed selection remains intact and identical through `window.getSelection()` and `document.getSelection()`.

Validation:

- `dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release --filter "FullyQualifiedName~Jint.Tests.Browser.Views.SelectionTests|FullyQualifiedName~Jint.Tests.Browser.DomBindingsStalenessTests"`
- net8.0: 11 passed
- net10.0: 11 passed
- binding generator: 0 diagnostics

Closes #3959
