### PR TITLE
Report execution progress when browser WPT times out

### DIFF
--- a/Jint.Tests.Browser/Wpt/WptBrowserDiagnostics.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserDiagnostics.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.Wpt;
+
+/// <summary>
+/// Evidence for a harness failure, especially #3947's Windows timeouts. These counters observe the test
+/// process, which may run other fixtures concurrently; they are not measurements of the page's CPU usage.
+/// No diagnostic affects the harness verdict, a deadline, the event loop, or whether a case is retried.
+/// </summary>
+internal sealed class WptBrowserDiagnostics
+{
+    private readonly long _started = Stopwatch.GetTimestamp();
+    private readonly TimeSpan? _cpu = ProcessCpu();
+    private readonly TimeSpan _gcPause = GC.GetTotalPauseDuration();
+    private readonly int _gen0 = GC.CollectionCount(0);
+    private readonly int _gen1 = GC.CollectionCount(1);
+    private readonly int _gen2 = GC.CollectionCount(2);
+
+    internal string Describe(Page page, WptBrowserCollector collector)
+    {
+        var cpu = ProcessCpu();
+        var cpuMs = cpu is { } current && _cpu is { } initial
+            ? (current - initial).TotalMilliseconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)
+            : "unavailable";
+
+        // Page.Requests contains transport-owned snapshots and is explicitly safe off the page loop.
+        // It exposes status, not request timings: do not infer completion duration from these counts.
+        var requests = page.Requests;
+        var pending = 0;
+        var failed = 0;
+        foreach (var request in requests)
+        {
+            if (request.Failed)
+            {
+                failed++;
+            }
+            else if (request.Status == 0 && request.NotFetchedReason is null)
+            {
+                pending++;
+            }
+        }
+
+        return FormattableString.Invariant(
+            $" [WPT diagnostics: runtime={RuntimeInformation.FrameworkDescription}; processors={Environment.ProcessorCount}; elapsedMs={Stopwatch.GetElapsedTime(_started).TotalMilliseconds:F1}; processCpuMs={cpuMs}; processGcPauseMs={(GC.GetTotalPauseDuration() - _gcPause).TotalMilliseconds:F1}; processCollections={GC.CollectionCount(0) - _gen0}/{GC.CollectionCount(1) - _gen1}/{GC.CollectionCount(2) - _gen2}; threadPoolThreads={ThreadPool.ThreadCount}; threadPoolPending={ThreadPool.PendingWorkItemCount}; requests={requests.Count}; awaitingResponse={pending}; failedRequests={failed}; {collector.DescribeProgress()}]");
+    }
+
+    private static TimeSpan? ProcessCpu()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return process.TotalProcessorTime;
+        }
+        catch (Exception exception) when (exception is Win32Exception or InvalidOperationException or NotSupportedException)
+        {
+            // Some hosts deny process counters. Diagnostics must preserve the original harness failure.
+            return null;
+        }
+    }
+}

--- a/Jint.Tests.Browser/Wpt/WptBrowserDiagnosticsTests.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserDiagnosticsTests.cs
@@ -1,0 +1,37 @@
+namespace Jint.Tests.Browser.Wpt;
+
+public sealed class WptBrowserDiagnosticsTests
+{
+    [Test]
+    public void ATimeoutRetainsItsVerdictAndReportsPartialProgress()
+    {
+        var collector = new WptBrowserCollector();
+        collector.Add("""{"kind":"result","name":"finished assertion","status":0,"message":""}""", "loading", scriptActive: true);
+        collector.Add("""{"kind":"completion","status":2,"message":"","count":1}""", "loading", scriptActive: true);
+
+        var outcome = collector.Outcome(budgetFailure: null);
+        outcome.HarnessError.Should().Be("the harness reported TIMEOUT: ");
+        outcome.Results.Should().BeEmpty("a partial report must not become a successful census measurement");
+        var progress = collector.DescribeProgress();
+        progress.Should().Contain("results=1;")
+            .And.Contain("lastReportReadyState=loading;")
+            .And.Contain("lastReportScriptActive=True")
+            .And.NotContain("unreported");
+    }
+
+    [Test]
+    public void NoReportIsDistinguishedFromACompletedEmptyReport()
+    {
+        var collector = new WptBrowserCollector();
+        collector.DescribeProgress().Should().Contain("firstResultMs=unreported;")
+            .And.Contain("completionMs=unreported;");
+
+        collector.Add("""{"kind":"completion","status":0,"message":"","count":0}""", "complete");
+
+        collector.Outcome(budgetFailure: null).HarnessError.Should().BeNull();
+        collector.DescribeProgress().Should().Contain("firstResultMs=unreported;")
+            .And.NotContain("completionMs=unreported;")
+            .And.Contain("lastReportReadyState=complete;")
+            .And.Contain("lastReportScriptActive=False");
+    }
+}

