### PR TITLE
Move to AngleSharp.Css 1.1.1-beta.308, the preview with the converter re-entry fix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,14 @@
          the two records disagree, because the checked-in Jint.Browser/Dom/Generated/ is a picture of exactly
          these assemblies' [DomName] surface. Bump both together, regenerate, and read the diff. -->
     <PackageVersion Include="AngleSharp" Version="1.8.0" />
-    <PackageVersion Include="AngleSharp.Css" Version="1.1.0" />
+    <!-- A prerelease deliberately, and the maintainer's own preference for this repository: 1.1.1-beta.308 is
+         1.1.0 plus AngleSharp/AngleSharp.Css#244, which stops a composite converter reparsing an unresolved
+         any-value with itself. Without it `translate`, `rotate` and `scale` overflow the stack inside
+         ComputeCurrentStyle(), and a stack overflow is the one failure Dom/Views/CssCascade's guard cannot
+         turn into a null cascade — it ends the process. Jint.Tests.Browser/Views/IndividualTransformStyleTests
+         is what holds the fix. AngleSharp itself stays on 1.8.0: nothing later is published, prerelease
+         included. -->
+    <PackageVersion Include="AngleSharp.Css" Version="1.1.1-beta.308" />
     <!-- Neither of these is in the binding generator's pin, and deliberately: the generator reads AngleSharp
          and AngleSharp.Css and nothing else, and neither of these carries a [DomName] the binding could
          project. Each is referenced for one thing the package's own principle says must not be written here —

--- a/Jint.Tests.Browser/DomBindingsPinTests.cs
+++ b/Jint.Tests.Browser/DomBindingsPinTests.cs
@@ -32,10 +32,11 @@ public sealed class DomBindingsPinTests
     {
         var pinned = ReadPin();
 
-        // The assembly version drops the patch component for a prerelease suffix, so this compares the three
-        // numeric parts rather than the whole string.
-        Major(typeof(IElement).Assembly.GetName().Version!.ToString()).Should().Be(Major(pinned["AngleSharp"]));
-        Major(typeof(ICssStyleDeclaration).Assembly.GetName().Version!.ToString()).Should().Be(Major(pinned["AngleSharp.Css"]));
+        // An assembly version carries a fourth revision component a package version never states, and it
+        // carries no prerelease suffix at all — AngleSharp.Css 1.1.1-beta.308 is assembly 1.1.1.0 — so this
+        // compares the three numeric parts of the release portion rather than the whole string.
+        Release(typeof(IElement).Assembly.GetName().Version!.ToString()).Should().Be(Release(pinned["AngleSharp"]));
+        Release(typeof(ICssStyleDeclaration).Assembly.GetName().Version!.ToString()).Should().Be(Release(pinned["AngleSharp.Css"]));
     }
 
     private static SortedDictionary<string, string> ReadPin()
@@ -72,9 +73,10 @@ public sealed class DomBindingsPinTests
         return versions;
     }
 
-    private static string Major(string version)
+    /// <summary>Major.minor.patch, with any prerelease suffix and any revision component dropped.</summary>
+    private static string Release(string version)
     {
-        var parts = version.Split('.');
-        return string.Join('.', parts.Take(3));
+        var release = version.Split('-')[0];
+        return string.Join('.', release.Split('.').Take(3));
     }
 }

