### PR TITLE
Harden Test262 corpus acquisition

### DIFF
--- a/Jint.Tests.Test262/AGENTS.md
+++ b/Jint.Tests.Test262/AGENTS.md
@@ -13,7 +13,13 @@ Test sources live in `..\test262\test`, which you may always read, and the harne
 
 ### Updating the test262 suite
 
-Bump `SuiteGitSha` in `Jint.Tests.Test262/Test262Harness.settings.json` to the new upstream commit. The next build notices the settings-file hash changed, wipes `Generated/` and regenerates it (`dotnet tool restore && dotnet test262 generate`); `Generated/` is gitignored, so the committed diff stays one line.
+Bump `SuiteGitSha` in `Jint.Tests.Test262/Test262Harness.settings.json` to the new upstream commit. The next build notices the settings-file hash changed, wipes `Generated/` and regenerates it (`dotnet tool restore && dotnet test262 generate`); `Generated/` is gitignored.
+
+The runtime half of that pin is `CorpusContentSha256` in `State.cs`: a canonical digest of every path and
+per-file digest under `harness/` and `test/`. Update it with the reviewed corpus whenever `SuiteGitSha` changes.
+Leaving the old value fails closed and reports the downloaded tree's actual digest; never bypass that failure
+or accept a directory-only archive, because generated source proves which tests exist but not which corpus
+content the runner opened.
 
 A bump is a **code** change, not just a pin change. An upstream normative change can turn a feature that passes today red tomorrow, so read the commits in the range rather than only the new test files — `git log --oneline <old>..<new>` in a test262 checkout, plus the `features.txt` diff for newly added features.
 