--- a/Jint.Tests.Browser/Wpt/WptBrowserHarness.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserHarness.cs
@@ -152,6 +152,7 @@ internal sealed class WptBrowserHarness : IDisposable
     internal async Task<WptBrowserOutcome> RunAsync(string path)
     {
         var collector = new WptBrowserCollector();
+        var diagnostics = new WptBrowserDiagnostics();
 
         var context = await _browser.NewContextAsync(new BrowserContextOptions
         {
@@ -172,6 +173,11 @@ internal sealed class WptBrowserHarness : IDisposable
                 // outcome comes back through — so the census sees the whole lane whatever the theory then
                 // asserts, and a file the theories already ran is tallied rather than run a second time.
                 var outcome = await RunAsync(page, collector, path).ConfigureAwait(false);
+                if (outcome.HarnessError is { } failure)
+                {
+                    outcome = WptBrowserOutcome.Failed(failure + diagnostics.Describe(page, collector));
+                }
+
                 WptBrowserCensus.Record(path, outcome);
                 WptBrowserCauses.Record(path, outcome);
                 return outcome;
@@ -332,14 +338,16 @@ internal sealed class WptBrowserHarness : IDisposable
     /// Routes one posted report to the page whose engine posted it.
     /// </summary>
     /// <remarks>
-    /// Called on that page's own loop thread, from inside whatever turn the harness reported in. It touches
-    /// nothing of the engine's: the payload is already a string, and the collector it lands in is the driver's.
+    /// Called on that page's own loop thread, from inside whatever turn the harness reported in. The payload
+    /// is already a string; the only additional reads are the runtime's native readiness and script flags.
     /// </remarks>
     private void Report(Engine engine, string json)
     {
-        if (PageRuntime.Find(engine)?.Page is { } page && _collectors.TryGetValue(page, out var collector))
+        if (PageRuntime.Find(engine) is { Page: { } page } runtime && _collectors.TryGetValue(page, out var collector))
         {
-            collector.Add(json);
+            // Copy only native state on its owning loop. Do not evaluate script-visible getters or retain
+            // a runtime/node for the test thread to inspect after a timeout.
+            collector.Add(json, runtime.ReadyState, runtime.CurrentScript is not null);
         }
     }
 
@@ -392,6 +400,12 @@ internal sealed class WptBrowserCollector
     private volatile bool _complete;
     private int _harnessStatus;
     private string _harnessMessage = "";
+    private readonly long _started = Stopwatch.GetTimestamp();
+    private long _firstResult;
+    private long _lastResult;
+    private long _completion;
+    private string _readyState = "unreported";
+    private bool _scriptActive;
 
     /// <summary>Whether the harness has run its completion callback.</summary>
     internal bool IsComplete => _complete;
@@ -408,7 +422,7 @@ internal sealed class WptBrowserCollector
         }
     }
 
-    internal void Add(string json)
+    internal void Add(string json, string readyState = "unreported", bool scriptActive = false)
     {
         using var document = JsonDocument.Parse(json);
         var root = document.RootElement;
@@ -423,17 +437,46 @@ internal sealed class WptBrowserCollector
             lock (_gate)
             {
                 _results.Add(result);
+                var now = Stopwatch.GetTimestamp();
+                if (_firstResult == 0)
+                {
+                    _firstResult = now;
+                }
+
+                _lastResult = now;
+                _readyState = readyState;
+                _scriptActive = scriptActive;
             }
 
             return;
         }
 
-        _harnessStatus = root.GetProperty("status").GetInt32();
-        _harnessMessage = root.GetProperty("message").GetString() ?? "";
+        lock (_gate)
+        {
+            _harnessStatus = root.GetProperty("status").GetInt32();
+            _harnessMessage = root.GetProperty("message").GetString() ?? "";
+            _completion = Stopwatch.GetTimestamp();
+            _readyState = readyState;
+            _scriptActive = scriptActive;
+        }
 
-        // Last, and after the two fields it publishes: the test thread reads them the moment this turns true.
+        // Last, after the fields it publishes: the test thread reads them the moment this turns true.
         _complete = true;
     }
+
+    /// <summary>A failure-only rendering; callback work is limited to timestamps and native scalar fields.</summary>
+    internal string DescribeProgress()
+    {
+        lock (_gate)
+        {
+            return FormattableString.Invariant(
+                $"results={_results.Count}; firstResultMs={Elapsed(_firstResult)}; lastResultMs={Elapsed(_lastResult)}; completionMs={Elapsed(_completion)}; lastReportReadyState={_readyState}; lastReportScriptActive={_scriptActive}");
+        }
+    }
+
+    private string Elapsed(long timestamp) => timestamp == 0
+        ? "unreported"
+        : Stopwatch.GetElapsedTime(_started, timestamp).TotalMilliseconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
 
     /// <summary>
     /// What the file produced. <paramref name="budgetFailure"/> is a harness error the harness itself could


### PR DESCRIPTION
Browser WPT timeouts currently discard the partial result count and execution state, leaving too little evidence to diagnose #3947. Add failure-only summaries with first/last-result and completion timings, native document readiness and script activity, process CPU/GC counters, thread-pool state, and request status counts.

The callbacks copy native scalar values on the owning page loop. Corpus bytes, harness deadlines, scheduling, exclusions, and verdicts are unchanged; process counters are labeled as process-wide rather than page measurements. This supplies evidence for #3947 and does not claim to fix its timeouts.

Validation: Release on SDK 10.0.400, net8.0 and net10.0; focused diagnostics, census, and Range selection passed 23 tests on each framework, with one optional census test skipped.
