### PR TITLE
Run browser target frameworks sequentially

### DIFF
--- a/Jint.Tests.Browser/Jint.Tests.Browser.csproj
+++ b/Jint.Tests.Browser/Jint.Tests.Browser.csproj
@@ -5,6 +5,13 @@
          Jint.Browser is net8.0+, like Jint/WebApi/ and Jint.DevTools. -->
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 
+    <!-- Upstream's browser harness uses a ten-second wall-clock timeout. Running this project's two
+         testhosts together lets one synchronous document consume that deadline while its process is
+         descheduled: three unrelated CI changes have produced that signature, while either framework
+         alone and a single testhost with 64 NUnit workers complete. Keep the frameworks one after the
+         other; every fixture, census check and target framework still runs. -->
+    <TestTfmsInParallel>false</TestTfmsInParallel>
+
     <!-- Signed with the repository key, because Jint.Browser is signed and names this assembly as a friend.
          Everything the binding has is internal, so without the grant there is nothing here to test. -->
     <AssemblyOriginatorKeyFile>..\Jint\Jint.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Three unrelated changes have hit the same browser WPT harness timeout while the `net8.0` and `net10.0` `Jint.Tests.Browser` testhosts run concurrently. The decisive Linux occurrence began both browser hosts only after the repository's other suites had finished: net10 passed in 2m51 while net8 timed out a synchronous Range document at 3m23. A single testhost with 64 NUnit workers passes, which rules out fixture-level parallelism as the measured boundary.

Set `TestTfmsInParallel` to `false` for `Jint.Tests.Browser` so its two target-framework hosts run one after the other. Every fixture, census check, framework, deadline, and NUnit worker still runs; solution build parallelism and every other test project are unchanged. This also avoids wasting four-core runner time on two contending browser hosts whose observed overlap was slower than their isolated combined runtime.

Validation:

- Fresh Release `Jint.Tests.Browser` run completed both frameworks sequentially and exited 0.
- Focused unchanged Range WPT suite passed 17/17 on net8.0 and 17/17 on net10.0, with the logs confirming net10 began after net8 completed.
- The SDK 10.0.400 cross-targeting target maps `TestTfmsInParallel` directly to the inner test-build `BuildInParallel` switch.
- `git diff --check` passes.

Closes #3947