--- a/Jint.Tests.Test262/README.md
+++ b/Jint.Tests.Test262/README.md
@@ -5,6 +5,13 @@ dotnet tool restore
 dotnet test262 generate
 ```
 
+The test run downloads the archive for the generated suite's exact `SuiteGitSha` into a unique
+staging directory, verifies the pinned corpus content digest, and atomically publishes it to the
+cache. Transient acquisition failures are retried up to three times. Set `JINT_TEST262_CACHE` to
+choose the directory that holds `test262-<sha>.zip`. Set `JINT_TEST262_OFFLINE=1` to require that
+exact cached archive and disable network acquisition; a missing, partial, corrupt, or mismatched
+archive fails the run rather than falling back to another corpus.
+
 ## Reusable provider examples
 
 `NodaTimeZoneProvider.cs` and `IcuCldrProvider.cs` in this directory are not just test

--- a/Jint.Tests.Test262/State.cs
+++ b/Jint.Tests.Test262/State.cs
@@ -1,3 +1,7 @@
+#nullable enable
+
+using Test262Harness;
+
 namespace Jint.Tests.Test262;
 
 /// <summary>
@@ -5,8 +9,53 @@ namespace Jint.Tests.Test262;
 /// </summary>
 public static partial class State
 {
+    // Canonical SHA-256 over every /harness and /test path and per-file SHA-256 at GitHubSha.
+    // A Test262 pin bump must update this digest from the reviewed corpus too.
+    private const string CorpusContentSha256 = "c52be014920e6367aab7af3196ceb4e7aa3fa3b902581df31445d5139fde08cb";
+
+    private static readonly Lazy<Task<Test262Stream>> _test262Stream = new(LoadTest262Stream);
+
+    static State()
+    {
+        // The generated harness initializes this property to the package's single-attempt downloader.
+        // Assign it from the static constructor so this always runs after generated field initializers.
+        Test262StreamLoader = () => _test262Stream.Value;
+    }
+
     /// <summary>
     /// Pre-compiled scripts for faster execution.
     /// </summary>
     public static readonly Dictionary<string, Prepared<Script>> Sources = new(StringComparer.OrdinalIgnoreCase);
+
+    internal static Exception? CorpusInitializationFailure { get; private set; }
+
+    private static async Task<Test262Stream> LoadTest262Stream()
+    {
+        var cacheDirectory = Environment.GetEnvironmentVariable("JINT_TEST262_CACHE");
+        if (string.IsNullOrWhiteSpace(cacheDirectory))
+        {
+            cacheDirectory = Path.GetTempPath();
+        }
+
+        var offlineValue = Environment.GetEnvironmentVariable("JINT_TEST262_OFFLINE");
+        var offline = offlineValue == "1"
+                      || bool.TryParse(offlineValue, out var parsedOffline) && parsedOffline;
+
+        try
+        {
+            var acquisition = Test262CorpusAcquisition.CreateDefault(
+                CorpusContentSha256,
+                message => TestContext.Progress.WriteLine(message));
+            return await acquisition.LoadAsync(GitHubSha, cacheDirectory, offline);
+        }
+        catch (Exception exception)
+        {
+            CorpusInitializationFailure = exception;
+
+            // Let the generated SetUpFixture finish so selected generated cases reach the unavailable
+            // filesystem below. Throwing here makes NUnit copy one setup error to every case.
+            var fileSystem = new UnavailableTest262FileSystem(exception);
+            return Test262Stream.FromFileSystem(fileSystem);
+        }
+    }
 }

--- a/Jint.Tests.Test262/Test262CorpusAcquisition.cs
+++ b/Jint.Tests.Test262/Test262CorpusAcquisition.cs
@@ -46,6 +46,7 @@ internal sealed class Test262CorpusAcquisition
 
         Directory.CreateDirectory(cacheDirectory);
         var archive = GetArchivePath(commitSha, cacheDirectory);
+        var removeInvalidArchive = false;
         if (File.Exists(archive))
         {
             try
@@ -55,6 +56,7 @@ internal sealed class Test262CorpusAcquisition
             catch (Exception exception) when (!offline)
             {
                 _log($"Ignoring invalid Test262 cache entry {archive}: {exception.Message}");
+                removeInvalidArchive = true;
             }
             catch (Exception exception)
             {
@@ -77,6 +79,26 @@ internal sealed class Test262CorpusAcquisition
 
             try
             {
+                if (removeInvalidArchive)
+                {
+                    // A concurrent acquisition may already have repaired the cache since the first
+                    // validation failed. Keep a valid replacement; otherwise remove the invalid file
+                    // before staging so publication never has to overwrite an archive in use.
+                    if (File.Exists(archive))
+                    {
+                        try
+                        {
+                            return LoadAndValidate(archive, commitSha);
+                        }
+                        catch
+                        {
+                            File.Delete(archive);
+                        }
+                    }
+
+                    removeInvalidArchive = false;
+                }
+
                 Directory.CreateDirectory(stagingDirectory);
                 var stream = await _loadStaged(commitSha, stagingDirectory);
                 try
@@ -95,11 +117,11 @@ internal sealed class Test262CorpusAcquisition
                 }
 
                 // The unique staging directory is under the cache root, so this publishes a completely
-                // validated archive with one same-volume rename. Concurrent processes may replace it only
-                // with another archive that passed the same pinned tree digest.
+                // validated archive with one same-volume rename. The first publisher owns the cache entry;
+                // later publishers must not replace an archive that a returned Test262Stream is reading.
                 try
                 {
-                    File.Move(stagedArchive, archive, overwrite: true);
+                    File.Move(stagedArchive, archive);
                 }
                 catch (IOException) when (File.Exists(archive))
                 {

--- a/Jint.Tests.Test262/Test262CorpusAcquisition.cs
+++ b/Jint.Tests.Test262/Test262CorpusAcquisition.cs
@@ -1,0 +1,225 @@
+#nullable enable
+
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using Test262Harness;
+using Zio;
+
+namespace Jint.Tests.Test262;
+
+internal sealed class Test262CorpusAcquisition
+{
+    private const int MaximumAttempts = 3;
+
+    private readonly Func<string, string, Task<Test262Stream>> _loadStaged;
+    private readonly Func<TimeSpan, Task> _delay;
+    private readonly string _expectedDigest;
+    private readonly Action<string> _log;
+
+    internal Test262CorpusAcquisition(
+        Func<string, string, Task<Test262Stream>> loadStaged,
+        Func<TimeSpan, Task> delay,
+        string expectedDigest,
+        Action<string>? log = null)
+    {
+        _loadStaged = loadStaged;
+        _delay = delay;
+        _expectedDigest = expectedDigest;
+        _log = log ?? (_ => { });
+    }
+
+    internal static Test262CorpusAcquisition CreateDefault(string expectedDigest, Action<string> log)
+        => new(
+            static (sha, stagingDirectory) => Test262StreamExtensions.FromGitHub(sha, stagingDirectory),
+            Task.Delay,
+            expectedDigest,
+            log);
+
+    internal async Task<Test262Stream> LoadAsync(string commitSha, string cacheDirectory, bool offline = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(commitSha);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cacheDirectory);
+
+        Directory.CreateDirectory(cacheDirectory);
+        var archive = GetArchivePath(commitSha, cacheDirectory);
+        if (File.Exists(archive))
+        {
+            try
+            {
+                return LoadAndValidate(archive, commitSha);
+            }
+            catch (Exception exception) when (!offline)
+            {
+                _log($"Ignoring invalid Test262 cache entry {archive}: {exception.Message}");
+            }
+            catch (Exception exception)
+            {
+                throw new Test262CorpusUnavailableException(commitSha, 1, exception);
+            }
+        }
+        else if (offline)
+        {
+            var exception = new FileNotFoundException(
+                $"Offline Test262 mode requires the pinned archive at {archive}.",
+                archive);
+            throw new Test262CorpusUnavailableException(commitSha, 1, exception);
+        }
+
+        for (var attempt = 1; ; attempt++)
+        {
+            var stagingDirectory = Path.Combine(
+                cacheDirectory,
+                $".test262-{commitSha}-{Environment.ProcessId}-{Guid.NewGuid():N}");
+
+            try
+            {
+                Directory.CreateDirectory(stagingDirectory);
+                var stream = await _loadStaged(commitSha, stagingDirectory);
+                try
+                {
+                    Validate(stream, commitSha);
+                }
+                finally
+                {
+                    stream.Options.FileSystem.Dispose();
+                }
+
+                var stagedArchive = GetArchivePath(commitSha, stagingDirectory);
+                if (!File.Exists(stagedArchive))
+                {
+                    throw new InvalidDataException("The staged Test262 download did not produce an archive.");
+                }
+
+                // The unique staging directory is under the cache root, so this publishes a completely
+                // validated archive with one same-volume rename. Concurrent processes may replace it only
+                // with another archive that passed the same pinned tree digest.
+                try
+                {
+                    File.Move(stagedArchive, archive, overwrite: true);
+                }
+                catch (IOException) when (File.Exists(archive))
+                {
+                    // Another process can win the same atomic publish. Accept its archive only after
+                    // independently proving that it is the same pinned tree.
+                    return LoadAndValidate(archive, commitSha);
+                }
+
+                return LoadAndValidate(archive, commitSha);
+            }
+            catch (Exception exception) when (IsTransient(exception) && attempt < MaximumAttempts)
+            {
+                var delay = TimeSpan.FromSeconds(attempt);
+                _log($"Test262 corpus acquisition for {commitSha} failed on attempt {attempt}/{MaximumAttempts}: "
+                     + $"{exception.Message}. Retrying in {delay.TotalSeconds:0} second(s).");
+                await _delay(delay);
+            }
+            catch (Exception exception)
+            {
+                throw new Test262CorpusUnavailableException(commitSha, attempt, exception);
+            }
+            finally
+            {
+                TryDeleteDirectory(stagingDirectory);
+            }
+        }
+    }
+
+    private Test262Stream LoadAndValidate(string archive, string commitSha)
+    {
+        var stream = Test262Stream.FromZipArchive(archive, $"test262-{commitSha}");
+        try
+        {
+            Validate(stream, commitSha);
+            return stream;
+        }
+        catch
+        {
+            stream.Options.FileSystem.Dispose();
+            throw;
+        }
+    }
+
+    private void Validate(Test262Stream stream, string commitSha)
+    {
+        var actualDigest = ComputeDigest(stream);
+        if (!actualDigest.Equals(_expectedDigest, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"The Test262 content digest for {commitSha} was {actualDigest}; expected {_expectedDigest}.");
+        }
+    }
+
+    private static string ComputeDigest(Test262Stream stream)
+    {
+        var fileSystem = stream.Options.FileSystem;
+        var paths = fileSystem.EnumerateFiles("/harness", "*", SearchOption.AllDirectories)
+            .Concat(fileSystem.EnumerateFiles("/test", "*", SearchOption.AllDirectories))
+            .Select(static path => path.FullName)
+            .OrderBy(static path => path, StringComparer.Ordinal);
+
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        Span<byte> pathLength = stackalloc byte[sizeof(int)];
+
+        foreach (var path in paths)
+        {
+            var encodedPath = Encoding.UTF8.GetBytes(path);
+            BinaryPrimitives.WriteInt32LittleEndian(pathLength, encodedPath.Length);
+            hash.AppendData(pathLength);
+            hash.AppendData(encodedPath);
+
+            using var content = fileSystem.OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            hash.AppendData(SHA256.HashData(content));
+        }
+
+        return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+    }
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+        catch
+        {
+            // A uniquely named staging directory cannot affect another run or be mistaken for the cache.
+        }
+    }
+
+    private static string GetArchivePath(string commitSha, string directory)
+        => Path.Combine(directory, $"test262-{commitSha}.zip");
+
+    private static bool IsTransient(Exception exception)
+    {
+        if (exception is HttpRequestException httpException)
+        {
+            return httpException.StatusCode is null
+                   or HttpStatusCode.RequestTimeout
+                   or HttpStatusCode.TooManyRequests
+                   || (int)httpException.StatusCode >= 500;
+        }
+
+        return exception is IOException or InvalidDataException or SocketException or TimeoutException or TaskCanceledException;
+    }
+}
+
+internal sealed class Test262CorpusUnavailableException : Exception
+{
+    internal Test262CorpusUnavailableException(string commitSha, int attempts, Exception innerException)
+        : base($"Could not acquire the pinned Test262 corpus {commitSha} after {attempts} attempt(s).", innerException)
+    {
+        CommitSha = commitSha;
+        Attempts = attempts;
+    }
+
+    internal string CommitSha { get; }
+
+    internal int Attempts { get; }
+}

--- a/Jint.Tests.Test262/Test262CorpusAcquisitionTests.cs
+++ b/Jint.Tests.Test262/Test262CorpusAcquisitionTests.cs
@@ -67,56 +67,105 @@ public sealed class Test262CorpusAcquisitionTests
         const string sha = "0123456789abcdef";
         var cacheDirectory = NewCacheDirectory();
         var bothDownloadsReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondDownload = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var readyCount = 0;
 
-        Task<Test262Stream> Stage(string actualSha, string stagingDirectory)
+        async Task<Test262Stream> Stage(
+            string actualSha,
+            string stagingDirectory,
+            string marker,
+            bool waitForRelease)
         {
             var archive = Path.Combine(stagingDirectory, $"test262-{actualSha}.zip");
-            CreateArchive(archive, actualSha);
+            CreateArchive(archive, actualSha, marker);
             if (Interlocked.Increment(ref readyCount) == 2)
             {
                 bothDownloadsReady.SetResult();
             }
 
-            return Finish();
-
-            async Task<Test262Stream> Finish()
+            await bothDownloadsReady.Task;
+            if (waitForRelease)
             {
-                await bothDownloadsReady.Task;
-                return Test262Stream.FromZipArchive(archive, $"test262-{actualSha}");
+                await releaseSecondDownload.Task;
             }
+
+            return Test262Stream.FromZipArchive(archive, $"test262-{actualSha}");
         }
 
-        var first = new Test262CorpusAcquisition(Stage, _ => Task.CompletedTask, TinyCorpusDigest);
-        var second = new Test262CorpusAcquisition(Stage, _ => Task.CompletedTask, TinyCorpusDigest);
+        var first = new Test262CorpusAcquisition(
+            (actualSha, stagingDirectory) => Stage(actualSha, stagingDirectory, "first", waitForRelease: false),
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+        var second = new Test262CorpusAcquisition(
+            (actualSha, stagingDirectory) => Stage(actualSha, stagingDirectory, "second", waitForRelease: true),
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+        Test262Stream? firstStream = null;
+        Test262Stream? secondStream = null;
 
         try
         {
-            var streams = await Task.WhenAll(
-                first.LoadAsync(sha, cacheDirectory),
-                second.LoadAsync(sha, cacheDirectory));
-            try
-            {
-                Assert.That(streams, Has.Length.EqualTo(2));
-                Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
-                Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
+            var firstTask = first.LoadAsync(sha, cacheDirectory);
+            var secondTask = second.LoadAsync(sha, cacheDirectory);
+            firstStream = await firstTask;
+            releaseSecondDownload.SetResult();
+            secondStream = await secondTask;
 
-                var offline = new Test262CorpusAcquisition(
-                    (_, _) => throw new InvalidOperationException("A published cache entry must not download."),
-                    _ => Task.CompletedTask,
-                    TinyCorpusDigest);
-                var offlineStream = await offline.LoadAsync(sha, cacheDirectory, offline: true);
-                using (offlineStream.Options.FileSystem)
-                {
-                    Assert.That(offlineStream, Is.Not.Null);
-                }
-            }
-            finally
+            Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
+            Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
+
+            var offline = new Test262CorpusAcquisition(
+                (_, _) => throw new InvalidOperationException("A published cache entry must not download."),
+                _ => Task.CompletedTask,
+                TinyCorpusDigest);
+            var offlineStream = await offline.LoadAsync(sha, cacheDirectory, offline: true);
+            using (offlineStream.Options.FileSystem)
             {
-                foreach (var stream in streams)
-                {
-                    stream.Options.FileSystem.Dispose();
-                }
+                Assert.That(offlineStream, Is.Not.Null);
+            }
+
+            firstStream.Options.FileSystem.Dispose();
+            firstStream = null;
+            secondStream.Options.FileSystem.Dispose();
+            secondStream = null;
+
+            var archive = Path.Combine(cacheDirectory, $"test262-{sha}.zip");
+            using var zip = ZipFile.OpenRead(archive);
+            Assert.That(zip.GetEntry("first"), Is.Not.Null);
+            Assert.That(zip.GetEntry("second"), Is.Null);
+        }
+        finally
+        {
+            releaseSecondDownload.TrySetResult();
+            firstStream?.Options.FileSystem.Dispose();
+            secondStream?.Options.FileSystem.Dispose();
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task InvalidOnlineCacheIsRemovedBeforePublishingItsReplacement()
+    {
+        const string sha = "0123456789abcdef";
+        var cacheDirectory = NewCacheDirectory();
+        var archive = Path.Combine(cacheDirectory, $"test262-{sha}.zip");
+        CreatePartialArchive(archive, sha);
+        var acquisition = new Test262CorpusAcquisition(
+            (actualSha, stagingDirectory) =>
+            {
+                var stagedArchive = Path.Combine(stagingDirectory, $"test262-{actualSha}.zip");
+                CreateArchive(stagedArchive, actualSha);
+                return Task.FromResult(Test262Stream.FromZipArchive(stagedArchive, $"test262-{actualSha}"));
+            },
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+
+        try
+        {
+            var stream = await acquisition.LoadAsync(sha, cacheDirectory);
+            using (stream.Options.FileSystem)
+            {
+                Assert.That(stream.Options.FileSystem.DirectoryExists("/test/language"), Is.True);
             }
         }
         finally
@@ -324,9 +373,14 @@ public sealed class Test262CorpusAcquisitionTests
         return directory;
     }
 
-    private static void CreateArchive(string archive, string sha)
+    private static void CreateArchive(string archive, string sha, string? marker = null)
     {
         using var zip = ZipFile.Open(archive, ZipArchiveMode.Create);
+        if (marker is not null)
+        {
+            zip.CreateEntry(marker);
+        }
+
         zip.CreateEntry($"test262-{sha}/");
         zip.CreateEntry($"test262-{sha}/harness/");
         zip.CreateEntry($"test262-{sha}/harness/assert.js");

--- a/Jint.Tests.Test262/Test262CorpusAcquisitionTests.cs
+++ b/Jint.Tests.Test262/Test262CorpusAcquisitionTests.cs
@@ -43,15 +43,17 @@ public sealed class Test262CorpusAcquisitionTests
         try
         {
             var stream = await acquisition.LoadAsync(sha, cacheDirectory);
-
-            Assert.That(stream.Options.FileSystem.DirectoryExists("/test"), Is.True);
-            Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
-            Assert.That(calls, Has.Count.EqualTo(2));
-            Assert.That(calls.Select(static call => call.Sha), Is.All.EqualTo(sha));
-            Assert.That(calls.Select(static call => call.StagingDirectory), Is.All.Not.EqualTo(cacheDirectory));
-            Assert.That(calls.Select(static call => call.StagingDirectory).Distinct().Count(), Is.EqualTo(2));
-            Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
-            Assert.That(delays, Is.EqualTo(new[] { TimeSpan.FromSeconds(1) }));
+            using (stream.Options.FileSystem)
+            {
+                Assert.That(stream.Options.FileSystem.DirectoryExists("/test"), Is.True);
+                Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
+                Assert.That(calls, Has.Count.EqualTo(2));
+                Assert.That(calls.Select(static call => call.Sha), Is.All.EqualTo(sha));
+                Assert.That(calls.Select(static call => call.StagingDirectory), Is.All.Not.EqualTo(cacheDirectory));
+                Assert.That(calls.Select(static call => call.StagingDirectory).Distinct().Count(), Is.EqualTo(2));
+                Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
+                Assert.That(delays, Is.EqualTo(new[] { TimeSpan.FromSeconds(1) }));
+            }
         }
         finally
         {
@@ -93,16 +95,29 @@ public sealed class Test262CorpusAcquisitionTests
             var streams = await Task.WhenAll(
                 first.LoadAsync(sha, cacheDirectory),
                 second.LoadAsync(sha, cacheDirectory));
+            try
+            {
+                Assert.That(streams, Has.Length.EqualTo(2));
+                Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
+                Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
 
-            Assert.That(streams, Has.Length.EqualTo(2));
-            Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
-            Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
-
-            var offline = new Test262CorpusAcquisition(
-                (_, _) => throw new InvalidOperationException("A published cache entry must not download."),
-                _ => Task.CompletedTask,
-                TinyCorpusDigest);
-            Assert.That(await offline.LoadAsync(sha, cacheDirectory, offline: true), Is.Not.Null);
+                var offline = new Test262CorpusAcquisition(
+                    (_, _) => throw new InvalidOperationException("A published cache entry must not download."),
+                    _ => Task.CompletedTask,
+                    TinyCorpusDigest);
+                var offlineStream = await offline.LoadAsync(sha, cacheDirectory, offline: true);
+                using (offlineStream.Options.FileSystem)
+                {
+                    Assert.That(offlineStream, Is.Not.Null);
+                }
+            }
+            finally
+            {
+                foreach (var stream in streams)
+                {
+                    stream.Options.FileSystem.Dispose();
+                }
+            }
         }
         finally
         {
@@ -129,10 +144,12 @@ public sealed class Test262CorpusAcquisitionTests
         try
         {
             var stream = await acquisition.LoadAsync(sha, cacheDirectory, offline: true);
-
-            Assert.That(stream.Options.FileSystem.DirectoryExists("/harness"), Is.True);
-            Assert.That(stream.Options.FileSystem.DirectoryExists("/test"), Is.True);
-            Assert.That(downloadCalls, Is.Zero);
+            using (stream.Options.FileSystem)
+            {
+                Assert.That(stream.Options.FileSystem.DirectoryExists("/harness"), Is.True);
+                Assert.That(stream.Options.FileSystem.DirectoryExists("/test"), Is.True);
+                Assert.That(downloadCalls, Is.Zero);
+            }
         }
         finally
         {

--- a/Jint.Tests.Test262/Test262CorpusAcquisitionTests.cs
+++ b/Jint.Tests.Test262/Test262CorpusAcquisitionTests.cs
@@ -1,0 +1,329 @@
+#nullable enable
+
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using Jint.Tests.Test262;
+using Test262Harness;
+
+namespace Jint.Tests.Test262Infrastructure;
+
+[TestFixture]
+public sealed class Test262CorpusAcquisitionTests
+{
+    private const string TinyCorpusDigest = "c1467ff005a7345aa858548da8503b8be23fe0c52b38a8055568386dbf02c7cd";
+
+    [Test]
+    public async Task TransientFailureStagesAndPublishesTheSamePinnedCorpus()
+    {
+        const string sha = "0123456789abcdef";
+        var cacheDirectory = NewCacheDirectory();
+        var calls = new List<(string Sha, string StagingDirectory)>();
+        var delays = new List<TimeSpan>();
+        var acquisition = new Test262CorpusAcquisition(
+            (actualSha, stagingDirectory) =>
+            {
+                calls.Add((actualSha, stagingDirectory));
+                if (calls.Count == 1)
+                {
+                    return Task.FromException<Test262Stream>(new HttpRequestException("temporary DNS failure"));
+                }
+
+                var archive = Path.Combine(stagingDirectory, $"test262-{actualSha}.zip");
+                CreateArchive(archive, actualSha);
+                return Task.FromResult(Test262Stream.FromZipArchive(archive, $"test262-{actualSha}"));
+            },
+            delay =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            },
+            TinyCorpusDigest);
+
+        try
+        {
+            var stream = await acquisition.LoadAsync(sha, cacheDirectory);
+
+            Assert.That(stream.Options.FileSystem.DirectoryExists("/test"), Is.True);
+            Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
+            Assert.That(calls, Has.Count.EqualTo(2));
+            Assert.That(calls.Select(static call => call.Sha), Is.All.EqualTo(sha));
+            Assert.That(calls.Select(static call => call.StagingDirectory), Is.All.Not.EqualTo(cacheDirectory));
+            Assert.That(calls.Select(static call => call.StagingDirectory).Distinct().Count(), Is.EqualTo(2));
+            Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
+            Assert.That(delays, Is.EqualTo(new[] { TimeSpan.FromSeconds(1) }));
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task IndependentAcquisitionsPublishSafelyToTheSameCache()
+    {
+        const string sha = "0123456789abcdef";
+        var cacheDirectory = NewCacheDirectory();
+        var bothDownloadsReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var readyCount = 0;
+
+        Task<Test262Stream> Stage(string actualSha, string stagingDirectory)
+        {
+            var archive = Path.Combine(stagingDirectory, $"test262-{actualSha}.zip");
+            CreateArchive(archive, actualSha);
+            if (Interlocked.Increment(ref readyCount) == 2)
+            {
+                bothDownloadsReady.SetResult();
+            }
+
+            return Finish();
+
+            async Task<Test262Stream> Finish()
+            {
+                await bothDownloadsReady.Task;
+                return Test262Stream.FromZipArchive(archive, $"test262-{actualSha}");
+            }
+        }
+
+        var first = new Test262CorpusAcquisition(Stage, _ => Task.CompletedTask, TinyCorpusDigest);
+        var second = new Test262CorpusAcquisition(Stage, _ => Task.CompletedTask, TinyCorpusDigest);
+
+        try
+        {
+            var streams = await Task.WhenAll(
+                first.LoadAsync(sha, cacheDirectory),
+                second.LoadAsync(sha, cacheDirectory));
+
+            Assert.That(streams, Has.Length.EqualTo(2));
+            Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
+            Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
+
+            var offline = new Test262CorpusAcquisition(
+                (_, _) => throw new InvalidOperationException("A published cache entry must not download."),
+                _ => Task.CompletedTask,
+                TinyCorpusDigest);
+            Assert.That(await offline.LoadAsync(sha, cacheDirectory, offline: true), Is.Not.Null);
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task OfflineModeUsesOnlyTheArchiveNamedForThePinnedCommit()
+    {
+        const string sha = "0123456789abcdef";
+        var cacheDirectory = NewCacheDirectory();
+        CreateArchive(Path.Combine(cacheDirectory, $"test262-{sha}.zip"), sha);
+        var downloadCalls = 0;
+        var acquisition = new Test262CorpusAcquisition(
+            (_, _) =>
+            {
+                downloadCalls++;
+                throw new InvalidOperationException("The network must not be used in offline mode.");
+            },
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+
+        try
+        {
+            var stream = await acquisition.LoadAsync(sha, cacheDirectory, offline: true);
+
+            Assert.That(stream.Options.FileSystem.DirectoryExists("/harness"), Is.True);
+            Assert.That(stream.Options.FileSystem.DirectoryExists("/test"), Is.True);
+            Assert.That(downloadCalls, Is.Zero);
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void OfflineModeFailsClosedWhenThePinnedArchiveIsAbsent()
+    {
+        var cacheDirectory = NewCacheDirectory();
+        var downloadCalls = 0;
+        var acquisition = new Test262CorpusAcquisition(
+            (_, _) =>
+            {
+                downloadCalls++;
+                throw new InvalidOperationException("The network must not be used in offline mode.");
+            },
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+
+        try
+        {
+            var exception = Assert.ThrowsAsync<Test262CorpusUnavailableException>(() =>
+                acquisition.LoadAsync("0123456789abcdef", cacheDirectory, offline: true));
+
+            Assert.That(exception!.InnerException, Is.TypeOf<FileNotFoundException>());
+            Assert.That(downloadCalls, Is.Zero);
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void OfflineModeRejectsAPartialArchiveWithTheExactRootDirectories()
+    {
+        const string sha = "0123456789abcdef";
+        var cacheDirectory = NewCacheDirectory();
+        CreatePartialArchive(Path.Combine(cacheDirectory, $"test262-{sha}.zip"), sha);
+        var acquisition = new Test262CorpusAcquisition(
+            (_, _) => throw new InvalidOperationException("The network must not be used in offline mode."),
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+
+        try
+        {
+            var exception = Assert.ThrowsAsync<Test262CorpusUnavailableException>(() =>
+                acquisition.LoadAsync(sha, cacheDirectory, offline: true));
+
+            Assert.That(exception!.InnerException, Is.TypeOf<InvalidDataException>());
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void OfflineModeRejectsAnArchiveWhoseRootDoesNotMatchThePinnedCommit()
+    {
+        const string sha = "0123456789abcdef";
+        var cacheDirectory = NewCacheDirectory();
+        CreateArchive(Path.Combine(cacheDirectory, $"test262-{sha}.zip"), "different-commit");
+        var acquisition = new Test262CorpusAcquisition(
+            (_, _) => throw new InvalidOperationException("The network must not be used in offline mode."),
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+
+        try
+        {
+            Assert.ThrowsAsync<Test262CorpusUnavailableException>(() =>
+                acquisition.LoadAsync(sha, cacheDirectory, offline: true));
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void PermanentTransientFailureStopsAtTheBound()
+    {
+        const string sha = "fedcba9876543210";
+        var cacheDirectory = NewCacheDirectory();
+        var attempts = 0;
+        var acquisition = new Test262CorpusAcquisition(
+            (_, _) =>
+            {
+                attempts++;
+                return Task.FromException<Test262Stream>(new HttpRequestException("DNS unavailable"));
+            },
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+
+        try
+        {
+            var exception = Assert.ThrowsAsync<Test262CorpusUnavailableException>(() =>
+                acquisition.LoadAsync(sha, cacheDirectory));
+
+            Assert.That(attempts, Is.EqualTo(3));
+            Assert.That(exception!.CommitSha, Is.EqualTo(sha));
+            Assert.That(exception.Attempts, Is.EqualTo(3));
+            Assert.That(exception.InnerException, Is.TypeOf<HttpRequestException>());
+            Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void PermanentHttpFailureIsReportedWithoutRetrying()
+    {
+        var cacheDirectory = NewCacheDirectory();
+        var attempts = 0;
+        var acquisition = new Test262CorpusAcquisition(
+            (_, _) =>
+            {
+                attempts++;
+                return Task.FromException<Test262Stream>(
+                    new HttpRequestException("not found", null, HttpStatusCode.NotFound));
+            },
+            _ => Task.CompletedTask,
+            TinyCorpusDigest);
+
+        try
+        {
+            var exception = Assert.ThrowsAsync<Test262CorpusUnavailableException>(() =>
+                acquisition.LoadAsync("0123456789abcdef", cacheDirectory));
+
+            Assert.That(attempts, Is.EqualTo(1));
+            Assert.That(exception!.Attempts, Is.EqualTo(1));
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task UnavailableCorpusProducesOneFailureAcrossConcurrentGeneratedCalls()
+    {
+        const int callCount = 16;
+        var stream = Test262Stream.FromFileSystem(
+            new UnavailableTest262FileSystem(new HttpRequestException("DNS unavailable")));
+
+        var calls = Enumerable.Range(0, callCount).Select(_ => Task.Run(() =>
+        {
+            try
+            {
+                stream.GetTestFile("language/example.js");
+                return null;
+            }
+            catch (Exception exception)
+            {
+                return exception;
+            }
+        }));
+        var exceptions = await Task.WhenAll(calls);
+
+        Assert.That(exceptions.Count(static exception => exception is AssertionException), Is.EqualTo(1));
+        Assert.That(exceptions.Count(static exception => exception is IgnoreException), Is.EqualTo(callCount - 1));
+    }
+
+    private static string NewCacheDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void CreateArchive(string archive, string sha)
+    {
+        using var zip = ZipFile.Open(archive, ZipArchiveMode.Create);
+        zip.CreateEntry($"test262-{sha}/");
+        zip.CreateEntry($"test262-{sha}/harness/");
+        zip.CreateEntry($"test262-{sha}/harness/assert.js");
+        zip.CreateEntry($"test262-{sha}/test/");
+        zip.CreateEntry($"test262-{sha}/test/language/");
+        zip.CreateEntry($"test262-{sha}/test/language/example.js");
+    }
+
+    private static void CreatePartialArchive(string archive, string sha)
+    {
+        using var zip = ZipFile.Open(archive, ZipArchiveMode.Create);
+        zip.CreateEntry($"test262-{sha}/");
+        zip.CreateEntry($"test262-{sha}/harness/");
+        zip.CreateEntry($"test262-{sha}/harness/assert.js");
+        zip.CreateEntry($"test262-{sha}/test/");
+    }
+}

--- a/Jint.Tests.Test262/Test262CorpusAcquisitionTests.cs
+++ b/Jint.Tests.Test262/Test262CorpusAcquisitionTests.cs
@@ -100,16 +100,14 @@ public sealed class Test262CorpusAcquisitionTests
             (actualSha, stagingDirectory) => Stage(actualSha, stagingDirectory, "second", waitForRelease: true),
             _ => Task.CompletedTask,
             TinyCorpusDigest);
-        Test262Stream? firstStream = null;
-        Test262Stream? secondStream = null;
+        var firstTask = first.LoadAsync(sha, cacheDirectory);
+        var secondTask = second.LoadAsync(sha, cacheDirectory);
 
         try
         {
-            var firstTask = first.LoadAsync(sha, cacheDirectory);
-            var secondTask = second.LoadAsync(sha, cacheDirectory);
-            firstStream = await firstTask;
+            await firstTask;
             releaseSecondDownload.SetResult();
-            secondStream = await secondTask;
+            await secondTask;
 
             Assert.That(File.Exists(Path.Combine(cacheDirectory, $"test262-{sha}.zip")), Is.True);
             Assert.That(Directory.EnumerateDirectories(cacheDirectory), Is.Empty);
@@ -124,11 +122,6 @@ public sealed class Test262CorpusAcquisitionTests
                 Assert.That(offlineStream, Is.Not.Null);
             }
 
-            firstStream.Options.FileSystem.Dispose();
-            firstStream = null;
-            secondStream.Options.FileSystem.Dispose();
-            secondStream = null;
-
             var archive = Path.Combine(cacheDirectory, $"test262-{sha}.zip");
             using var zip = ZipFile.OpenRead(archive);
             Assert.That(zip.GetEntry("first"), Is.Not.Null);
@@ -136,9 +129,28 @@ public sealed class Test262CorpusAcquisitionTests
         }
         finally
         {
+            bothDownloadsReady.TrySetResult();
             releaseSecondDownload.TrySetResult();
-            firstStream?.Options.FileSystem.Dispose();
-            secondStream?.Options.FileSystem.Dispose();
+            try
+            {
+                await Task.WhenAll(firstTask, secondTask);
+            }
+            catch
+            {
+                // The test's awaits report acquisition failures. Cleanup must still join both tasks
+                // and close every successful reader before removing the shared cache.
+            }
+
+            if (firstTask.IsCompletedSuccessfully)
+            {
+                firstTask.Result.Options.FileSystem.Dispose();
+            }
+
+            if (secondTask.IsCompletedSuccessfully)
+            {
+                secondTask.Result.Options.FileSystem.Dispose();
+            }
+
             Directory.Delete(cacheDirectory, recursive: true);
         }
     }

--- a/Jint.Tests.Test262/TestHarness.cs
+++ b/Jint.Tests.Test262/TestHarness.cs
@@ -12,6 +12,13 @@ public partial class TestHarness
 
     private static partial Task InitializeCustomState()
     {
+        if (State.CorpusInitializationFailure is not null)
+        {
+            // The unavailable stream reports this once from the first selected generated test and
+            // ignores the rest. Returning keeps NUnit from copying a namespace setup failure to all cases.
+            return Task.CompletedTask;
+        }
+
         // Test262Harness hands us State.HarnessFiles from the top level of harness/ only, and keys
         // nothing: an include is looked up by the exact string the test's frontmatter wrote. The
         // staging/ tests ported from SpiderMonkey include their helpers as "sm/non262-Set-shell.js",

--- a/Jint.Tests.Test262/UnavailableTest262FileSystem.cs
+++ b/Jint.Tests.Test262/UnavailableTest262FileSystem.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+using Zio;
+using Zio.FileSystems;
+
+namespace Jint.Tests.Test262;
+
+internal sealed class UnavailableTest262FileSystem : MemoryFileSystem
+{
+    private readonly Exception _failure;
+    private int _reported;
+
+    internal UnavailableTest262FileSystem(Exception failure)
+    {
+        _failure = failure;
+        CreateDirectory("/harness");
+        CreateDirectory("/test");
+    }
+
+    protected override Stream OpenFileImpl(UPath path, FileMode mode, FileAccess access, FileShare share)
+    {
+        if (path.FullName.StartsWith("/test/", StringComparison.Ordinal))
+        {
+            var message = $"The pinned Test262 corpus could not be acquired. {_failure}";
+            if (Interlocked.CompareExchange(ref _reported, 1, 0) == 0)
+            {
+                throw new AssertionException(message);
+            }
+
+            throw new IgnoreException(
+                "The pinned Test262 corpus could not be acquired; the first selected generated case reports the failure.");
+        }
+
+        return base.OpenFileImpl(path, mode, access, share);
+    }
+}


### PR DESCRIPTION
The generated Test262 namespace setup let a transient corpus download exception escape from `OneTimeSetUp`, so NUnit copied the same infrastructure error onto all 102,692 generated cases. The runner now retries transient acquisition failures up to three times while continuing to request the generated suite's exact SHA.

Downloads go to a unique per-process staging directory. The runner computes a canonical digest over every `harness/` and `test/` path and file body, then atomically publishes the verified archive to the shared cache. Concurrent acquisitions can only accept another process's archive after independently verifying the same pinned digest. Missing, partial, corrupt, or mismatched content remains a failure, and `JINT_TEST262_OFFLINE=1` provides a deterministic cache-only path.

If acquisition still fails, the first selected generated case reports the infrastructure error and the remaining selected cases skip. This keeps full and generated-only filtered runs red without producing tens of thousands of duplicate failures.

Validation:

- Full Release Test262 run: 102,594 passed, 107 existing exclusions skipped, 0 failed (102,701 total including 9 new infrastructure tests), 2m28s.
- Fresh empty-cache acquisition through staging, digest verification, and atomic publication: passed; only the final 54.8 MB archive remained.
- Forced generated-only offline missing-cache probe: exactly one failure and one selected generated case skipped.
- Two independent acquisitions targeting one cache publish safely; the resulting archive passes an offline digest check.
- Test262 infrastructure tests: 9 passed in Release.
- Agent instruction guardian: 5 passed on net8.0 and 5 passed on net10.0 in Release.

Closes #3967
