### PR TITLE
Let a fetch observer read the body of the response it answers

### DIFF
--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net10.0.verified.txt
@@ -3110,6 +3110,7 @@ namespace Jint.WebApi.Fetch
         public virtual void OnCompleted(Jint.WebApi.Fetch.FetchRequestId id, long bodyLength) { }
         public virtual void OnData(Jint.WebApi.Fetch.FetchRequestId id, System.ReadOnlySpan<byte> chunk) { }
         public virtual void OnFailed(Jint.WebApi.Fetch.FetchRequestId id, string reason, System.Exception? exception) { }
+        public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchResponseInterception?> OnInterceptedResponseAsync(Jint.WebApi.Fetch.FetchResponseInterceptionContext context, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchInterception?> OnRequestAsync(Jint.WebApi.Fetch.ObservedFetchRequest request, System.Threading.CancellationToken cancellationToken) { }
         public virtual void OnResponse(Jint.WebApi.Fetch.ObservedFetchResponse response) { }
         public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchResponseInterception?> OnResponseAsync(Jint.WebApi.Fetch.ObservedFetchResponse response, System.Threading.CancellationToken cancellationToken) { }
@@ -3127,12 +3128,23 @@ namespace Jint.WebApi.Fetch
         public static Jint.WebApi.Fetch.FetchResponseInterception Fail(string reason) { }
         public static Jint.WebApi.Fetch.FetchResponseInterception Fulfill(int status, System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader>? headers = null, System.ReadOnlyMemory<byte> body = default, string? statusText = null) { }
     }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class FetchResponseInterceptionContext