--- a/Jint.Tests.Browser/Views/IndividualTransformStyleTests.cs
+++ b/Jint.Tests.Browser/Views/IndividualTransformStyleTests.cs
@@ -1,0 +1,124 @@
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// The individual transform properties —
+/// <a href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">CSS Transforms Level 2 §3</a>'s
+/// <c>translate</c>, <c>rotate</c> and <c>scale</c> — reach a computed style and a box without taking the
+/// process with them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this is a suite of its own.</b> Every one of these declarations used to be fatal rather than
+/// wrong. AngleSharp.Css shapes those three properties as an <c>Or</c> of <c>none</c> with an <i>any</i>
+/// arm, and <c>CssAnyValue.Compute</c> only avoided reparsing when the compute context's converter was
+/// <i>directly</i> that any-converter; through the composite it reparsed the unchanged text with the same
+/// composite converter, whose any arm handed back another unresolved value, forever
+/// (<a href="https://github.com/AngleSharp/AngleSharp.Css/issues/243">AngleSharp/AngleSharp.Css#243</a>,
+/// fixed by <a href="https://github.com/AngleSharp/AngleSharp.Css/pull/244">#244</a> and released in
+/// 1.1.1-beta.308). A stack overflow is not an exception in .NET: it cannot be caught, so
+/// <c>Dom/Views/CssCascade</c>'s guard — the door every <c>ComputeCurrentStyle()</c> caller comes through —
+/// could not have converted it into the <see langword="null"/> cascade that every other CSS failure becomes.
+/// <c>&lt;div style="translate: 1px"&gt;</c> took the whole host down with it, and a page is not something a
+/// host can sandbox out of that.
+/// </para>
+/// <para>
+/// <b>Both doors, because they are two code paths.</b> <c>getComputedStyle</c> reads the native
+/// per-element cascade through <c>CssCascade.Of</c>, while a geometry query builds the flat box model over
+/// <c>CssCascade.Traversal</c>, which computes each element's declarations against its own context. The
+/// first is the exact shape the upstream issue reports; the second was measured to be just as fatal on
+/// 1.1.0, running alone, so both are pinned here.
+/// </para>
+/// <para>
+/// <b>What this does not claim.</b> The upstream fix is a computation-boundary fix, so the value that comes
+/// back is the token sequence AngleSharp.Css parsed, not a browser's normalized <c>translate</c>. Nothing
+/// here transforms a box: the flat layout has no transform stage, and the geometry assertions are about a
+/// box still being answered rather than about where it moved to.
+/// </para>
+/// </remarks>
+public sealed class IndividualTransformStyleTests
+{
+    /// <summary>
+    /// The declarations the upstream issue confirms as fatal in 1.1.0, plus the multi-component and
+    /// percentage forms its reproduction lists.
+    /// </summary>
+    [TestCase("translate", "1px")]
+    [TestCase("translate", "0 -50%")]
+    [TestCase("translate", "10px 20px 30px")]
+    [TestCase("rotate", "45deg")]
+    [TestCase("scale", "1")]
+    public async Task AnIndividualTransformComputesRatherThanReenteringItsConverter(string property, string value)
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='moved' style='" + property + ": " + value + "'>a</div>");
+
+        var computed = "getComputedStyle(document.getElementById('moved'))";
+
+        // The token sequence AngleSharp.Css parsed, unchanged: the upstream fix is about the computation
+        // terminating, not about a browser's normalized transform grammar.
+        (await page.EvaluateAsync<string>(computed + ".getPropertyValue('" + property + "')"))
+            .Should().Be(value, "the declared {0} is in the cascade, so the computed style answers it", property);
+
+        // And the rest of the cascade survives the same call: ComputeCurrentStyle() computes every matched
+        // declaration in one pass, so a property that could not compute used to take the whole style with it.
+        (await page.EvaluateAsync<string>(computed + ".visibility")).Should().Be("visible");
+    }
+
+    /// <summary>
+    /// The keyword arm of the same converter, which terminated even in 1.1.0 — so a green run here is not
+    /// evidence for the cases above.
+    /// </summary>
+    [TestCase("translate")]
+    [TestCase("rotate")]
+    [TestCase("scale")]
+    public async Task TheNoneKeywordStillComputes(string property)
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='still' style='" + property + ": none'>a</div>");
+
+        (await page.EvaluateAsync<string>(
+            "getComputedStyle(document.getElementById('still')).getPropertyValue('" + property + "')"))
+            .Should().Be("none");
+    }
+
+    /// <summary>
+    /// The other door: a geometry query over a document whose style sheet puts an individual transform on
+    /// an element and on one of its ancestors, so the cascade the flat layout walks carries it too.
+    /// </summary>
+    [Test]
+    public async Task AGeometryQueryOverATranslatedSubtreeStillAnswersABox()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync(
+            """
+            <style>
+              #outer { translate: 0 -50%; rotate: 45deg }
+              #inner { translate: 10px 20px; scale: 2 }
+            </style>
+            <div id="outer"><span id="inner">a</span></div>
+            """);
+
+        (await page.EvaluateAsync<bool>(
+            """
+            (() => {
+              const rect = document.getElementById('inner').getBoundingClientRect();
+              return rect.width > 0 && rect.height > 0;
+            })()
+            """))
+            .Should().BeTrue("the flat box model computes the cascade for every rendered element");
+
+        // The ancestor that declares its own individual transforms has a box as well, so the walk reached
+        // both elements rather than stopping at the first one it could compute.
+        (await page.EvaluateAsync<double>("document.getElementById('outer').getBoundingClientRect().height"))
+            .Should().BeGreaterThan(0);
+    }
+}

--- a/tools/dom-bindings/pin.json
+++ b/tools/dom-bindings/pin.json
@@ -7,7 +7,7 @@
   ],
   "packages": {
     "AngleSharp": "1.8.0",
-    "AngleSharp.Css": "1.1.0"
+    "AngleSharp.Css": "1.1.1-beta.308"
   },
-  "retrieved": "2026-09-05"
+  "retrieved": "2026-09-08"
 }