+    {
+        public Jint.WebApi.Fetch.ObservedFetchResponse Response { get; }
+        public System.Threading.Tasks.ValueTask<System.ReadOnlyMemory<byte>?> TryReadBodyAsync(Jint.WebApi.Fetch.IFetchResponseBodyBudget budget, System.Threading.CancellationToken cancellationToken) { }
+    }
     public readonly struct FetchTiming : System.IEquatable<Jint.WebApi.Fetch.FetchTiming>
     {
         public FetchTiming(System.DateTimeOffset SentAt, System.TimeSpan TimeToHeaders) { }
         public System.DateTimeOffset HeadersAt { get; }
         public System.DateTimeOffset SentAt { get; init; }
         public System.TimeSpan TimeToHeaders { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public interface IFetchResponseBodyBudget
+    {
+        bool TryReserve(int bytes, out System.IDisposable? lease);
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class ObservedFetchAuthChallenge : System.IEquatable<Jint.WebApi.Fetch.ObservedFetchAuthChallenge>

--- a/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
+++ b/Jint.Tests.PublicInterface/Verify/PublicApiTest_net8.0.verified.txt
@@ -3110,6 +3110,7 @@ namespace Jint.WebApi.Fetch
         public virtual void OnCompleted(Jint.WebApi.Fetch.FetchRequestId id, long bodyLength) { }
         public virtual void OnData(Jint.WebApi.Fetch.FetchRequestId id, System.ReadOnlySpan<byte> chunk) { }
         public virtual void OnFailed(Jint.WebApi.Fetch.FetchRequestId id, string reason, System.Exception? exception) { }
+        public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchResponseInterception?> OnInterceptedResponseAsync(Jint.WebApi.Fetch.FetchResponseInterceptionContext context, System.Threading.CancellationToken cancellationToken) { }
         public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchInterception?> OnRequestAsync(Jint.WebApi.Fetch.ObservedFetchRequest request, System.Threading.CancellationToken cancellationToken) { }
         public virtual void OnResponse(Jint.WebApi.Fetch.ObservedFetchResponse response) { }
         public virtual System.Threading.Tasks.ValueTask<Jint.WebApi.Fetch.FetchResponseInterception?> OnResponseAsync(Jint.WebApi.Fetch.ObservedFetchResponse response, System.Threading.CancellationToken cancellationToken) { }
@@ -3127,12 +3128,23 @@ namespace Jint.WebApi.Fetch
         public static Jint.WebApi.Fetch.FetchResponseInterception Fail(string reason) { }
         public static Jint.WebApi.Fetch.FetchResponseInterception Fulfill(int status, System.Collections.Generic.IReadOnlyList<Jint.WebApi.Fetch.FetchHeader>? headers = null, System.ReadOnlyMemory<byte> body = default, string? statusText = null) { }
     }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public sealed class FetchResponseInterceptionContext
+    {
+        public Jint.WebApi.Fetch.ObservedFetchResponse Response { get; }
+        public System.Threading.Tasks.ValueTask<System.ReadOnlyMemory<byte>?> TryReadBodyAsync(Jint.WebApi.Fetch.IFetchResponseBodyBudget budget, System.Threading.CancellationToken cancellationToken) { }
+    }
     public readonly struct FetchTiming : System.IEquatable<Jint.WebApi.Fetch.FetchTiming>
     {
         public FetchTiming(System.DateTimeOffset SentAt, System.TimeSpan TimeToHeaders) { }
         public System.DateTimeOffset HeadersAt { get; }
         public System.DateTimeOffset SentAt { get; init; }
         public System.TimeSpan TimeToHeaders { get; init; }
+    }
+    [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
+    public interface IFetchResponseBodyBudget
+    {
+        bool TryReserve(int bytes, out System.IDisposable? lease);
     }
     [System.Diagnostics.CodeAnalysis.Experimental("JINT0002")]
     public sealed class ObservedFetchAuthChallenge : System.IEquatable<Jint.WebApi.Fetch.ObservedFetchAuthChallenge>

--- a/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchDocumentTests.cs
@@ -1104,6 +1104,10 @@ public class WebApiFetchDocumentTests
             typeof(FetchInterception), typeof(FetchResponseInterception), typeof(FetchRequestId),
             typeof(FetchHeader), typeof(FetchTiming),
 
+            // The body read is the one callback argument owning bytes off the socket, so it takes the same
+            // walk: what a protocol layer holds while a response is paused may not be a page's value.
+            typeof(FetchResponseInterceptionContext), typeof(IFetchResponseBodyBudget),
+
             // The socket seam is a second observer with the same rule, so it takes the same walk.
             typeof(Jint.WebApi.WebSockets.WebSocketObserver), typeof(Jint.WebApi.WebSockets.WebSocketId),
             typeof(Jint.WebApi.WebSockets.ObservedWebSocketHandshake), typeof(Jint.WebApi.WebSockets.ObservedWebSocketResponse),

--- a/Jint.Tests.PublicInterface/WebApiFetchResponseBodyTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchResponseBodyTests.cs
@@ -482,6 +482,33 @@ public class WebApiFetchResponseBodyTests
 
     // ---- a body that lies, fails or is cancelled ----
 
+    [Test]
+    public void AKnownLengthBodyChargesAboutItsOwnSizeAndNotAWholeStep()
+    {
+        // The declared length may only make the first reservation smaller. A small body charging a whole
+        // growth step of a shared allowance is a sibling refused for no reason.
+        var bytes = Pattern(40);
+        var allowance = new Allowance(1 << 20);
+        var observer = new Reader { Budget = allowance };
+
+        using var handler = new StubHandler(() =>
+        {
+            var response = Body(bytes);
+            response.Content.Headers.ContentLength = bytes.Length;
+            return response;
+        });
+
+        var engine = WebEngine(handler, observer);
+
+        engine.Evaluate("fetch('https://example.org/a').then(r => r.arrayBuffer()).then(b => b.byteLength)")
+            .UnwrapIfPromise(TransportSignalCeiling)
+            .AsNumber().Should().Be(40);
+
+        observer.Bodies[0].Should().Equal(bytes);
+        allowance.Peak.Should().Be(41, "the declared length plus the one byte that finds its end");
+        allowance.Used.Should().Be(0);
+    }
+
     [TestCase(1_000L)]
     [TestCase(3L)]
     public void ADeceptiveContentLengthChangesNeitherWhatIsReadNorWhatIsSpent(long declared)

--- a/Jint.Tests.PublicInterface/WebApiFetchResponseBodyTests.cs
+++ b/Jint.Tests.PublicInterface/WebApiFetchResponseBodyTests.cs
@@ -1,0 +1,748 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+#pragma warning disable JINT0002 // the fetch observer is a preview surface; this suite is what pins its shape
+
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint;
+using Jint.WebApi.Fetch;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The one capability a response-stage pause needs that metadata cannot give it: reading the body before the
+/// caller does, against an allowance the host owns, without the caller ever noticing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This project has no <c>InternalsVisibleTo</c>, so everything here is reachable by a third party — which is
+/// the point: <c>Fetch.getResponseBody</c> is implemented on top of exactly this surface and nothing else.
+/// </para>
+/// <para>
+/// <b>Every test asserts both halves.</b> What the observer got, and what the script got. A read that
+/// succeeded, one the budget refused and one that failed must all leave the page receiving every original
+/// byte exactly once, because a body read is a debugging capability and a page is not a debugger.
+/// </para>
+/// </remarks>
+public class WebApiFetchResponseBodyTests
+{
+    private static readonly TimeSpan TransportSignalCeiling = TimeSpan.FromMinutes(2);
+
+    // ---- harness ----
+
+    /// <summary>An allowance with a ceiling, counting what it granted and what it refused.</summary>
+    private sealed class Allowance : IFetchResponseBodyBudget
+    {
+        private readonly long _max;
+        private readonly object _gate = new();
+        private long _used;
+
+        internal Allowance(long max) => _max = max;
+
+        internal long Used
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _used;
+                }
+            }
+        }
+
+        internal long Peak { get; private set; }
+
+        internal int Grants { get; private set; }
+
+        internal int Refusals { get; private set; }
+
+        public bool TryReserve(int bytes, out IDisposable? lease)
+        {
+            lock (_gate)
+            {
+                if (bytes < 0 || _used + bytes > _max)
+                {
+                    Refusals++;
+                    lease = null;
+                    return false;
+                }
+
+                _used += bytes;
+                Peak = Math.Max(Peak, _used);
+                Grants++;
+                lease = new Lease(this, bytes);
+                return true;
+            }
+        }
+
+        private void Release(int bytes)
+        {
+            lock (_gate)
+            {
+                _used -= bytes;
+            }
+        }
+
+        private sealed class Lease(Allowance allowance, int bytes) : IDisposable
+        {
+            private int _disposed;
+
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                {
+                    allowance.Release(bytes);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// A body that arrives in fixed-size pieces, optionally failing part-way and optionally telling the test
+    /// how far it has got — which is how a cancellation is armed mid-read.
+    /// </summary>
+    private sealed class ScriptedStream : Stream
+    {
+        private readonly byte[] _bytes;
+        private readonly int _chunk;
+        private readonly int _failAt;
+        private readonly Action<int>? _reached;
+        private readonly bool _deferred;
+        private int _position;
+
+        internal ScriptedStream(byte[] bytes, int chunk = int.MaxValue, int failAt = -1, Action<int>? reached = null, bool deferred = false)
+        {
+            _bytes = bytes;
+            _chunk = chunk;
+            _failAt = failAt;
+            _reached = reached;
+            _deferred = deferred;
+        }
+
+        internal int Reads { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            Reads++;
+
+            if (_failAt >= 0 && _position >= _failAt)
+            {
+                throw new IOException("the response ended prematurely");
+            }
+
+            var count = Math.Min(Math.Min(buffer.Length, _chunk), _bytes.Length - _position);
+            if (count <= 0)
+            {
+                return 0;
+            }
+
+            _bytes.AsSpan(_position, count).CopyTo(buffer);
+            _position += count;
+            _reached?.Invoke(_position);
+            return count;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (_deferred)
+            {
+                // Nothing completes synchronously, which is what lets a test start a second read while the
+                // first is genuinely still in flight.
+                await Task.Yield();
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return Read(buffer.Span);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>An observer that reads the body a given number of times and then answers.</summary>
+    private sealed class Reader : FetchObserver
+    {
+        internal IFetchResponseBodyBudget? Budget { get; init; }
+
+        internal int Reads { get; init; } = 1;
+
+        internal Func<FetchResponseInterceptionContext, FetchResponseInterception?>? Answer { get; init; }
+
+        internal CancellationToken ReadToken { get; init; }
+
+        internal List<byte[]?> Bodies { get; } = [];
+
+        internal List<ReadOnlyMemory<byte>?> Memories { get; } = [];
+
+        internal Exception? Failure { get; private set; }
+
+        internal FetchResponseInterceptionContext? Context { get; private set; }
+
+        public override async ValueTask<FetchResponseInterception?> OnInterceptedResponseAsync(
+            FetchResponseInterceptionContext context,
+            CancellationToken cancellationToken)
+        {
+            Context = context;
+
+            if (Budget is { } budget)
+            {
+                var token = ReadToken.CanBeCanceled ? ReadToken : cancellationToken;
+
+                for (var i = 0; i < Reads; i++)
+                {
+                    try
+                    {
+                        var body = await context.TryReadBodyAsync(budget, token).ConfigureAwait(false);
+                        Memories.Add(body);
+                        Bodies.Add(body?.ToArray());
+                    }
+#pragma warning disable CA1031 // the test is the thing that decides what a read failure means
+                    catch (Exception exception)
+#pragma warning restore CA1031
+                    {
+                        Failure ??= exception;
+                        break;
+                    }
+                }
+            }
+
+            return Answer?.Invoke(context);
+        }
+    }
+
+    /// <summary>An observer that overrides only the metadata callback, i.e. every observer written so far.</summary>
+    private sealed class MetadataOnly : FetchObserver
+    {
+        internal int Asks { get; private set; }
+
+        internal Func<ObservedFetchResponse, FetchResponseInterception?>? Answer { get; init; }
+
+        public override ValueTask<FetchResponseInterception?> OnResponseAsync(
+            ObservedFetchResponse response,
+            CancellationToken cancellationToken)
+        {
+            Asks++;
+            return new ValueTask<FetchResponseInterception?>(Answer?.Invoke(response));
+        }
+    }
+
+    private sealed class StubHandler(Func<HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(responder());
+    }
+
+    private static HttpResponseMessage Body(
+        byte[] bytes,
+        int chunk = int.MaxValue,
+        long? contentLength = null,
+        int failAt = -1,
+        Action<int>? reached = null,
+        bool deferred = false)
+    {
+        var content = new StreamContent(new ScriptedStream(bytes, chunk, failAt, reached, deferred));
+        content.Headers.TryAddWithoutValidation("content-type", "application/octet-stream");
+
+        if (contentLength is { } length)
+        {
+            content.Headers.TryAddWithoutValidation("content-length", length.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    private static Engine WebEngine(HttpMessageHandler handler, FetchObserver? observer)
+        => new(options => options.UseWebApis(WebApiFeatures.Timers).UseFetch(fetch =>
+        {
+            fetch.HttpClient = new HttpClient(handler);
+            fetch.Observer = observer;
+        }));
+
+    /// <summary>Runs one fetch and answers what the script saw of the body, as a latin-1 string of bytes.</summary>
+    private static string FetchBytes(HttpResponseMessage response, FetchObserver? observer, string expression = "r.arrayBuffer()")
+    {
+        using var handler = new StubHandler(() => response);
+        var engine = WebEngine(handler, observer);
+
+        return engine.Evaluate($$"""
+            fetch('https://example.org/a')
+                .then(r => {{expression}})
+                .then(b => Array.from(new Uint8Array(b)).join(','), e => 'rejected:' + e.constructor.name)
+            """)
+            .UnwrapIfPromise(TransportSignalCeiling)
+            .AsString();
+    }
+
+    private static string Joined(byte[] bytes) => string.Join(",", bytes);
+
+    private static byte[] Pattern(int length)
+    {
+        var bytes = new byte[length];
+        for (var i = 0; i < length; i++)
+        {
+            bytes[i] = (byte) ((i * 7) % 251);
+        }
+
+        return bytes;
+    }
+
+    // ---- reading ----
+
+    [Test]
+    public void AnEmptyBodyIsReadAsANonNullEmptyValue()
+    {
+        var allowance = new Allowance(1024);
+        var observer = new Reader { Budget = allowance };
+
+        FetchBytes(Body([]), observer).Should().BeEmpty();
+
+        observer.Bodies.Should().ContainSingle();
+        observer.Bodies[0].Should().NotBeNull().And.BeEmpty();
+        observer.Failure.Should().BeNull();
+        allowance.Used.Should().Be(0, "every lease is released once the response has been delivered");
+    }
+
+    [Test]
+    public void ATextBodyIsReadWholeAndThePageStillReceivesIt()
+    {
+        var bytes = Encoding.UTF8.GetBytes("héllo — wörld");
+        var allowance = new Allowance(1024);
+        var observer = new Reader { Budget = allowance };
+
+        FetchBytes(Body(bytes), observer).Should().Be(Joined(bytes));
+
+        observer.Bodies[0].Should().Equal(bytes);
+        allowance.Used.Should().Be(0);
+    }
+
+    [Test]
+    public void ABinaryBodyIsReadByteForByte()
+    {
+        // Every byte value, including the ones a charset would mangle: the read is bytes and stays bytes.
+        var bytes = new byte[256];
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = (byte) i;
+        }
+
+        var observer = new Reader { Budget = new Allowance(4096) };
+
+        FetchBytes(Body(bytes, chunk: 17), observer).Should().Be(Joined(bytes));
+        observer.Bodies[0].Should().Equal(bytes);
+    }
+
+    [Test]
+    public void AnUnknownLengthChunkedBodyIsReadWhole()
+    {
+        var bytes = Pattern(20_000);
+        var response = Body(bytes, chunk: 1_000);
+        response.Content.Headers.ContentLength.Should().BeNull("the test body must be unknown-length");
+
+        var allowance = new Allowance(1 << 20);
+        var observer = new Reader { Budget = allowance };
+
+        FetchBytes(response, observer).Should().Be(Joined(bytes));
+        observer.Bodies[0].Should().Equal(bytes);
+        allowance.Used.Should().Be(0);
+    }
+
+    [Test]
+    public void ARepeatedReadAnswersTheSameMemoryWithoutTouchingTheSocketAgain()
+    {
+        var bytes = Pattern(64);
+        var observer = new Reader { Budget = new Allowance(4096), Reads = 3 };
+
+        FetchBytes(Body(bytes), observer).Should().Be(Joined(bytes));
+
+        observer.Bodies.Should().HaveCount(3);
+        observer.Bodies[1].Should().Equal(bytes);
+        observer.Bodies[2].Should().Equal(bytes);
+        observer.Memories[0]!.Value.Equals(observer.Memories[1]!.Value).Should().BeTrue("the body is immutable and reused");
+        observer.Memories[1]!.Value.Equals(observer.Memories[2]!.Value).Should().BeTrue();
+    }
+
+    // ---- the allowance ----
+
+    [Test]
+    public void ABodyExactlyAtTheAllowanceIsRead()
+    {
+        // The case an unknown-length body cannot answer without one byte of lookahead: the buffer is full and
+        // the allowance is spent, and the body has nevertheless ended.
+        var bytes = Pattern(24);
+        var allowance = new Allowance(24);
+        var observer = new Reader { Budget = allowance };
+
+        FetchBytes(Body(bytes, chunk: 5), observer).Should().Be(Joined(bytes));
+
+        observer.Bodies[0].Should().Equal(bytes);
+        observer.Failure.Should().BeNull();
+        allowance.Peak.Should().Be(24);
+        allowance.Used.Should().Be(0);
+    }
+
+    [Test]
+    public void ABodyOneByteOverTheAllowanceIsRefusedAndThePageStillReceivesEveryByte()
+    {
+        var bytes = Pattern(25);
+        var allowance = new Allowance(24);
+        var observer = new Reader { Budget = allowance };
+
+        FetchBytes(Body(bytes, chunk: 5), observer).Should().Be(Joined(bytes), "a refusal must be invisible to the page");
+
+        observer.Bodies.Should().ContainSingle();
+        observer.Bodies[0].Should().BeNull("null is what a refusal answers");
+        observer.Failure.Should().BeNull();
+        allowance.Refusals.Should().BeGreaterThan(0);
+        allowance.Peak.Should().BeLessThanOrEqualTo(24);
+        allowance.Used.Should().Be(0);
+    }
+
+    [Test]
+    public void ARefusalIsStickyForThatResponse()
+    {
+        var bytes = Pattern(25);
+        var allowance = new Allowance(24);
+        var observer = new Reader { Budget = allowance, Reads = 3 };
+
+        FetchBytes(Body(bytes, chunk: 5), observer).Should().Be(Joined(bytes));
+
+        observer.Bodies.Should().HaveCount(3);
+        observer.Bodies.Should().AllSatisfy(body => body.Should().BeNull());
+
+        // The later reads answered from the refusal, not from the socket: nothing more was ever asked for.
+        allowance.Peak.Should().BeLessThanOrEqualTo(24);
+    }
+
+    [Test]
+    public void AZeroAllowanceRefusesEveryBodyButTheEmptyOne()
+    {
+        var allowance = new Allowance(0);
+
+        var refused = new Reader { Budget = allowance };
+        FetchBytes(Body("x"u8.ToArray()), refused).Should().Be("120");
+        refused.Bodies[0].Should().BeNull();
+
+        var empty = new Reader { Budget = allowance };
+        FetchBytes(Body([]), empty).Should().BeEmpty();
+        empty.Bodies[0].Should().NotBeNull().And.BeEmpty("an empty body retains nothing, so nothing was refused");
+    }
+
+    [Test]
+    public void AnAllowanceAlreadySpentElsewhereRefusesTheReadAndIsGivenBackAfterwards()
+    {
+        // One ledger, many holders: what a sibling capture or a still-unfinished pause is holding is exactly
+        // what this read does not get, and it waits for none of them.
+        var bytes = Pattern(4_000);
+        var allowance = new Allowance(8_192);
+
+        allowance.TryReserve(8_000, out var held).Should().BeTrue();
+
+        var refused = new Reader { Budget = allowance };
+        FetchBytes(Body(bytes, chunk: 500), refused).Should().Be(Joined(bytes));
+        refused.Bodies[0].Should().BeNull("the allowance was spent by somebody else");
+
+        held!.Dispose();
+        allowance.Used.Should().Be(0);
+
+        var granted = new Reader { Budget = allowance };
+        FetchBytes(Body(bytes, chunk: 500), granted).Should().Be(Joined(bytes));
+        granted.Bodies[0].Should().Equal(bytes, "the same ledger admits the same body once the holder let go");
+        allowance.Used.Should().Be(0);
+    }
+
+    // ---- a body that lies, fails or is cancelled ----
+
+    [TestCase(1_000L)]
+    [TestCase(3L)]
+    public void ADeceptiveContentLengthChangesNeitherWhatIsReadNorWhatIsSpent(long declared)
+    {
+        // Content-Length is never trusted for sizing: the reservation follows the bytes that actually land.
+        var bytes = Pattern(40);
+        var allowance = new Allowance(4_096);
+        var observer = new Reader { Budget = allowance };
+
+        FetchBytes(Body(bytes, chunk: 9, contentLength: declared), observer).Should().Be(Joined(bytes));
+
+        observer.Bodies[0].Should().Equal(bytes);
+        allowance.Peak.Should().BeLessThanOrEqualTo(8 * 1024 + 1, "the growth is the reader's, not the header's");
+        allowance.Used.Should().Be(0);
+    }
+
+    [Test]
+    public void AReadThatFailsIsThrownRatherThanBecomingAShortBody()
+    {
+        var bytes = Pattern(4_000);
+        var allowance = new Allowance(1 << 20);
+        var observer = new Reader
+        {
+            Budget = allowance,
+
+            // Continue after the failure: the page then meets the same broken stream, and must be told so
+            // rather than handed the prefix as though it were the response.
+            Answer = _ => null,
+        };
+
+        FetchBytes(Body(bytes, chunk: 500, failAt: 1_500), observer)
+            .Should().Be("rejected:TypeError", "a failed transfer is a failed transfer on both sides");
+
+        observer.Failure.Should().BeOfType<IOException>();
+        observer.Bodies.Should().BeEmpty();
+        allowance.Used.Should().Be(0);
+    }
+
+    [Test]
+    public void ACancelledReadIsThrownAndThePageStillReceivesEveryByte()
+    {
+        var bytes = Pattern(4_000);
+        var allowance = new Allowance(1 << 20);
+        using var cancellation = new CancellationTokenSource();
+
+        var observer = new Reader { Budget = allowance, ReadToken = cancellation.Token };
+
+        // Cancel once the read is under way, so a prefix has been taken and has to be given back.
+        var response = Body(bytes, chunk: 500, reached: position =>
+        {
+            if (position >= 1_000)
+            {
+                cancellation.Cancel();
+            }
+        });
+
+        FetchBytes(response, observer).Should().Be(Joined(bytes), "the prefix is replayed ahead of the rest");
+
+        observer.Failure.Should().BeAssignableTo<OperationCanceledException>();
+        allowance.Used.Should().Be(0);
+    }
+
+    // ---- what the read does not change ----
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void AResponseNobodyReadsIsNotTouchedBeforeItsConsumerAsks(bool read)
+    {
+        // "Still streaming" stated as something a third party can see: with the headers in hand and nobody
+        // having asked for the body, not one byte has come off the socket unless the observer read it.
+        var bytes = Pattern(8_000);
+        var stream = new ScriptedStream(bytes, chunk: 500);
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(stream) };
+
+        var observer = new Reader { Budget = read ? new Allowance(1 << 20) : null };
+
+        using var handler = new StubHandler(() => response);
+        var engine = WebEngine(handler, observer);
+
+        engine.Evaluate("globalThis.held = null; fetch('https://example.org/a').then(r => { globalThis.held = r; return r.status; })")
+            .UnwrapIfPromise(TransportSignalCeiling)
+            .AsNumber().Should().Be(200);
+
+        observer.Context.Should().NotBeNull("the context is handed over whether or not it is used");
+        (stream.Reads == 0).Should().Be(!read, "only a body read takes bytes before the consumer asks for them");
+
+        engine.Evaluate("held.arrayBuffer().then(b => b.byteLength)")
+            .UnwrapIfPromise(TransportSignalCeiling)
+            .AsNumber().Should().Be(8_000, "the consumer still receives the whole body");
+    }
+
+    [Test]
+    public void AnObserverThatOnlyOverridesOnResponseAsyncIsUnaffected()
+    {
+        var bytes = Pattern(64);
+        var observer = new MetadataOnly();
+
+        FetchBytes(Body(bytes), observer).Should().Be(Joined(bytes));
+        observer.Asks.Should().Be(1, "the default forwards, so the existing override is still the one asked");
+    }
+
+    [Test]
+    public void AReadIsAvailableOnTheXmlHttpRequestLaneToo()
+    {
+        // The ask lives in the one place every lane passes through, so the lane that does not take fetch()'s
+        // buffered path reads exactly the same way.
+        var bytes = Encoding.UTF8.GetBytes("xhr body");
+        var allowance = new Allowance(1024);
+        var observer = new Reader { Budget = allowance };
+
+        using var handler = new StubHandler(() => Body(bytes));
+        var engine = new Engine(options => options
+            .UseWebApis(WebApiFeatures.Timers | WebApiFeatures.XmlHttpRequest)
+            .UseFetch(fetch =>
+            {
+                fetch.HttpClient = new HttpClient(handler);
+                fetch.Observer = observer;
+            }));
+
+        engine.Evaluate("""
+            (() => {
+                const x = new XMLHttpRequest();
+                x.open('GET', 'https://example.org/a', false);
+                x.send();
+                return x.responseText;
+            })()
+            """)
+            .AsString().Should().Be("xhr body");
+
+        observer.Bodies[0].Should().Equal(bytes);
+        allowance.Used.Should().Be(0);
+    }
+
+    [TestCase("fulfill")]
+    [TestCase("fail")]
+    public void AResponseNobodyWillReceiveReleasesWhatWasRead(string decision)
+    {
+        var bytes = Pattern(4_000);
+        var allowance = new Allowance(1 << 20);
+        var observer = new Reader
+        {
+            Budget = allowance,
+            Answer = _ => decision == "fulfill"
+                ? FetchResponseInterception.Fulfill(201, body: "substitute"u8.ToArray())
+                : FetchResponseInterception.Fail("no"),
+        };
+
+        var seen = FetchBytes(Body(bytes, chunk: 500), observer);
+
+        seen.Should().Be(decision == "fulfill" ? Joined("substitute"u8.ToArray()) : "rejected:TypeError");
+        observer.Bodies[0].Should().Equal(bytes);
+        allowance.Used.Should().Be(0, "the bytes were discarded rather than replayed");
+    }
+
+    [Test]
+    public void AContinuedResponseCarriesTheRewrittenHeadersOverTheReplay()
+    {
+        var bytes = Encoding.UTF8.GetBytes("continued");
+        var observer = new Reader
+        {
+            Budget = new Allowance(1024),
+            Answer = _ => FetchResponseInterception.Continue(
+                status: 203,
+                headers: [new FetchHeader("content-type", "text/plain; charset=utf-8"), new FetchHeader("x-mark", "1")]),
+        };
+
+        using var handler = new StubHandler(() => Body(bytes));
+        var engine = WebEngine(handler, observer);
+
+        engine.Evaluate("""
+            fetch('https://example.org/a')
+                .then(r => r.text().then(t => [r.status, r.headers.get('content-type'), r.headers.get('x-mark'), t].join('|')))
+            """)
+            .UnwrapIfPromise(TransportSignalCeiling)
+            .AsString().Should().Be("203|text/plain; charset=utf-8|1|continued");
+    }
+
+    // ---- the shape of the capability ----
+
+    [Test]
+    public void TheContextIsSealedOnceTheCallbackHasReturned()
+    {
+        var observer = new Reader { Budget = new Allowance(1024) };
+
+        FetchBytes(Body("abc"u8.ToArray()), observer).Should().Be("97,98,99");
+
+        var context = observer.Context;
+        context.Should().NotBeNull();
+
+        var caught = Caught.Exception(() => context!.TryReadBodyAsync(new Allowance(1024), CancellationToken.None).AsTask().GetAwaiter().GetResult());
+        caught.Should().BeOfType<InvalidOperationException>();
+    }
+
+    [Test]
+    public void ASecondReadInFlightAtOnceIsRefused()
+    {
+        var observer = new Concurrent();
+
+        FetchBytes(Body(Pattern(2_000), chunk: 100, deferred: true), observer).Should().Be(Joined(Pattern(2_000)));
+
+        observer.Second.Should().BeOfType<InvalidOperationException>();
+    }
+
+    /// <summary>Starts a second read without awaiting the first, which the per-response state must refuse.</summary>
+    private sealed class Concurrent : FetchObserver
+    {
+        internal Exception? Second { get; private set; }
+
+        public override async ValueTask<FetchResponseInterception?> OnInterceptedResponseAsync(
+            FetchResponseInterceptionContext context,
+            CancellationToken cancellationToken)
+        {
+            var allowance = new Allowance(1 << 20);
+            var first = context.TryReadBodyAsync(allowance, cancellationToken);
+
+            try
+            {
+                await context.TryReadBodyAsync(allowance, cancellationToken).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // the test is what decides what a concurrent read means
+            catch (Exception exception)
+#pragma warning restore CA1031
+            {
+                Second = exception;
+            }
+
+            await first.ConfigureAwait(false);
+            return null;
+        }
+    }
+
+    [Test]
+    public void TheBudgetIsRequired()
+    {
+        var observer = new NullBudget();
+
+        FetchBytes(Body("abc"u8.ToArray()), observer).Should().Be("97,98,99");
+        observer.Caught.Should().BeOfType<ArgumentNullException>();
+    }
+
+    private sealed class NullBudget : FetchObserver
+    {
+        internal Exception? Caught { get; private set; }
+
+        public override async ValueTask<FetchResponseInterception?> OnInterceptedResponseAsync(
+            FetchResponseInterceptionContext context,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                await context.TryReadBodyAsync(null!, cancellationToken).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // the test is what decides what a missing budget means
+            catch (Exception exception)
+#pragma warning restore CA1031
+            {
+                Caught = exception;
+            }
+
+            return null;
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/AGENTS.md
+++ b/Jint/WebApi/Fetch/AGENTS.md
@@ -109,3 +109,28 @@ the handshake response (`ClientWebSocket.CollectHttpResponseDetails`, turned on 
 watching), and one terminal close
 ([#3621](https://github.com/sebastienros/jint/issues/3621),
 [#3701](https://github.com/sebastienros/jint/issues/3701) item 2).
+
+**The body of the response that ends the chain can be read at the ask, and `AnswerResponseAsync` is the only
+frame that may own that.** `OnInterceptedResponseAsync` is the ask; its default forwards to
+`OnResponseAsync`, so every observer written before it keeps its behaviour and an observer overrides one or
+the other, never both. What crosses is `FetchResponseInterceptionContext` — never a `Stream`, because a
+stream handed out is the accounting this seam exists for, bypassed. `TryReadBodyAsync` charges
+`IFetchResponseBodyBudget` **before** each growth of its buffer, so nothing is retained that was not first
+granted, and it answers three ways that must stay distinct: non-null-empty is *an empty body was read*, null
+is *the budget refused it*, and a throw is *the transfer failed* — never a short body dressed as a complete
+one. **A refusal is sticky for that response**, because the prefix already taken is pinned and reading on
+would spend an allowance that has just said it has none.
+
+**Whatever a read took is replayed, and that is the invariant the whole capability rests on.** The read
+consumes the socket, so `AttachReplay` puts the prefix in front of the unread remainder (a `StreamContent`
+over `FetchReplayStream`, carrying the content headers the interception settled on) before anything else
+looks — on continue and on a plain `null` answer alike. `Fulfill` and `Fail` `Discard` instead, because
+nobody will receive those bytes. The leases follow the bytes: the replay stream releases them once the prefix
+has been handed over or the content is dropped unread, so the ledger is charged exactly while the memory
+exists. **One byte is deliberately outside that accounting**, and it is the lookahead: an unknown-length body
+whose size is exactly the allowance cannot be told from one byte longer without reading one more byte, so the
+buffer always keeps a slot past what was reserved and writes to it only on the refusal path — where the byte
+in it is one the caller must still receive. A read of a body that never ends (an `EventSource` stream) is
+bounded by `Options.WebApi.Fetch.Timeout` and by nothing else; the ask is per final response, so a host that
+maps this onto a protocol decides for itself which responses it is willing to read
+([#3828](https://github.com/sebastienros/jint/issues/3828)).

--- a/Jint/WebApi/Fetch/FetchObservation.cs
+++ b/Jint/WebApi/Fetch/FetchObservation.cs
@@ -75,8 +75,13 @@ internal sealed class FetchObservation
     /// Asks the observer what to do with the response that ends the chain. Like <see cref="RequestAsync"/>
     /// and unlike every notification here, a throw is <b>not</b> swallowed.
     /// </summary>
-    internal async Task<FetchResponseInterception?> ResponseAsync(ObservedFetchResponse response, CancellationToken cancellationToken)
-        => await _observer.OnResponseAsync(response, cancellationToken).ConfigureAwait(false);
+    /// <remarks>
+    /// The ask goes to <c>OnInterceptedResponseAsync</c>, whose default forwards to <c>OnResponseAsync</c>:
+    /// the context is what carries the body read, and an observer that never reads is unaffected by its
+    /// existing.
+    /// </remarks>
+    internal async Task<FetchResponseInterception?> ResponseAsync(FetchResponseInterceptionContext context, CancellationToken cancellationToken)
+        => await _observer.OnInterceptedResponseAsync(context, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asks the observer how to answer an authentication challenge. Like <see cref="RequestAsync"/> and

--- a/Jint/WebApi/Fetch/FetchObserver.cs
+++ b/Jint/WebApi/Fetch/FetchObserver.cs
@@ -626,6 +626,38 @@ public abstract class FetchObserver
         => new((FetchResponseInterception?) null);
 
     /// <summary>
+    /// Called instead of <see cref="OnResponseAsync"/>, with the one capability that needs the socket: the
+    /// response's body can be read here and nowhere else.
+    /// </summary>
+    /// <param name="context">The response, and the bounded body read.</param>
+    /// <param name="cancellationToken">Cancelled when the fetch is aborted or times out.</param>
+    /// <returns>What to do with the response, or <see langword="null"/> to leave it alone.</returns>
+    /// <remarks>
+    /// <para>
+    /// <b>The default forwards to <see cref="OnResponseAsync"/></b>, so an observer that overrides only that
+    /// one behaves exactly as it did: this is the same ask, reached through a richer argument. Override one
+    /// or the other, not both — an override here replaces the forward, and with it the other override.
+    /// </para>
+    /// <para>
+    /// <b>Reading is opt-in and costs nothing until it is asked for.</b> A response nobody reads is still
+    /// streamed to whoever asked for the resource, byte for byte; a response that is read is streamed from
+    /// the bytes this took plus the ones still coming. Either way the caller receives every original byte
+    /// exactly once, whether the read succeeded or the budget refused it.
+    /// </para>
+    /// <para>
+    /// Like <see cref="OnResponseAsync"/>, a throw here fails the fetch: this is a call that was asked to
+    /// decide. <paramref name="context"/> is sealed as soon as this returns.
+    /// </para>
+    /// </remarks>
+    public virtual ValueTask<FetchResponseInterception?> OnInterceptedResponseAsync(
+        FetchResponseInterceptionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return OnResponseAsync(context.Response, cancellationToken);
+    }
+
+    /// <summary>
     /// Called when a server answers a hop with <c>401</c> and an authentication challenge; answer
     /// <see langword="null"/> to leave the challenge alone and let the <c>401</c> be delivered.
     /// </summary>

--- a/Jint/WebApi/Fetch/FetchResponseBodyRead.cs
+++ b/Jint/WebApi/Fetch/FetchResponseBodyRead.cs
@@ -172,7 +172,7 @@ public sealed class FetchResponseInterceptionContext
             {
                 if (_length == _reserved)
                 {
-                    var desired = _reserved == 0 ? InitialChunk : Math.Max(_reserved, InitialChunk);
+                    var desired = _reserved == 0 ? FirstChunk() : Math.Max(_reserved, InitialChunk);
                     if (!Grow(budget, desired))
                     {
                         // The allowance is spent with the buffer exactly full, which is the one state that
@@ -203,6 +203,21 @@ public sealed class FetchResponseInterceptionContext
         {
             Volatile.Write(ref _reading, 0);
         }
+    }
+
+    /// <summary>How much the first reservation asks for.</summary>
+    /// <remarks>
+    /// <b><c>Content-Length</c> is a hint that may only make it smaller.</b> A declared length above the
+    /// default step is ignored, so a header that lies upwards cannot reserve memory the body will never fill;
+    /// one that lies downwards costs another growth step and nothing else. What it buys is that a small body
+    /// stops charging a whole step of somebody else's allowance — a twelve-byte response reserving eight
+    /// kilobytes is a sibling refused for no reason. The extra byte is the one a body of exactly the declared
+    /// length needs to reach its end without a second reservation.
+    /// </remarks>
+    private int FirstChunk()
+    {
+        var declared = _message.Content.Headers.ContentLength;
+        return declared is >= 0 and < InitialChunk ? (int) declared.Value + 1 : InitialChunk;
     }
 
     /// <summary>The single slot beyond the reservation, which exists only so that a full buffer can ask.</summary>

--- a/Jint/WebApi/Fetch/FetchResponseBodyRead.cs
+++ b/Jint/WebApi/Fetch/FetchResponseBodyRead.cs
@@ -1,0 +1,466 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// The memory allowance a paused response's body is read against, owned by the host rather than by Jint.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Engine-free and thread-safe.</b> Every call comes from a transport thread while the fetch is waiting,
+/// so an implementation may touch no <c>Engine</c>, no <c>JsValue</c> and no realm, and two requests may
+/// reserve against the same instance at once.
+/// </para>
+/// <para>
+/// <b>Reservations cover backing capacity, not the body's final length.</b> The reader grows a buffer and
+/// charges each growth before any byte lands in it, so an implementation is told how much memory is about to
+/// exist rather than how much of it turned out to be body.
+/// </para>
+/// <para>
+/// The shape of this interface is a preview and is declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>.
+/// </para>
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public interface IFetchResponseBodyBudget
+{
+    /// <summary>
+    /// Reserves <paramref name="bytes"/> bytes, all or nothing, and answers whether the allowance had room.
+    /// </summary>
+    /// <param name="bytes">How many bytes are about to be allocated. Never negative.</param>
+    /// <param name="lease">
+    /// What releases the reservation, or <see langword="null"/> when the implementation needs nothing
+    /// released. Disposed exactly once, by Jint, when the bytes are discarded or replayed to the caller.
+    /// </param>
+    /// <returns><see langword="true"/> when the reservation was granted.</returns>
+    /// <remarks>
+    /// Refusing is ordinary rather than exceptional: the reader asks for progressively smaller amounts and
+    /// treats a refusal of one byte as "the allowance is spent". A <see langword="true"/> answer with a
+    /// <see langword="null"/> lease is a grant that costs nothing to release.
+    /// </remarks>
+    bool TryReserve(int bytes, out IDisposable? lease);
+}
+
+/// <summary>
+/// The response that ends a chain, plus the one capability that needs the socket: reading its body while the
+/// fetch is held at the response stage.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is valid only for the duration of the callback it is handed to.</b> Jint seals it as soon as
+/// <see cref="FetchObserver.OnInterceptedResponseAsync"/> returns, and every read afterwards throws: the
+/// exchange behind it may already have been disposed, substituted or handed to whoever asked for the
+/// resource.
+/// </para>
+/// <para>
+/// <b>No <see cref="Stream"/> crosses this surface.</b> A read either answers immutable bytes the caller may
+/// hold for the rest of the callback, or answers <see langword="null"/> because the budget refused them —
+/// which is the whole reason the budget is a parameter rather than an ambient setting.
+/// </para>
+/// <para>
+/// <b>Whatever was read is still delivered.</b> Bytes taken off the socket here are replayed ahead of the
+/// unread remainder when the response is delivered, so the caller receives every original byte exactly once
+/// whether the read succeeded, was refused, or was never made.
+/// </para>
+/// <para>
+/// The shape of this class is a preview and is declared to the compiler as <c>JINT0002</c>; see
+/// <see cref="JintDiagnosticIds"/>.
+/// </para>
+/// </remarks>
+[Experimental(JintDiagnosticIds.PreviewDiagnostic)]
+public sealed class FetchResponseInterceptionContext
+{
+    /// <summary>The first growth, and the floor every later one is measured from.</summary>
+    private const int InitialChunk = 8 * 1024;
+
+    private readonly HttpResponseMessage _message;
+    private List<IDisposable>? _leases;
+
+    /// <summary>
+    /// The retained prefix. Always one byte longer than <see cref="_reserved"/>: that last slot is the
+    /// lookahead an unknown-length body needs to tell "exactly at the limit" from "over it".
+    /// </summary>
+    private byte[]? _buffer;
+
+    private int _length;
+    private int _reserved;
+    private Stream? _stream;
+    private ReadOnlyMemory<byte>? _body;
+    private bool _refused;
+    private bool _sealed;
+    private int _reading;
+
+    internal FetchResponseInterceptionContext(ObservedFetchResponse response, HttpResponseMessage message)
+    {
+        Response = response;
+        _message = message;
+    }
+
+    /// <summary>Gets the response that ends the chain, exactly as <c>OnResponseAsync</c> is given it.</summary>
+    public ObservedFetchResponse Response { get; }
+
+    /// <summary>
+    /// Reads the complete response body into memory, charging every byte to <paramref name="budget"/> first.
+    /// </summary>
+    /// <param name="budget">The allowance the bytes are charged to.</param>
+    /// <param name="cancellationToken">Cancelled when the fetch is aborted or times out.</param>
+    /// <returns>
+    /// The whole body — a non-null empty value when the body was empty — or <see langword="null"/> when
+    /// <paramref name="budget"/> refused it.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// <b>A refusal is sticky.</b> Once this has answered <see langword="null"/> for a response, every later
+    /// read of that response answers <see langword="null"/> without touching the socket again: the prefix
+    /// already taken stays pinned and reading on would spend an allowance that has just said it has none.
+    /// </para>
+    /// <para>
+    /// <b>A success is immutable and reused.</b> The same memory is answered by every later read, and it
+    /// stays valid until the callback returns.
+    /// </para>
+    /// <para>
+    /// <b>A failure is a failure.</b> A socket error or a cancellation is thrown rather than becoming a
+    /// short body: a partial read must never be mistaken for a complete one. Whatever had been read is still
+    /// replayed to the caller.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="budget"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The callback has returned, or another read of this response is already in flight.
+    /// </exception>
+    public ValueTask<ReadOnlyMemory<byte>?> TryReadBodyAsync(IFetchResponseBodyBudget budget, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(budget);
+
+        if (_sealed)
+        {
+            throw new InvalidOperationException("The response body can only be read while the response callback is running.");
+        }
+
+        if (Interlocked.Exchange(ref _reading, 1) != 0)
+        {
+            throw new InvalidOperationException("Another read of this response body is already in flight.");
+        }
+
+        if (_body is { } cached)
+        {
+            Volatile.Write(ref _reading, 0);
+            return new ValueTask<ReadOnlyMemory<byte>?>(cached);
+        }
+
+        if (_refused)
+        {
+            Volatile.Write(ref _reading, 0);
+            return new ValueTask<ReadOnlyMemory<byte>?>((ReadOnlyMemory<byte>?) null);
+        }
+
+        return ReadAsync(budget, cancellationToken);
+    }
+
+    private async ValueTask<ReadOnlyMemory<byte>?> ReadAsync(IFetchResponseBodyBudget budget, CancellationToken cancellationToken)
+    {
+        try
+        {
+            _stream ??= await _message.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+            while (true)
+            {
+                if (_length == _reserved)
+                {
+                    var desired = _reserved == 0 ? InitialChunk : Math.Max(_reserved, InitialChunk);
+                    if (!Grow(budget, desired))
+                    {
+                        // The allowance is spent with the buffer exactly full, which is the one state that
+                        // cannot say whether the body ended here. One byte of lookahead answers it, into the
+                        // slot the buffer always keeps beyond what was reserved.
+                        var probe = await _stream.ReadAsync(Lookahead(), cancellationToken).ConfigureAwait(false);
+                        if (probe == 0)
+                        {
+                            return Complete();
+                        }
+
+                        _length += probe;
+                        _refused = true;
+                        return null;
+                    }
+                }
+
+                var read = await _stream.ReadAsync(_buffer.AsMemory(_length, _reserved - _length), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    return Complete();
+                }
+
+                _length += read;
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref _reading, 0);
+        }
+    }
+
+    /// <summary>The single slot beyond the reservation, which exists only so that a full buffer can ask.</summary>
+    private Memory<byte> Lookahead()
+    {
+        _buffer ??= new byte[1];
+        return _buffer.AsMemory(_length, 1);
+    }
+
+    /// <summary>Charges <paramref name="desired"/> bytes, or the largest halving of it the budget grants.</summary>
+    private bool Grow(IFetchResponseBodyBudget budget, int desired)
+    {
+        while (desired > 0)
+        {
+            if (budget.TryReserve(desired, out var lease))
+            {
+                if (lease is not null)
+                {
+                    (_leases ??= []).Add(lease);
+                }
+
+                // The extra slot is the lookahead: never handed out, never charged, and written to only on
+                // the refusal path, where the byte in it is one the caller must still receive.
+                Array.Resize(ref _buffer, _reserved + desired + 1);
+                _reserved += desired;
+                return true;
+            }
+
+            desired /= 2;
+        }
+
+        return false;
+    }
+
+    private ReadOnlyMemory<byte> Complete()
+    {
+        var body = _buffer is null ? ReadOnlyMemory<byte>.Empty : new ReadOnlyMemory<byte>(_buffer, 0, _length);
+        _body = body;
+        return body;
+    }
+
+    /// <summary>
+    /// Ends the capability and puts every byte read back in front of the still-unread stream, which is what
+    /// makes a read invisible to whoever asked for the resource.
+    /// </summary>
+    internal void AttachReplay()
+    {
+        _sealed = true;
+
+        if (_length == 0 || _buffer is null || _stream is null)
+        {
+            // Nothing was taken off the socket, so the content is still exactly what it was. A read that
+            // reserved capacity and found an empty body lands here too, and its reservation is released.
+            Release();
+            return;
+        }
+
+        var original = _message.Content;
+        var replay = new StreamContent(new FetchReplayStream(
+            new ReadOnlyMemory<byte>(_buffer, 0, _length),
+            original,
+            _stream,
+            _leases));
+
+        foreach (var header in original.Headers.NonValidated)
+        {
+            foreach (var value in header.Value)
+            {
+                replay.Headers.TryAddWithoutValidation(header.Key, value);
+            }
+        }
+
+        _message.Content = replay;
+
+        // Ownership of the leases moved to the replay stream, which releases them once the prefix has been
+        // handed over or the content is dropped unread.
+        _leases = null;
+        _buffer = null;
+        _body = null;
+        _stream = null;
+    }
+
+    /// <summary>
+    /// Ends the capability for a response nobody will receive — a substitution or a failure — so the bytes
+    /// read are released rather than replayed.
+    /// </summary>
+    internal void Discard()
+    {
+        _sealed = true;
+        Release();
+        _buffer = null;
+        _body = null;
+        _stream = null;
+    }
+
+    private void Release()
+    {
+        if (_leases is not { } leases)
+        {
+            return;
+        }
+
+        _leases = null;
+        foreach (var lease in leases)
+        {
+            lease.Dispose();
+        }
+    }
+}
+
+/// <summary>
+/// The prefix a body read took off the socket, in front of the bytes still coming, so the caller receives
+/// every original byte exactly once and in order.
+/// </summary>
+/// <remarks>
+/// It owns the original <see cref="HttpContent"/> it displaced: disposing the response disposes the content
+/// holding this stream, which disposes both the remainder and the content the remainder came from. The
+/// budget leases are released as soon as the prefix has been handed over, because from that moment the only
+/// thing holding those bytes is whoever asked for them.
+/// </remarks>
+internal sealed class FetchReplayStream : Stream
+{
+    private readonly HttpContent _original;
+    private readonly Stream _rest;
+
+    private ReadOnlyMemory<byte> _prefix;
+    private List<IDisposable>? _leases;
+    private int _position;
+
+    internal FetchReplayStream(ReadOnlyMemory<byte> prefix, HttpContent original, Stream rest, List<IDisposable>? leases)
+    {
+        _prefix = prefix;
+        _original = original;
+        _rest = rest;
+        _leases = leases;
+    }
+
+    /// <inheritdoc />
+    public override bool CanRead => true;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+    /// <inheritdoc />
+    public override bool CanWrite => false;
+
+    /// <inheritdoc />
+    public override long Length => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public override void Flush()
+    {
+    }
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    /// <inheritdoc />
+    public override int Read(Span<byte> buffer)
+    {
+        if (TryReplay(buffer, out var replayed))
+        {
+            return replayed;
+        }
+
+        return _rest.Read(buffer);
+    }
+
+    /// <inheritdoc />
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+    /// <inheritdoc />
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (TryReplay(buffer.Span, out var replayed))
+        {
+            return new ValueTask<int>(replayed);
+        }
+
+        return _rest.ReadAsync(buffer, cancellationToken);
+    }
+
+    /// <summary>
+    /// Hands over the next span of the prefix, never mixing it with a byte off the socket: a short read is
+    /// what every <see cref="Stream"/> consumer already handles, and one read spanning both would have to
+    /// touch the socket to answer.
+    /// </summary>
+    private bool TryReplay(Span<byte> buffer, out int replayed)
+    {
+        var remaining = _prefix.Length - _position;
+        if (remaining <= 0)
+        {
+            replayed = 0;
+            return false;
+        }
+
+        if (buffer.IsEmpty)
+        {
+            replayed = 0;
+            return true;
+        }
+
+        var count = Math.Min(remaining, buffer.Length);
+        _prefix.Span.Slice(_position, count).CopyTo(buffer);
+        _position += count;
+
+        if (_position == _prefix.Length)
+        {
+            _prefix = default;
+            ReleaseLeases();
+        }
+
+        replayed = count;
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _prefix = default;
+            ReleaseLeases();
+            _rest.Dispose();
+            _original.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void ReleaseLeases()
+    {
+        if (Interlocked.Exchange(ref _leases, null) is not { } leases)
+        {
+            return;
+        }
+
+        foreach (var lease in leases)
+        {
+            lease.Dispose();
+        }
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/FetchTransport.cs
+++ b/Jint/WebApi/Fetch/FetchTransport.cs
@@ -452,19 +452,37 @@ internal static class FetchTransport
             Timing = exchange.Timing,
         };
 
-        var interception = await observation.ResponseAsync(snapshot, cancellationToken).ConfigureAwait(false);
+        // The read/replay primitive lives here and nowhere else: this is the one frame that owns the unread
+        // content, so a prefix an observer took can be put back in front of it before anybody else looks.
+        var context = new FetchResponseInterceptionContext(snapshot, response);
+
+        FetchResponseInterception? interception;
+        try
+        {
+            interception = await observation.ResponseAsync(context, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            context.Discard();
+            throw;
+        }
+
         if (interception is null)
         {
+            context.AttachReplay();
             return exchange;
         }
 
         if (interception.Kind == FetchInterceptionKind.Fail)
         {
+            context.Discard();
             throw new FetchFailureException(FetchFailureKind.PolicyDenied, interception.Reason ?? "A fetch observer failed the response.");
         }
 
         if (interception.Kind == FetchInterceptionKind.Fulfill)
         {
+            context.Discard();
+
             var substitute = new FetchExchange
             {
                 Response = BuildResponse(interception.Status, interception.StatusText, interception.Headers, interception.Body),
@@ -511,6 +529,8 @@ internal static class FetchTransport
             }
         }
 
+        // Last, so the replay content is built from the header list the interception settled on.
+        context.AttachReplay();
         return exchange;
     }
 

--- a/docs/guide/migrating-to-v5.md
+++ b/docs/guide/migrating-to-v5.md
@@ -5587,6 +5587,7 @@ none of it changes an engine that does not.
 | A `Referer` header under a referrer policy, and an `Origin` header | `options.WebApi.Fetch.Referrer`, `.ReferrerPolicy`, `.Origin` | [§5.10](#5-10-fetch-can-behave-as-a-document-s-fetch-3617) |
 | Cookies, in a jar the host owns, consulted per redirect hop under the request's `credentials` mode | `options.WebApi.Fetch.CookieJar = new CookieContainerCookieJar()` | [§5.10](#5-10-fetch-can-behave-as-a-document-s-fetch-3617) |
 | Watching and intercepting every request, response and body chunk | `options.WebApi.Fetch.Observer = …`, plus `<NoWarn>$(NoWarn);JINT0002</NoWarn>` | [§5.10](#5-10-fetch-can-behave-as-a-document-s-fetch-3617) |
+| Reading the body of the response an observer is answering, against a memory allowance you own, without the caller losing a byte | override `OnInterceptedResponseAsync` instead of `OnResponseAsync` | [§5.34](#5-34-a-fetch-observer-can-read-the-body-of-the-response-it-is-answering-3828) |
 | When each hop went out and when its response headers came back, so a host can report a real time to first byte | `ObservedFetchResponse.Timing`, on the observer you already set | [§5.29](#5-29-an-observed-response-says-when-its-hop-went-out-and-when-its-headers-came-back-3701) |
 | The Chrome DevTools Protocol over a WebSocket, so a debugging client can attach to an engine your host is already running | `dotnet add package Jint.DevTools`, then `options.UseDevTools()` | [Jint.DevTools](../packages/jint-devtools/index.md) |
 | A headless browser — AngleSharp's DOM under Jint, drivable by Puppeteer and Playwright, plus a `jint-browser` command line | `dotnet add package Jint.Browser`, or `dotnet tool install -g Jint.Browser.Tool` | [Jint.Browser](../packages/jint-browser/index.md) |
@@ -6640,6 +6641,55 @@ Those constraints observe engine work; they do not preempt arbitrary managed cod
 The callback is synchronous. A callback may return a `Task` because the generic result is unrestricted, but
 Jint returns that task without awaiting it and restores the previous realm first. Use the engine's asynchronous
 entry APIs for work that must retain engine ownership across an `await`.
+
+### 5.34 A fetch observer can read the body of the response it is answering ([#3828](https://github.com/sebastienros/jint/issues/3828))
+
+`FetchObserver.OnResponseAsync` is asked once, for the response that ends the chain, with the headers in hand
+and the body still on the socket — and until now it could only answer from metadata. A new virtual takes the
+same decision with the body available:
+
+```csharp
+sealed class BodyReadingObserver : FetchObserver
+{
+    public override async ValueTask<FetchResponseInterception?> OnInterceptedResponseAsync(
+        FetchResponseInterceptionContext context,
+        CancellationToken cancellationToken)
+    {
+        var body = await context.TryReadBodyAsync(myBudget, cancellationToken);
+
+        // body is null when the budget refused it, and a non-null empty value when the body was empty.
+        return null; // deliver the response unchanged; the bytes just read are replayed ahead of the rest
+    }
+}
+```
+
+Three preview additions, all under `JINT0002` like the observer itself
+(`<NoWarn>$(NoWarn);JINT0002</NoWarn>`):
+
+| Member | What it is |
+| --- | --- |
+| `FetchObserver.OnInterceptedResponseAsync(FetchResponseInterceptionContext, CancellationToken)` | The ask. **Its default implementation forwards to `OnResponseAsync(context.Response, cancellationToken)`**, so an existing observer behaves exactly as it did and nothing has to change. Override one or the other, not both — an override here replaces the forward |
+| `FetchResponseInterceptionContext` | `Response`, the same `ObservedFetchResponse` the old ask received, and `TryReadBodyAsync(IFetchResponseBodyBudget, CancellationToken)` |
+| `IFetchResponseBodyBudget` | `bool TryReserve(int bytes, out IDisposable? lease)` — the host's own memory allowance, engine-free and thread-safe like everything else the transport touches |
+
+What the read promises:
+
+- **The caller still receives every original byte, exactly once.** Bytes taken off the socket are replayed
+  ahead of the unread remainder when the response is delivered. That holds whether the read succeeded, the
+  budget refused it, or it failed part-way. `Fulfill` and `Fail` discard them instead, because nobody
+  receives those bytes.
+- **Nothing is retained before it is charged.** The reader grows its buffer in granted steps, so a reservation
+  covers backing capacity rather than the body's final length. One byte sits outside it: the lookahead that
+  tells a body exactly at the allowance from one byte longer.
+- **`null` means refused and is sticky** for that response; a later read answers `null` without touching the
+  socket again. A success is immutable and reused by every later read.
+- **A failure is thrown, never returned as a short body**, and the read is valid only while the callback is
+  running — the context is sealed as soon as it returns.
+- **Nothing is read unless it is asked for.** `fetch`, a document or subresource load, `XMLHttpRequest` and
+  `EventSource` all stay streaming for an observer that does not call `TryReadBodyAsync`.
+
+A read waits for the whole body, so reading a response that never ends — a server-sent event stream — is
+bounded only by `Options.WebApi.Fetch.Timeout`. Decide per response whether to read.
 
 ## 6. AOT and trimming
 


### PR DESCRIPTION
Stacked PR 1 of 2 for #3828. This one adds **only the engine seam**; the `Fetch.getResponseBody` command is #3982, stacked on this branch. Nothing here changes an engine that does not set `Options.WebApi.Fetch.Observer`, and nothing changes an observer that does not override the new callback.

## What and why

`FetchObserver.OnResponseAsync` is asked once, for the response that ends the chain, with the headers in hand and the body still on the socket — and it could only ever answer from metadata. `FetchTransport.AnswerResponseAsync` is the one frame that owns that unread `HttpResponseMessage`, so a protocol layer above Jint (`Jint.Browser`'s `FetchDomain`) had no way to read a paused response's body without reaching around the boundary. That is the blocker the issue's last audit named, and this is the "smallest reviewable public proposal" from it, with the three reserved decisions taken as the maintainer stated them.

## Mechanism

- **The ask moves, the answer does not.** `FetchObserver.OnInterceptedResponseAsync(FetchResponseInterceptionContext, CancellationToken)` is the new virtual; its default implementation forwards to `OnResponseAsync(context.Response, cancellationToken)`, so every observer written so far behaves exactly as it did. There is deliberately **no** `OnResponseAsync` overload — that would be an ambiguity for overriders.
- **`TryReadBodyAsync(IFetchResponseBodyBudget, CancellationToken)` charges before it retains.** The reader grows its buffer in steps the allowance grants first (`TryReserve` all-or-nothing, retried downwards by halving), so a reservation covers backing capacity rather than the body's final length, and nothing lands in memory that was not granted. `Content-Length` is trusted only where it makes the first reservation *smaller*.
- **Three answers that stay distinct.** Non-null empty = an empty body was read. `null` = the budget refused it, and the refusal is **sticky** for that response: later reads answer `null` without touching the socket again. A throw = the transfer failed — never a short body dressed as a complete one. A success is immutable and reused by every later read.
- **No `Stream` crosses the surface.** Handing one out would bypass the very accounting the seam exists for.
- **The replay is what makes a read invisible.** The read consumes the socket, so `AttachReplay` puts the prefix in front of the unread remainder — a `StreamContent` over an internal `FetchReplayStream`, carrying the content headers the interception settled on — before anything else looks, on `Continue` and on a plain `null` answer alike. `Fulfill` and `Fail` `Discard` instead, since nobody receives those bytes. The caller therefore receives **every original byte exactly once**, whether the read succeeded, was refused, or failed part-way.
- **Leases follow the bytes.** The replay stream releases them once the prefix has been handed over or the content is dropped unread, so the ledger is charged exactly while the memory exists; `Discard` releases immediately.
- **The first reservation is sized by `Content-Length` when the header makes it *smaller*.** A declared length at or above the default step is ignored, so a header lying upwards cannot reserve memory the body will never fill, while one lying downwards costs another growth step and nothing else. What it buys is that a twelve-byte response stops charging a whole eight-kilobyte step of an allowance it shares with every sibling.
- **One byte is deliberately outside the accounting, and it is stated rather than hidden.** An unknown-length body whose size is exactly the allowance cannot be told from one byte longer without reading one more byte. The buffer therefore always keeps a single slot past what was reserved, and writes to it only on the refusal path — where the byte in it is one the caller must still receive. Without it, an exact-limit chunked body is wrongly refused (proved below).

The context is sealed as soon as the callback returns, and a second read started while one is in flight gets an explicit `InvalidOperationException` rather than racing stream ownership.

## Failing-first evidence

The capability is new, so the 25 tests cannot exist against unfixed code — instead each mechanism was **removed from the implementation in turn** and the suite re-run, on Release `net8.0`, to show which tests are actually holding it up:

| Mutation | Tests that went red |
| --- | --- |
| `AttachReplay` releases and returns without attaching (no replay) | **17** — `ATextBodyIsReadWholeAndThePageStillReceivesIt`, `ABinaryBodyIsReadByteForByte`, `AnUnknownLengthChunkedBodyIsReadWhole`, `ABodyExactlyAtTheAllowanceIsRead`, `ABodyOneByteOverTheAllowanceIsRefusedAndThePageStillReceivesEveryByte`, `ACancelledReadIsThrownAndThePageStillReceivesEveryByte`, `AContinuedResponseCarriesTheRewrittenHeadersOverTheReplay`, `ADeceptiveContentLength…` (×2), `AnAllowanceAlreadySpentElsewhere…`, `AReadIsAvailableOnTheXmlHttpRequestLaneToo`, `ARefusalIsStickyForThatResponse`, `ARepeatedReadAnswersTheSameMemory…`, `AResponseNobodyReadsIsNotTouchedBeforeItsConsumerAsks(True)`, `ASecondReadInFlightAtOnceIsRefused`, `AZeroAllowanceRefusesEveryBodyButTheEmptyOne`, `TheContextIsSealedOnceTheCallbackHasReturned` |
| `_refused = true` → `false` (refusal not sticky) | 1 — `ARefusalIsStickyForThatResponse` |
| `Release()` never releases | 3 — `AnEmptyBodyIsReadAsANonNullEmptyValue`, `AResponseNobodyWillReceiveReleasesWhatWasRead("fulfill")`, `…("fail")` |
| No lookahead slot (a full buffer always refuses) | 5 — `ABodyExactlyAtTheAllowanceIsRead`, `ABodyOneByteOverTheAllowance…`, `AnAllowanceAlreadySpentElsewhere…`, `ARefusalIsStickyForThatResponse`, `AZeroAllowanceRefusesEveryBodyButTheEmptyOne` |
| `FetchReplayStream.ReleaseLeases()` never releases | 10 — every test asserting the allowance returns to zero after delivery |
| The first reservation ignores `Content-Length` (second commit) | 1 — `AKnownLengthBodyChargesAboutItsOwnSizeAndNotAWholeStep`, which sees a peak of 8192 against a 40-byte body |

The implementation was restored byte-for-byte after each run.

## What was verified

Release, fresh builds, no `--no-build`, re-run after a rebase onto `main` `6943f0e35`, on head `2cc9e08eb`:

- `dotnet test -c Release Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj` — **3709/3709 net8.0, 3719/3719 net10.0, 2936/2936 net472**, 21 skipped per leg. That includes `PublicApiTest` (both baselines regenerated and reviewed — the diff is exactly the three additions), `PublicApiDocumentationTest`, and the extended `TheObserverSurfaceMentionsNoEngineType` guardian, which now walks `FetchResponseInterceptionContext` and `IFetchResponseBodyBudget` as well.
- `dotnet test -c Release Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName~WebApi|~AgentInstructionFileTests|~SpecCitation"` — **2973/2973 on net8.0 and net10.0**, 8/8 on net472.
- `dotnet test -c Release Jint.Tests.Browser/Jint.Tests.Browser.csproj --filter "FullyQualifiedName~Fetch|~Network"` — **97/97 on net8.0 and net10.0** (4 skipped), which is what says `PageNetworkRecorder`'s existing `OnResponseAsync` override is untouched by the forward.
- `dotnet build -c Release` for the whole solution — 0 errors, 0 new warnings (`TreatWarningsAsErrors` is on).

Re-run in full after the second commit; the figures above are that run.

The 25 new tests cover the issue's observer list: empty, text, binary, unknown-length chunked, exact limit, limit+1, deceptive `Content-Length` in both directions, read failure, cancellation mid-read, repeated reads, a refusal the page never notices, `Fulfill`/`Fail` discarding, the rewritten header list surviving the replay, an already-spent shared ledger, a zero allowance, the sealed context, a concurrent read, a null budget, the `XMLHttpRequest` lane, and — for "still streaming when nothing is read" — that with the headers in hand and nobody having asked for the body, **not one byte has come off the socket** unless the observer read it.

## The #3910 prerequisite

Confirmed before anything was written, as the issue asks. #3913 ("Bound unfinished Network captures by the page-wide byte budget") is merged and is an ancestor of this branch's base (`63b86ec8f`, verified with `git merge-base --is-ancestor`). `PageNetworkRecorder.Append` now charges each chunk against `_capturedBytes` **before** copying it, evicts the oldest capture to make room, refuses a chunk that cannot fit on its own, and `Seal` republishes the written buffer rather than allocating a second copy. So the aggregate PR 2 will share is the corrected one, not the one the audit measured at zero.

## Deliberately left out

- **The protocol command.** `Fetch.getResponseBody`, the per-pause state machine, the page-owned ledger wired to `BrowserOptions.MaxCapturedResponseBytes`, the tracked WebSocket send and the manifest entry are PR 2. This PR adds no CDP surface and no `Jint.Browser` change.
- **`Fetch.takeResponseBodyAsStream` and the `IO` domain**, per the issue's own scope reduction.
- **Redirect, request and auth stage reads.** The ask is per *final* response, where it always was.
- **Charset decoding.** The read answers bytes, which is what keeps a binary body intact and avoids a second charset policy.

## Known limitation, stated rather than hidden

A read waits for the **whole** body, so asking for one on a response that never ends — a server-sent event stream — is bounded only by `Options.WebApi.Fetch.Timeout`. The ask is per final response, so a host mapping this onto a protocol decides for itself which responses it is willing to read; PR 2's command inherits the pause's own lifetime for exactly this reason. Both `Jint/WebApi/Fetch/AGENTS.md` and the migration guide say so.

## Documentation

- `docs/guide/migrating-to-v5.md` §5.34 (next free number) plus a row in the §5 table.
- `Jint/WebApi/Fetch/AGENTS.md` gains the two paragraphs an agent needs before touching the read or the replay; the file is 12.9 KiB against the 32 KiB cap and `AgentInstructionFileTests` passes.

## Upstream findings

None. Nothing in this change touches AngleSharp or any other third-party repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