### PR DESCRIPTION
## What and why

Refs #3882. `Directory.Packages.props` moves **AngleSharp.Css from 1.1.0 to 1.1.1-beta.308**, the preview the maintainer asked this repository to consume. It unblocks draft #3888, which has been waiting for an official package containing [AngleSharp/AngleSharp.Css#244](https://github.com/AngleSharp/AngleSharp.Css/pull/244) and today carries no dependency change at all.

**Core AngleSharp stays at 1.8.0.** Verified against nuget.org's flat container: the newest version of `AngleSharp` is `1.8.0`, and the two entries before it (`1.8.0-beta.677`, `1.8.0-beta.679`) are its own pre-release run — there is no post-1.8.0 preview to move to.

## Mechanism

AngleSharp.Css 1.1.0 **stack-overflows** while computing a style for any of [CSS Transforms Level 2 §3](https://drafts.csswg.org/css-transforms-2/#individual-transforms)'s individual transform properties (`translate`, `rotate`, `scale`). Each is shaped as an `Or` of `none` with an *any* arm, and `CssAnyValue.Compute` skipped reparsing only when the compute context's converter was *directly* that any-converter; through the composite it reparsed the unchanged text with the same composite converter, whose any arm returned another unresolved value, without bound (AngleSharp/AngleSharp.Css#243).

That matters more here than an ordinary upstream bug, because it is the one CSS failure this package cannot contain. `Jint.Browser/Dom/Views/CssCascade` is the single guarded door onto `ComputeCurrentStyle()` and turns every CLR failure into a `null` cascade — but a .NET stack overflow is not an exception and cannot be caught, so `<div style="translate: 1px">` ended the host process. A page is not something an embedder can sandbox out of that.

**1.1.1-beta.308 is 1.1.0 plus exactly that fix.** Checked rather than assumed: `GET repos/AngleSharp/AngleSharp.Css/compare/v1.1.0...devel` reports `ahead_by 3`, and the three commits are `af16326e` (the fix), `f48e8ba2` (version bump) and `d4e41f29` (the #244 merge).

### What moved with it

- `tools/dom-bindings/pin.json` — the pin and the package reference are one record, which `DomBindingsPinTests` enforces.
- `Jint.Tests.Browser/DomBindingsPinTests.cs` — its assembly comparison took the pinned version's first three dot-separated parts, which for `1.1.1-beta.308` is `1.1.1-beta` and never matches the loaded assembly's `1.1.1`. It now drops the prerelease suffix first. This is a real failure the bump produced, not preventive tidying (log below).
- A comment on the `AngleSharp.Css` entry saying why the pin is a prerelease and why the core package is not.

## Failing-first evidence

New suite: `Jint.Tests.Browser/Views/IndividualTransformStyleTests` — nine cases over `getComputedStyle` and over a geometry query.

Run in this worktree with `Directory.Packages.props` temporarily reverted to `AngleSharp.Css 1.1.0`, everything else identical:

| Run (net8.0, Release) | Result on 1.1.0 | Result on 1.1.1-beta.308 |
| --- | --- | --- |
| `--filter FullyQualifiedName~IndividualTransformStyleTests` | **run aborted** — `Test host process crashed : Stack overflow.` | `Passed! Failed: 0, Passed: 9` |
| the geometry case alone (`AGeometryQueryOverATranslatedSubtreeStillAnswersABox`) | **run aborted** — same crash | passes |
| the control alone (`TheNoneKeywordStillComputes`) | `Passed! Failed: 0, Passed: 3` | passes |

The repeating frame in the crash output is the upstream one:

```
The active test run was aborted. Reason: Test host process crashed : Stack overflow.
   at AngleSharp.Css.Parser.IdentParser.IsIdentifier(AngleSharp.Text.StringSource, System.String)
   ...
   at AngleSharp.Css.Values.CssAnyValue.AngleSharp.Css.Dom.ICssValue.Compute(AngleSharp.Css.Values.ICssComputeContext)
   at AngleSharp.Css.Values.CssAnyValue.AngleSharp.Css.Dom.ICssValue.Compute(AngleSharp.Css.Values.ICssComputeContext)
   ... (repeated to the end of the stack)
Test Run Aborted.
```

So the "failing" half is a **process-fatal crash rather than a test failure**, which is exactly why it needs the `none` control beside it: `TheNoneKeywordStillComputes` exercises the same three properties through the same converter's keyword arm and passes on 1.1.0, so the new suite going green on the beta is a measurement and not a tautology. The `DomBindingsPinTests` change has an ordinary failing-first record instead:

```
Failed TheLoadedAssembliesAreThePinnedOnes
  Expected ... to be the same string, but they differ at index 5:
  "1.1.1"          (actual)
  "1.1.1-beta"     (expected)
```

## Verified

All Release, no `--no-build`, on this branch's head.

| What | Command | Result |
| --- | --- | --- |
| Whole solution | `dotnet build -c Release` | `Build succeeded. 1 Warning(s), 0 Error(s)` — the warning is the pre-existing `MSB3277` on `Jint.Tests.CommonScripts`'s net472 test-SDK assets; nothing in it names AngleSharp |
| Browser suite, net8.0, census on | `JINT_WPT_BROWSER_CENSUS=1 dotnet test -c Release Jint.Tests.Browser/Jint.Tests.Browser.csproj -f net8.0` | `Failed: 0, Passed: 2291, Skipped: 36` |
| Browser suite, net10.0, census on | same with `-f net10.0` | `Failed: 0, Passed: 2295, Skipped: 36` |
| Wpt browser census | the two runs above (`TheTableMatchesWhatTheLaneMeasures` is not among the 36 skipped) | table checked, **unchanged** — `Jint.Tests.Browser/Wpt/README.md` is untouched in the diff, so no `=update` regeneration was needed or performed |
| Agent instruction files | `dotnet test -c Release --filter FullyQualifiedName~AgentInstructionFileTests` | `Passed: 5` on each of net8.0, net10.0, net472 |
| Binding staleness + pin | `dotnet test -c Release Jint.Tests.Browser/Jint.Tests.Browser.csproj -f net8.0 --filter FullyQualifiedName~DomBindings` | `Passed: 5` |

**The bindings did not need regenerating, and that is a measurement too.** The generator was run the long way against both packages with the same pinned `AngleSharp 1.8.0` and the same `overrides.json`:

- `gen(1.1.0)` and `gen(1.1.1-beta.308)` are **byte-identical** (`diff -rq`).
- Their reports differ in exactly one line: `AngleSharp.Css 1.1.0.0` becomes `AngleSharp.Css 1.1.1.0`. Same attribute inventory, same skipped members, `Diagnostics (0)` on both.
- The beta's output matches the checked-in `Jint.Browser/Dom/Generated/` modulo line endings, which is what `DomBindingsStalenessTests` independently reports by passing.

## Deliberately left out

- **No `Jint.Browser/Dom/divergences.md` row was added or retired.** #243 was a crash, not a divergence, and the search for a Jint-side workaround came up empty — nothing in `Jint.Browser/` or `Jint.Tests.Browser/` mentions #243/#244, no exclusion in `WptBrowserExclusions` names a transform or a computed-style crash, no fixture declares `translate`/`rotate`/`scale`, and `CssCascade`'s `catch` filters could never have covered it. There was nothing to retire, and the beta's single change retires none of the recorded rows either (their subjects — colour serialization, `:enabled` on links, the `matchMedia` evaluator, explicit `inherit` — are untouched by #244, and the whole suite stays green).
- **No historical "1.1.0" prose was rewritten.** `docs/`, `Jint.Browser/AGENTS.md`, `Jint.Browser/Accessibility/AGENTS.md` and `divergences.md` say things like "shipped in 1.1.0" and "fixed by Css 1.1.0's native computed-style pipeline". Those state *which release introduced a behaviour* and are still true; only the two records that must agree with the reference — `Directory.Packages.props` and `pin.json` — carry the version.
- **No new entry in `docs/releases/headless-browser.md`.** Its upstream-contributions tables are a snapshot of what a specific release consumed (they do not list AngleSharp.Css#242 either), not a running ledger.
- **No geometry, task-budget or Scalar work.** That is #3888's, and this PR is only the dependency it was waiting on.
- The new tests assert that the computation *terminates and answers*, not that a transform moves a box. The flat layout has no transform stage, and #244 is a computation-boundary fix, not transform grammar, unit normalization or layout.

## Upstream (AngleSharp) findings

None new. For the record, the two this consumes:

- [AngleSharp/AngleSharp.Css#243](https://github.com/AngleSharp/AngleSharp.Css/issues/243) — `ComputeCurrentStyle` stack-overflows for `translate`/`rotate`/`scale` through `CssAnyValue` converter re-entry. Closed.
- [AngleSharp/AngleSharp.Css#244](https://github.com/AngleSharp/AngleSharp.Css/pull/244) — the fix. Merged, milestone v1.1.1, released as `1.1.1-beta.308`.

One thing worth a maintainer's eye rather than an upstream report: a stable `Jint.Browser` would now carry a **prerelease transitive dependency**. That is fine while the package ships as `5.0.0-preview-*`, and it is the reason the pin comment says so out loud, but it wants a stable `AngleSharp.Css 1.1.1` before a stable `Jint.Browser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
