### PR TITLE
Reflection: the sectioning elements' attribute table, so 5,604 more assertions of HTML 2.6.1 run

### DIFF
--- a/Jint.Browser/Dom/Generated/DomReflected.g.cs
+++ b/Jint.Browser/Dom/Generated/DomReflected.g.cs
@@ -15,6 +15,30 @@ namespace Jint.Browser.Dom;
 /// </summary>
 internal static class DomReflected
 {
+    /// <summary><c>Document.alinkColor</c> reflects <c>alink</c> as a string.</summary>
+    internal static readonly ReflectedAttribute DocumentAlinkColor =
+        ReflectedAttribute.Text("Document.alinkColor", "alink", legacyNullToEmptyString: true, target: ReflectedTarget.Body);
+
+    /// <summary><c>Document.bgColor</c> reflects <c>bgcolor</c> as a string.</summary>
+    internal static readonly ReflectedAttribute DocumentBgColor =
+        ReflectedAttribute.Text("Document.bgColor", "bgcolor", legacyNullToEmptyString: true, target: ReflectedTarget.Body);
+
+    /// <summary><c>Document.dir</c> reflects <c>dir</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute DocumentDir =
+        ReflectedAttribute.Enumerated("Document.dir", "dir", ["ltr", "rtl", "auto"], missing: "", invalid: null, target: ReflectedTarget.DocumentElement);
+
+    /// <summary><c>Document.fgColor</c> reflects <c>text</c> as a string.</summary>
+    internal static readonly ReflectedAttribute DocumentFgColor =
+        ReflectedAttribute.Text("Document.fgColor", "text", legacyNullToEmptyString: true, target: ReflectedTarget.Body);
+
+    /// <summary><c>Document.linkColor</c> reflects <c>link</c> as a string.</summary>
+    internal static readonly ReflectedAttribute DocumentLinkColor =
+        ReflectedAttribute.Text("Document.linkColor", "link", legacyNullToEmptyString: true, target: ReflectedTarget.Body);
+
+    /// <summary><c>Document.vlinkColor</c> reflects <c>vlink</c> as a string.</summary>
+    internal static readonly ReflectedAttribute DocumentVlinkColor =
+        ReflectedAttribute.Text("Document.vlinkColor", "vlink", legacyNullToEmptyString: true, target: ReflectedTarget.Body);
+
     /// <summary><c>HTMLAnchorElement.charset</c> reflects <c>charset</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLAnchorElementCharset =
         ReflectedAttribute.Text("HTMLAnchorElement.charset", "charset");
@@ -50,6 +74,30 @@ internal static class DomReflected
     /// <summary><c>HTMLBRElement.clear</c> reflects <c>clear</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLBRElementClear =
         ReflectedAttribute.Text("HTMLBRElement.clear", "clear");
+
+    /// <summary><c>HTMLBodyElement.aLink</c> reflects <c>alink</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLBodyElementALink =
+        ReflectedAttribute.Text("HTMLBodyElement.aLink", "alink", legacyNullToEmptyString: true);
+
+    /// <summary><c>HTMLBodyElement.background</c> reflects <c>background</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLBodyElementBackground =
+        ReflectedAttribute.Text("HTMLBodyElement.background", "background");
+
+    /// <summary><c>HTMLBodyElement.bgColor</c> reflects <c>bgcolor</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLBodyElementBgColor =
+        ReflectedAttribute.Text("HTMLBodyElement.bgColor", "bgcolor", legacyNullToEmptyString: true);
+
+    /// <summary><c>HTMLBodyElement.link</c> reflects <c>link</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLBodyElementLink =
+        ReflectedAttribute.Text("HTMLBodyElement.link", "link", legacyNullToEmptyString: true);
+
+    /// <summary><c>HTMLBodyElement.text</c> reflects <c>text</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLBodyElementText =
+        ReflectedAttribute.Text("HTMLBodyElement.text", "text", legacyNullToEmptyString: true);
+
+    /// <summary><c>HTMLBodyElement.vLink</c> reflects <c>vlink</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLBodyElementVLink =
+        ReflectedAttribute.Text("HTMLBodyElement.vLink", "vlink", legacyNullToEmptyString: true);
 
     /// <summary><c>HTMLDivElement.align</c> reflects <c>align</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLDivElementAlign =
@@ -102,6 +150,10 @@ internal static class DomReflected
     /// <summary><c>HTMLHRElement.width</c> reflects <c>width</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLHRElementWidth =
         ReflectedAttribute.Text("HTMLHRElement.width", "width");
+
+    /// <summary><c>HTMLHeadingElement.align</c> reflects <c>align</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLHeadingElementAlign =
+        ReflectedAttribute.Text("HTMLHeadingElement.align", "align");
 
     /// <summary><c>HTMLHtmlElement.version</c> reflects <c>version</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLHtmlElementVersion =

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -659,6 +659,17 @@ internal static partial class DomInterfaces
                     return self.Realm.WrapNodeValue(self.Target.Adopt(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Document.adoptNode")));
                 }),
                 length: 1)
+            .Accessor("alinkColor",
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.alinkColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.alinkColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentAlinkColor.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.alinkColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.alinkColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentAlinkColor.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("all",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.all", static (thisObj, args) =>
                 {
@@ -678,6 +689,17 @@ internal static partial class DomInterfaces
                     self.Target.Append(global::Jint.Browser.Dom.DomConvert.NodeOrTextRest(self.Realm, self.Target, args, 0, "Document.append")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
+            .Accessor("bgColor",
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.bgColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.bgColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentBgColor.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.bgColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.bgColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentBgColor.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("body",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.body", static (thisObj, args) =>
                 {
@@ -868,12 +890,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.dir", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.dir");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Direction);
+                    return global::Jint.Browser.Dom.DomReflected.DocumentDir.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.dir", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.dir");
-                    self.Target.Direction = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.dir"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.DocumentDir.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("doctype",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.doctype", static (thisObj, args) =>
@@ -945,6 +967,17 @@ internal static partial class DomInterfaces
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.ExecuteCommand(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.execCommand"), global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 1, false), global::Jint.Browser.Dom.DomConvert.OptionalText(args, 2, "")!));
                 }),
                 length: 1)
+            .Accessor("fgColor",
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.fgColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.fgColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentFgColor.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.fgColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.fgColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentFgColor.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("firstElementChild",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.firstElementChild", static (thisObj, args) =>
                 {
@@ -1054,6 +1087,17 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.lastStyleSheetSet");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.LastStyleSheetSet);
+                }))
+            .Accessor("linkColor",
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.linkColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.linkColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentLinkColor.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.linkColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.linkColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentLinkColor.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("links",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.links", static (thisObj, args) =>
@@ -1216,6 +1260,17 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.visibilityState");
                     return global::Jint.Native.JsString.Create(global::Jint.Browser.Runtime.PageRuntime.Find(self.Realm.Engine, self.Target)?.VisibilityState ?? "hidden");
+                }))
+            .Accessor("vlinkColor",
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.vlinkColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.vlinkColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentVlinkColor.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("Document.vlinkColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.vlinkColor");
+                    return global::Jint.Browser.Dom.DomReflected.DocumentVlinkColor.Set(self.Realm, self.Target, args);
                 }))
             .Method("write",
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.write", static (thisObj, args) =>

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -1135,6 +1135,72 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("HTMLBodyElement")
             .PerRealmSlot("constructor", enumerable: false)
+            .Accessor("aLink",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.aLink", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.aLink");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementALink.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.aLink", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.aLink");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementALink.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("background",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.background", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.background");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementBackground.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.background", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.background");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementBackground.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("bgColor",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.bgColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.bgColor");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementBgColor.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.bgColor", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.bgColor");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementBgColor.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("link",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.link", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.link");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementLink.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.link", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.link");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementLink.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("text",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.text", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.text");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementText.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.text", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.text");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementText.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("vLink",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.vLink", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.vLink");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementVLink.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLBodyElement.vLink", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlBodyElement>(thisObj, "HTMLBodyElement.vLink");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLBodyElementVLink.Set(self.Realm, self.Target, args);
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLButtonElement</c>.</summary>
@@ -1932,6 +1998,17 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("HTMLHeadingElement")
             .PerRealmSlot("constructor", enumerable: false)
+            .Accessor("align",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLHeadingElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlHeadingElement>(thisObj, "HTMLHeadingElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLHeadingElementAlign.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLHeadingElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlHeadingElement>(thisObj, "HTMLHeadingElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLHeadingElementAlign.Set(self.Realm, self.Target, args);
+                }))
             .Build();
 
     /// <summary>The members of <c>HTMLHtmlElement</c>.</summary>

--- a/Jint.Browser/Dom/ReflectedAttribute.cs
+++ b/Jint.Browser/Dom/ReflectedAttribute.cs
@@ -7,7 +7,31 @@ using Jint.WebApi.DomException;
 
 namespace Jint.Browser.Dom;
 
+/// <summary>
+/// Which element a reflected IDL attribute's content attribute lives on, when it is not the one the IDL
+/// attribute was read from.
+/// </summary>
+/// <remarks>
+/// HTML has six of these and all six are on <c>Document</c>: §3.2.6.4's <c>dir</c>, which reflects the
+/// <c>html</c> element's attribute, and §16.3's five obsolete colours, which reflect the <c>body</c>
+/// element's. All six are a string or an enumeration, which is why only those two factories take one — a
+/// numeric or boolean member reflecting onto another element does not exist, and the generator refuses to
+/// invent one.
+/// </remarks>
+internal enum ReflectedTarget
+{
+    /// <summary>The element the IDL attribute was read from, which is every row but six.</summary>
+    Self,
+
+    /// <summary>The document element — the <c>html</c> element, when there is one.</summary>
+    DocumentElement,
+
+    /// <summary>The body element.</summary>
+    Body,
+}
+
 /// <summary>Which of HTML §2.6.1's per-type reflection algorithms an IDL attribute takes.</summary>
+
 internal enum ReflectedKind
 {
     /// <summary>A <c>DOMString</c>, transparently and case-preservingly.</summary>
@@ -97,6 +121,8 @@ internal sealed class ReflectedAttribute
     private readonly double _default;
     private readonly long _min;
     private readonly long _max;
+    private readonly bool _legacyNull;
+    private readonly ReflectedTarget _target;
 
     private ReflectedAttribute(
         string member,
@@ -107,7 +133,9 @@ internal sealed class ReflectedAttribute
         string? invalid = null,
         double fallback = 0,
         long min = 0,
-        long max = 0)
+        long max = 0,
+        bool legacyNull = false,
+        ReflectedTarget target = ReflectedTarget.Self)
     {
         Member = member;
         _attribute = attribute;
@@ -118,14 +146,35 @@ internal sealed class ReflectedAttribute
         _default = fallback;
         _min = min;
         _max = max;
+        _legacyNull = legacyNull;
+        _target = target;
     }
 
     /// <summary>The qualified member name — <c>HTMLElement.dir</c> — as a refusal names it.</summary>
     internal string Member { get; }
 
     /// <summary>A <c>DOMString</c>, or a <c>DOMString?</c> when <paramref name="nullable"/>.</summary>
-    internal static ReflectedAttribute Text(string member, string attribute, bool nullable = false)
-        => new(member, attribute, nullable ? ReflectedKind.NullableText : ReflectedKind.Text);
+    /// <param name="member">The qualified member name.</param>
+    /// <param name="attribute">The content attribute reflected.</param>
+    /// <param name="nullable">Whether the IDL type is <c>DOMString?</c>, whose setter takes null as a removal.</param>
+    /// <param name="legacyNullToEmptyString">
+    /// WebIDL's <c>[LegacyNullToEmptyString]</c>: the null value converts to the empty string rather than to
+    /// <c>"null"</c>. It is only ever on a <c>DOMString</c>, never on a <c>DOMString?</c>, and it says nothing
+    /// about <c>undefined</c>, which still converts to <c>"undefined"</c>.
+    /// </param>
+    /// <param name="target">Which element the content attribute lives on.</param>
+    internal static ReflectedAttribute Text(
+        string member,
+        string attribute,
+        bool nullable = false,
+        bool legacyNullToEmptyString = false,
+        ReflectedTarget target = ReflectedTarget.Self)
+        => new(
+            member,
+            attribute,
+            nullable ? ReflectedKind.NullableText : ReflectedKind.Text,
+            legacyNull: legacyNullToEmptyString,
+            target: target);
 
     /// <summary>A <c>USVString</c> whose content attribute is defined to contain a URL.</summary>
     internal static ReflectedAttribute Url(string member, string attribute)
@@ -141,8 +190,15 @@ internal sealed class ReflectedAttribute
     /// setter therefore takes <c>null</c> as a removal.
     /// </param>
     /// <param name="invalid">The invalid value default; the missing value default when there is none.</param>
-    internal static ReflectedAttribute Enumerated(string member, string attribute, string[] keywords, string? missing, string? invalid)
-        => new(member, attribute, ReflectedKind.Enumerated, keywords, missing, invalid);
+    /// <param name="target">Which element the content attribute lives on.</param>
+    internal static ReflectedAttribute Enumerated(
+        string member,
+        string attribute,
+        string[] keywords,
+        string? missing,
+        string? invalid,
+        ReflectedTarget target = ReflectedTarget.Self)
+        => new(member, attribute, ReflectedKind.Enumerated, keywords, missing, invalid, target: target);
 
     /// <summary>A <c>boolean</c> attribute: the attribute's presence and nothing else.</summary>
     internal static ReflectedAttribute Boolean(string member, string attribute)
@@ -176,8 +232,36 @@ internal sealed class ReflectedAttribute
     }
 
     /// <summary>
+    /// The IDL attribute of one of HTML's six <c>Document</c> members that reflect an attribute of
+    /// <b>another</b> element — the document element, or the body element.
+    /// </summary>
+    /// <remarks>
+    /// "If there is no such element, then the attribute must return the empty string and do nothing on
+    /// setting" (HTML §3.2.6.4, and §16.3 for the colours): a missing target reads exactly as an absent
+    /// content attribute, which is what passing no element to the shared getter says.
+    /// </remarks>
+    internal JsValue Get(IDocument document)
+        => Get(ElementIn(document), CurrentBaseUri(document, document.BaseUri));
+
+    /// <summary>The same member's setter, which does nothing when the target element is absent.</summary>
+    internal JsValue Set(DomRealm realm, IDocument document, JsValue[] arguments)
+    {
+        var element = ElementIn(document);
+        return element is null ? JsValue.Undefined : Set(realm, element, arguments);
+    }
+
+    /// <summary>The element a <see cref="ReflectedTarget"/> names in <paramref name="document"/>.</summary>
+    private IElement? ElementIn(IDocument document) => _target switch
+    {
+        ReflectedTarget.DocumentElement => document.DocumentElement,
+        ReflectedTarget.Body => document.Body,
+        _ => null,
+    };
+
+    /// <summary>
     /// The node document's current base URL, derived without AngleSharp's cached <c>Node.BaseUri</c>.
     /// </summary>
+
     private static string? CurrentBaseUri(IDocument? document, string? fallback)
     {
         if (document is null)
@@ -195,9 +279,9 @@ internal sealed class ReflectedAttribute
         return PageUrl.Resolve(href, address) ?? address;
     }
 
-    private JsValue Get(IElement element, string? baseUri)
+    private JsValue Get(IElement? element, string? baseUri)
     {
-        var value = element.GetAttribute(_attribute);
+        var value = element?.GetAttribute(_attribute);
 
         switch (_kind)
         {
@@ -211,7 +295,7 @@ internal sealed class ReflectedAttribute
                 return DomConvert.Bool(value is not null);
 
             case ReflectedKind.Nonce:
-                return DomConvert.Text(CryptographicNonce.Get(element));
+                return DomConvert.Text(element is null ? "" : CryptographicNonce.Get(element));
 
             case ReflectedKind.Url:
                 return DomConvert.Text(ResolveUrl(value, baseUri));
@@ -261,6 +345,12 @@ internal sealed class ReflectedAttribute
             case ReflectedKind.NullableText:
             case ReflectedKind.Enumerated when _missing is null:
                 return SetOrRemove(element, value);
+
+            // WebIDL's [LegacyNullToEmptyString]: null converts to "" rather than to "null". Only null,
+            // and pointedly not undefined, which is what the corpus asserts of <body text> either way.
+            case ReflectedKind.Text when _legacyNull && value.IsNull():
+                element.SetAttribute(_attribute, "");
+                return JsValue.Undefined;
 
             // On setting, a URL attribute takes the value as given; resolution is the getter's business.
             case ReflectedKind.Text:

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -31,14 +31,14 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `dom/lists/` | 5 | 0 | 189 | 5 |
 | `dom/traversal/` | 13 | 0 | 52 | 0 |
 | `dom/ranges/` | 17 | 0 | 82 | 4 |
-| `html/dom/` | 9 | 0 | 23,632 | 61 |
+| `html/dom/` | 10 | 0 | 29,236 | 61 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 12 |
 | `custom-elements/` | 16 | 0 | 510 | 247 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **353** | **9** | **33,530** | **1,445** |
+| **total** | **354** | **9** | **39,134** | **1,445** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -176,7 +176,7 @@ a supported name; the collection's named reads remain live.
 
 `dom/nodes/`, `dom/collections/`, `dom/lists/`, `dom/traversal/`, `dom/ranges/` and `html/dom/` are the DOM
 standard's own suites and HTML's DOM half — the corpus every other suite in this lane is written on top of.
-Across the six of them there are 220 documents and 32,113 tests, and **1,100 of those tests do not pass**.
+Across the six of them there are 221 documents and 37,717 tests, and **1,100 of those tests do not pass**.
 Those three figures are live and checked against the census. They arrived together as 207 documents and
 5,247 tests with 1,532 not passing; those arrival figures are historical and deliberately not re-derived.
 
@@ -211,16 +211,16 @@ table needs to be regenerated.
 | 3 | 1 | [#3769](https://github.com/sebastienros/jint/issues/3769) **A `(Node or DOMString)` union parameter takes only a `Node`.** Three `ChildNode.before` rows still reject strings. <!-- cause: a (Node or DOMString) union parameter takes only a Node --> |
 | 2 | 1 | **A Range whose shadow root was removed has the wrong boundary behavior.** These are the two remaining `Range-in-shadow-after-the-shadow-removed.html` rows. <!-- cause: Range's own algorithms --> |
 
-**Four of HTML's ten reflection documents are cases, and two of the four pass whole.** HTML §2.6.1's
+**Five of HTML's ten reflection documents are cases, and three of the five pass whole.** HTML §2.6.1's
 reflection algorithms are `Jint.Browser/Dom/ReflectedAttribute.cs` and the members that take them are
 `overrides.json`'s `reflected` list, so `reflection-misc.html` (4,877 assertions, 1,866 of them failing
-before) and `reflection-text.html` (10,202, 3,360 failing before) pass with **nothing** excluded, and
-`reflection-grouping.html` (5,358, 2,006 failing before) and `reflection-metadata.html` (3,110, 1,218
-failing before) have one cause each.
+before), `reflection-text.html` (10,202, 3,360 failing before) and `reflection-sections.html` (5,604, 2,189
+failing before) pass with **nothing** excluded, and `reflection-grouping.html` (5,358, 2,006 failing before)
+and `reflection-metadata.html` (3,110, 1,218 failing before) have one cause each.
 
-Forty-nine rows did it, and the first fifteen were mostly the **global** attributes every element carries —
+Sixty-two rows did it, and the first fifteen were mostly the **global** attributes every element carries —
 `dir`, `lang`, `tabIndex`, `autofocus`, `inputMode`, `enterKeyHint` — which is why `text` needed only eleven
-rows of its own for 3,360 assertions. The rest are element-specific and that is what the remaining six
+rows of its own for 3,360 assertions. The rest are element-specific and that is what the remaining five
 documents need: `align`, `compact` and their kind, one `reflected` row each. `metadata` took seven of those —
 `link`'s `as`, `crossOrigin`, `referrerPolicy`, `charset` and `target`, and `meta`'s `media` and `scheme` —
 plus one member that is deliberately not reflection at all: **`nonce` answers HTML §2.5.3's
@@ -228,12 +228,20 @@ plus one member that is deliberately not reflection at all: **`nonce` answers HT
 `script[nonce]` selector cannot read back a nonce a header-delivered policy issued
 (`Jint.Browser/Dom/CryptographicNonce.cs`).
 
+`sections` took thirteen and cost the row model two things it could not say. Six of its members are on
+**`Document` and reflect an attribute of another element** — §3.2.6.4's `document.dir` off the `html`
+element, and §16.3.3's `fgColor`, `linkColor`, `vlinkColor`, `alinkColor` and `bgColor` off the `body`
+element — so a row names a `target` now, and a document with no such element reads exactly as an absent
+attribute and does nothing on setting, which is what the standard says of `dir`. Ten of them are
+**`[LegacyNullToEmptyString]`**, where `el.text = null` writes `""` and not `"null"`; that is a flag on the
+`DOMString` row rather than a fourteenth algorithm, because the getter is unchanged.
+
 **Neither of the two causes left is reflection.** `<dl>` has no `HTMLDListElement` in the pinned assemblies,
 so there is no interface for `compact` to be reflected onto; the divergence table records it and thirteen
 rows name the tests. And `<style>`'s `media` cannot be *written* at all when the value is not a media query
 AngleSharp.Css can parse — the exception comes out of `Element.setAttribute` itself, through the attribute
 observer AngleSharp core registers, where Media Queries §2.1 requires an unparseable query to be replaced by
-`not all`. Those fifty-four rows are the only failures this lane's `html/dom/` figure gained, against 18,670
+`not all`. Those fifty-four rows are the only failures this lane's `html/dom/` figure gained, against 24,274
 assertions it did not have before.
 
 **Four documents did not terminate at all, and that was the finding this campaign put first.**

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -289,20 +289,20 @@ internal static class WptBrowserExclusions
         ("html/dom/usvstring-reflection.https.html", "needs webrtc/RTCPeerConnection-helper.js and a real RTCPeerConnection to reflect a USVString off"),
 
         // ------------------------------------------------------------ HTML's reflection suite
-        // Ten generated documents, 56,660 assertions. Four of them are cases now — reflection-misc.html,
-        // reflection-text.html, reflection-grouping.html and reflection-metadata.html, 23,547 assertions
-        // between them — because HTML §2.6.1's reflection algorithms are implemented
-        // (Jint.Browser/Dom/ReflectedAttribute.cs) and driven by overrides.json's `reflected` list. The first
-        // two pass whole; grouping's only failures are <dl>'s, which is AngleSharp having no
-        // HTMLDListElement rather than reflection, and metadata's only failures are <style>'s `media`, which
-        // AngleSharp.Css refuses from inside setAttribute.
+        // Ten generated documents, 56,660 assertions. Five of them are cases now — reflection-misc.html,
+        // reflection-text.html, reflection-sections.html, reflection-grouping.html and
+        // reflection-metadata.html, 29,151 assertions between them — because HTML §2.6.1's reflection
+        // algorithms are implemented (Jint.Browser/Dom/ReflectedAttribute.cs) and driven by overrides.json's
+        // `reflected` list. The first three pass whole; grouping's only failures are <dl>'s, which is
+        // AngleSharp having no HTMLDListElement rather than reflection, and metadata's only failures are
+        // <style>'s `media`, which AngleSharp.Css refuses from inside setAttribute.
         //
-        // The other six are out for one reason and it is no longer "reflection is not implemented": each
+        // The other five are out for one reason and it is no longer "reflection is not implemented": each
         // needs the per-element attribute table it tests, one `reflected` row per content attribute, which is
-        // #3770's remaining work. The forty-nine rows written so far were mostly the GLOBAL attributes every
+        // #3770's remaining work. The sixty-two rows written so far were mostly the GLOBAL attributes every
         // element carries (`dir`, `lang`, `tabIndex`, `autofocus`, `inputMode`, `enterKeyHint`), so they have
-        // already moved the six a long way: sections fell from 2,189 failing assertions to 489. What is left
-        // in them is `align`, `compact` and their kind — element-specific attributes, each one row.
+        // already moved the five a long way. What is left in them is `align`, `compact` and their kind —
+        // element-specific attributes, each one row.
         //
         // **None of them is slow**: the whole set runs in 22.5 s and the largest (reflection-embedded.html,
         // 8,922 tests) in 7.3 s, well inside the driver's 30 s deadline. What has always kept them out is the
@@ -312,7 +312,6 @@ internal static class WptBrowserExclusions
         ("html/dom/*-forms.*", "#3770: the form controls and their attribute table; 2,160 of 8,271"),
         ("html/dom/*-forms-weekmonth.*", "#3770: the week and month input types and their attribute table; 420 of 1,579"),
         ("html/dom/*-obsolete.*", "#3770: the obsolete elements and their attribute table; 1,483 of 2,621"),
-        ("html/dom/*-sections.*", "#3770: the sectioning elements and their attribute table; 2,189 of 5,604 at the measurement, 489 with the rows written so far — and its Document-level members (document.dir, bgColor, fgColor, linkColor, vlinkColor, alinkColor) reflect an attribute of ANOTHER element, which the `reflected` list cannot say yet"),
         ("html/dom/*-tabular.*", "#3770: the tabular-data elements and their attribute table; 3,552 of 6,116"),
         ("html/dom/reflection-original.html", "the same suite in the aggregating spelling, which reports only failures rather than one test per assertion — a second answer to what reflection-*.html already say"),
         ("html/dom/elements-aria-enumerated.js", "the attribute table of aria-attribute-reflection-enumerated.tentative.html, which tests a proposal the specification has not adopted"),
@@ -770,6 +769,7 @@ internal static class WptBrowserExclusions
         ["html/dom/reflection-grouping.html"] = 5358,
         ["html/dom/reflection-metadata.html"] = 3110,
         ["html/dom/reflection-misc.html"] = 4877,
+        ["html/dom/reflection-sections.html"] = 5604,
         ["html/dom/reflection-text.html"] = 10202,
         ["html/webappapis/scripting/events/body-onload.html"] = 1,
         ["html/webappapis/scripting/events/compile-event-handler-lexical-scopes-form-owner.html"] = 4,

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -385,7 +385,7 @@ corpus.
 | `dom/traversal/` | 13 `.html` | `NodeIterator` and `TreeWalker`; four of them are the walks that used to run forever ([#3765](https://github.com/sebastienros/jint/issues/3765)) |
 | `dom/traversal/support/` | 1 `.html`, 1 `.js` | An empty document a filter's realm comes from, and the node assertions |
 | `dom/ranges/` | 17 `.html` | The `Range` and `StaticRange` documents that do not load `dom/common.js`; the twenty-four that do are not-vendored rows |
-| `html/dom/` | 9 `.html`, 7 `.js` | ARIA reflection, `accessKeyLabel`, HTML's historical members, and `reflection-misc.html`, `-text.html`, `-grouping.html` and `-metadata.html` with the helpers they load — four of HTML's ten reflection documents. The other six are the browser lane's README |
+| `html/dom/` | 10 `.html`, 8 `.js` | ARIA reflection, `accessKeyLabel`, HTML's historical members, and `reflection-misc.html`, `-text.html`, `-grouping.html`, `-metadata.html` and `-sections.html` with the helpers they load — five of HTML's ten reflection documents. The other five are the browser lane's README |
 | `dom/constants.js` | 1 | The `Node` and `NodeFilter` constant tables, shared by `dom/nodes/` and `dom/traversal/` |
 | `dom/common.js` is *not* here | — | It calls `document.createCDATASection` at file scope, which the bindings do not have, so every document that loads it reports nothing at all |
 
@@ -1635,8 +1635,8 @@ find . -type f \( $TYPES \) | sort | while read -r f; do
 done
 ```
 
-Silence is a clean corpus, and at this pin there are 890 files in 79 directories to be silent
-about — 362 of them the documents the browser lane navigates to, the rest the scripts, payloads and
+Silence is a clean corpus, and at this pin there are 892 files in 79 directories to be silent
+about — 363 of them the documents the browser lane navigates to, the rest the scripts, payloads and
 sidecars every lane reads.
 
 <!-- end generated -->

--- a/Jint.Tests/Wpt/Vendor/html/dom/elements-sections.js
+++ b/Jint.Tests/Wpt/Vendor/html/dom/elements-sections.js
@@ -1,0 +1,64 @@
+var sectionElements = {
+  body: {
+    // Obsolete
+    text: {type: "string", treatNullAsEmptyString: true},
+    link: {type: "string", treatNullAsEmptyString: true},
+    vLink: {type: "string", treatNullAsEmptyString: true},
+    aLink: {type: "string", treatNullAsEmptyString: true},
+    bgColor: {type: "string", treatNullAsEmptyString: true},
+    background: "string",
+  },
+  article: {},
+  section: {},
+  nav: {},
+  aside: {},
+  h1: {
+    // Obsolete
+    align: "string",
+  },
+  h2: {
+    // Obsolete
+    align: "string",
+  },
+  h3: {
+    // Obsolete
+    align: "string",
+  },
+  h4: {
+    // Obsolete
+    align: "string",
+  },
+  h5: {
+    // Obsolete
+    align: "string",
+  },
+  h6: {
+    // Obsolete
+    align: "string",
+  },
+  hgroup: {},
+  header: {},
+  footer: {},
+  address: {},
+};
+
+mergeElements(sectionElements);
+
+extraTests.push(function() {
+  ReflectionTests.reflects({type: "enum", keywords: ["ltr", "rtl", "auto"]}, "dir", document, "dir", document.documentElement);
+  // TODO: these behave differently if the body element is a frameset.  Also
+  // should probably test with multiple bodies.
+  ReflectionTests.reflects({type: "string", treatNullAsEmptyString: true}, "fgColor", document, "text", document.body);
+  ReflectionTests.reflects({type: "string", treatNullAsEmptyString: true}, "linkColor", document, "link", document.body);
+  ReflectionTests.reflects({type: "string", treatNullAsEmptyString: true}, "vlinkColor", document, "vlink", document.body);
+  ReflectionTests.reflects({type: "string", treatNullAsEmptyString: true}, "alinkColor", document, "alink", document.body);
+  ReflectionTests.reflects({type: "string", treatNullAsEmptyString: true}, "bgColor", document, "bgcolor", document.body);
+  // Edge remains RTL if we don't do this, despite removing the attribute
+  document.dir = "ltr";
+  // Don't mess up the colors :)
+  document.documentElement.removeAttribute("dir");
+  var attrs = ["text", "bgcolor", "link", "alink", "vlink"];
+  for (var i = 0; i < attrs.length; i++) {
+    document.body.removeAttribute(attrs[i]);
+  }
+});

--- a/Jint.Tests/Wpt/Vendor/html/dom/reflection-sections.html
+++ b/Jint.Tests/Wpt/Vendor/html/dom/reflection-sections.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>HTML5 reflection tests: section elements</title>
+<meta name=timeout content=long>
+<p>Implementers looking to fix bugs might want to use the <a
+href=reflection-original.html>original version</a> of this suite's test
+framework, which conveniently aggregates similar errors and only reports
+failures.  This file is (part of) the authoritative conformance test suite, and
+is suitable for incorporation into automated test suites.
+
+<div id=log></div>
+
+<script src="/resources/testharness.js"></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=original-harness.js></script>
+<script src=new-harness.js></script>
+<script src=elements-sections.js></script>
+<script src=reflection.js></script>

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
@@ -557,6 +557,11 @@ internal sealed class ModelBuilder
         var qualified = CSharpNames.Literal(model.DomName + "." + entry.Member);
         var attribute = CSharpNames.Literal(entry.Attribute);
 
+        if (!TryReflectedTarget(model, entry, out var target))
+        {
+            return false;
+        }
+
         if (entry.Type == "enum")
         {
             if (entry.Keywords.Count == 0)
@@ -576,13 +581,16 @@ internal sealed class ModelBuilder
             var invalid = entry.Invalid is null ? "null" : CSharpNames.Literal(entry.Invalid);
 
             factory = "ReflectedAttribute.Enumerated(" + qualified + ", " + attribute + ", " + keywords
-                + ", missing: " + missing + ", invalid: " + invalid + ")";
+                + ", missing: " + missing + ", invalid: " + invalid + target + ")";
             return true;
         }
 
         if (entry.Type == "string")
         {
-            factory = "ReflectedAttribute.Text(" + qualified + ", " + attribute + (entry.Nullable ? ", nullable: true" : "") + ")";
+            factory = "ReflectedAttribute.Text(" + qualified + ", " + attribute
+                + (entry.Nullable ? ", nullable: true" : "")
+                + (entry.LegacyNullToEmptyString ? ", legacyNullToEmptyString: true" : "")
+                + target + ")";
             return true;
         }
 
@@ -604,6 +612,14 @@ internal sealed class ModelBuilder
         {
             factory = "ReflectedAttribute.Nonce(" + qualified + ", " + attribute + ")";
             return true;
+        }
+
+        if (entry.LegacyNullToEmptyString)
+        {
+            _model.Diagnostics.Add(
+                "overrides.json reflects " + model.DomName + "." + entry.Member + " (" + entry.Reason
+                + ") as '" + entry.Type + "' with legacyNullToEmptyString, which WebIDL only puts on a DOMString.");
+            return false;
         }
 
         if (!_numericKinds.TryGetValue(entry.Type, out var numeric))
@@ -632,7 +648,58 @@ internal sealed class ModelBuilder
         return true;
     }
 
+    /// <summary>
+    /// The <c>target:</c> argument one entry's factory takes, or a diagnostic saying why the entry cannot
+    /// have one.
+    /// </summary>
+    /// <remarks>
+    /// HTML's six members that reflect an attribute of another element are all on <c>Document</c> and are
+    /// all a string or an enumeration — §3.2.6.4's <c>dir</c> off the <c>html</c> element and §16.3's five
+    /// obsolete colours off the <c>body</c> element. Both halves are checked here rather than assumed,
+    /// because a row that named a target on a member whose accessor pair could not take one would generate
+    /// a member that silently reflected the wrong element.
+    /// </remarks>
+    private bool TryReflectedTarget(InterfaceModel model, Overrides.ReflectedEntry entry, out string target)
+    {
+        target = "";
+
+        if (entry.Target is null)
+        {
+            return true;
+        }
+
+        if (entry.Type is not ("string" or "enum"))
+        {
+            _model.Diagnostics.Add(
+                "overrides.json reflects " + model.DomName + "." + entry.Member + " (" + entry.Reason
+                + ") onto another element as '" + entry.Type + "'; only a string or an enumeration can.");
+            return false;
+        }
+
+        if (model.DomName != "Document")
+        {
+            _model.Diagnostics.Add(
+                "overrides.json reflects " + model.DomName + "." + entry.Member + " (" + entry.Reason
+                + ") onto another element; only a Document member does that, because the accessor pair"
+                + " that resolves a target takes an IDocument.");
+            return false;
+        }
+
+        if (entry.Target is not ("documentElement" or "body"))
+        {
+            _model.Diagnostics.Add(
+                "overrides.json reflects " + model.DomName + "." + entry.Member + " (" + entry.Reason
+                + ") onto '" + entry.Target + "', which is neither documentElement nor body.");
+            return false;
+        }
+
+        target = ", target: ReflectedTarget."
+            + (entry.Target == "documentElement" ? "DocumentElement" : "Body");
+        return true;
+    }
+
     /// <summary>A C# <c>double</c> literal that round-trips, for a reflected attribute's default value.</summary>
+
     private static string Number(double value) => value.ToString("R", CultureInfo.InvariantCulture);
 
     /// <summary>

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/Overrides.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/Overrides.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Jint.Browser.BindingGenerator;
@@ -259,6 +259,21 @@ internal sealed class Overrides
         /// </summary>
         [JsonPropertyName("nullable")]
         public bool Nullable { get; init; }
+
+        /// <summary>
+        /// WebIDL's <c>[LegacyNullToEmptyString]</c> on a <c>DOMString</c>: the null value converts to the
+        /// empty string rather than to <c>"null"</c>. It says nothing about <c>undefined</c>.
+        /// </summary>
+        [JsonPropertyName("legacyNullToEmptyString")]
+        public bool LegacyNullToEmptyString { get; init; }
+
+        /// <summary>
+        /// Which element the content attribute lives on, when it is not the one the IDL attribute was read
+        /// from: <c>documentElement</c> or <c>body</c>. HTML has six such members and all six are on
+        /// <c>Document</c>.
+        /// </summary>
+        [JsonPropertyName("target")]
+        public string? Target { get; init; }
 
         /// <summary>A numeric attribute's default value, when it is not the type's own.</summary>
         [JsonPropertyName("default")]

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -1617,6 +1617,60 @@
 
   "reflected": [
     {
+      "interface": "Document",
+      "member": "dir",
+      "attribute": "dir",
+      "type": "enum",
+      "keywords": ["ltr", "rtl", "auto"],
+      "target": "documentElement",
+      "reason": "HTML \u00a73.2.6.4: `document.dir` reflects the `dir` content attribute OF THE HTML ELEMENT, limited to only known values -- and returns the empty string and does nothing on setting when there is no such element. AngleSharp has no member for it, and no CLR signature could say which element it reads."
+    },
+    {
+      "interface": "Document",
+      "member": "fgColor",
+      "attribute": "text",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "target": "body",
+      "reason": "HTML \u00a716.3.3: `document.fgColor` reflects the BODY element's `text` content attribute, as a [LegacyNullToEmptyString] DOMString. AngleSharp has no member for it."
+    },
+    {
+      "interface": "Document",
+      "member": "linkColor",
+      "attribute": "link",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "target": "body",
+      "reason": "HTML \u00a716.3.3: the body element's `link` content attribute, as a [LegacyNullToEmptyString] DOMString. AngleSharp has no member for it."
+    },
+    {
+      "interface": "Document",
+      "member": "vlinkColor",
+      "attribute": "vlink",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "target": "body",
+      "reason": "HTML \u00a716.3.3: the body element's `vlink` content attribute, as a [LegacyNullToEmptyString] DOMString. AngleSharp has no member for it."
+    },
+    {
+      "interface": "Document",
+      "member": "alinkColor",
+      "attribute": "alink",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "target": "body",
+      "reason": "HTML \u00a716.3.3: the body element's `alink` content attribute, as a [LegacyNullToEmptyString] DOMString. AngleSharp has no member for it."
+    },
+    {
+      "interface": "Document",
+      "member": "bgColor",
+      "attribute": "bgcolor",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "target": "body",
+      "reason": "HTML \u00a716.3.3: the body element's `bgcolor` content attribute, as a [LegacyNullToEmptyString] DOMString. AngleSharp has no member for it."
+    },
+    {
       "interface": "HTMLElement",
       "member": "dir",
       "attribute": "dir",
@@ -1682,6 +1736,60 @@
       "attribute": "href",
       "type": "url",
       "reason": "HTML \u00a74.2.4 reflects `href` as a URL against the element's node document's current base URL. AngleSharp's Href can retain the URL of a removed base element, so it does not observe later tree mutations (#3896)."
+    },
+    {
+      "interface": "HTMLBodyElement",
+      "member": "text",
+      "attribute": "text",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for, as a [LegacyNullToEmptyString] DOMString -- so `body.text = null` writes the empty string where an ordinary DOMString writes \"null\". AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLBodyElement",
+      "member": "link",
+      "attribute": "link",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute, [LegacyNullToEmptyString]. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLBodyElement",
+      "member": "vLink",
+      "attribute": "vlink",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute, [LegacyNullToEmptyString]. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLBodyElement",
+      "member": "aLink",
+      "attribute": "alink",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute, [LegacyNullToEmptyString]. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLBodyElement",
+      "member": "bgColor",
+      "attribute": "bgcolor",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute, [LegacyNullToEmptyString]. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLBodyElement",
+      "member": "background",
+      "attribute": "background",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. It is a plain DOMString and NOT a URL reflection, which is the one row of this group that is not [LegacyNullToEmptyString] either. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLHeadingElement",
+      "member": "align",
+      "attribute": "align",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for, on the one interface <h1> to <h6> share. AngleSharp has no member for it."
     },
     {
       "interface": "HTMLLinkElement",


### PR DESCRIPTION
`html/dom/reflection-sections.html` becomes a case and **passes whole**, so **5,604 more assertions of HTML §2.6.1 run** with nothing excluded. 704 of them failed on the unfixed tree.

**Stacks on #3979** (the metadata family). The branch is #3979's branch plus one commit, and the base is `main` only because a cross-fork pull request cannot target a branch this repository does not have — so **the diff below contains #3979's commit too, and the one to review here is the second, `Reflection: the sectioning elements' attribute table`.** They merge in order: metadata → **sections** → obsolete → tabular → forms-weekmonth → forms → embedded, and this one is rebased after each merge below it.

## What and why

`reflection-sections.html` tests every content attribute of `<body>`, `<article>`, `<section>`, `<nav>`, `<aside>`, `<h1>`–`<h6>`, `<hgroup>`, `<header>`, `<footer>` and `<address>` — and, in its `extraTests`, six members of `Document` itself. Thirteen `reflected` rows cover all of it, and two of the thirteen needed the row model to learn something it could not say.

## Mechanism

**A row can name the element its content attribute lives on.** Six of the document's members are on `Document` and reflect an attribute of a *different* element:

| Member | Reflects | On | Spec |
| --- | --- | --- | --- |
| `document.dir` | `dir`, limited to only known values | the **html** element | [HTML §3.2.6.4](https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute) |
| `document.fgColor` | `text` | the **body** element | HTML §16.3.3 |
| `document.linkColor` | `link` | the body element | HTML §16.3.3 |
| `document.vlinkColor` | `vlink` | the body element | HTML §16.3.3 |
| `document.alinkColor` | `alink` | the body element | HTML §16.3.3 |
| `document.bgColor` | `bgcolor` | the body element | HTML §16.3.3 |

`ReflectedTarget` is that axis: an entry says `"target": "documentElement"` or `"target": "body"`, and `ReflectedAttribute` grew an `IDocument` accessor pair that resolves it. **A document with no such element reads exactly as an absent content attribute and does nothing on setting** — which is what §3.2.6.4 states of `dir` in as many words, and is why the shared getter takes a nullable element rather than growing a second path.

**A `DOMString` row can be `[LegacyNullToEmptyString]`.** Ten of the thirteen are: `body.text = null` writes the empty string where an ordinary reflected `DOMString` writes `"null"`. It is a flag on the string row rather than a fourteenth algorithm, because only the *setter* changes — and it converts the null value only, so `undefined` still writes `"undefined"`, which is what the corpus asserts either way.

The rest are `HTMLBodyElement`'s six — `text`, `link`, `vLink`, `aLink`, `bgColor`, and `background`, the one that is a plain `DOMString` and not a URL reflection — and `HTMLHeadingElement.align`, the one interface `<h1>` to `<h6>` share. **AngleSharp projects none of the thirteen.**

The generator refuses what the two additions cannot mean, each as a diagnostic rather than as a member that would silently reflect the wrong element:

* a `target` on anything but a `Document` member (the accessor pair that resolves one takes an `IDocument`);
* a `target` on anything but a string or an enumeration (HTML's six are all one or the other);
* a `target` naming anything but `documentElement` or `body`;
* `legacyNullToEmptyString` on anything but a `DOMString`.

## Failing-first evidence

Vendoring the document with **no** rows written and **no** exclusions — 704 of its 5,604 tests fail:

```
 58 #document.dir (<html dir>)      38 h1.align … h6.align   (×6)
 38 body.text  body.link  body.vLink  body.aLink  body.bgColor  body.background
 38 #document.fgColor  #document.linkColor  #document.vlinkColor
 38 #document.alinkColor  #document.bgColor
```

Every one of them is the member being absent (`typeof IDL attribute: expected "string" but got "undefined"`) except `#document.dir`, whose 58 are the *enumeration* rules missing. With the thirteen rows: **0**. The document needs no exclusion table at all.

## Remaining exclusions

None. `WptBrowserExclusions` gains no row for this document.

## Upstream (AngleSharp) findings

* **None of HTML §16.3.3's body-element members is projected.** `IHtmlBodyElement` has no `Text`, `Link`, `VLink`, `ALink`, `BgColor` or `Background`, so `document.body.bgColor` is `undefined` and assigning to it makes an expando that writes no attribute.
* **`IHtmlHeadingElement` has no `Align`**, which is the one member HTML gives that interface.
* **`IDocument` has no `Dir`, `FgColor`, `LinkColor`, `VLinkColor`, `ALinkColor` or `BgColor`.** These are the six members whose *storage* is another element, so no CLR property signature could carry the fact even if one existed — which is why the `reflected` list is where they belong rather than `additions`.

None of these is a defect so much as a surface AngleSharp never modelled; no issues were opened on AngleSharp's repositories.

## Deliberately left out

* **`SVGElement`'s half of the `HTMLOrSVGElement` mixin** (carried over from #3979): `nonce` is still on `HTMLElement` only.
* **`document.dir`'s frameset caveat.** The corpus's own comment notes the body members behave differently when the body element is a frameset, and does not test it; nothing here models it either.
* **The five remaining reflection documents**, which are the rest of this stack.

## Verified

| What | Command | Result |
| --- | --- | --- |
| Solution builds | `dotnet build -c Release` | 0 errors |
| The document | `dotnet test -c Release Jint.Tests.Browser --filter RunsTheHtmlDomSuite` | 10/10, both frameworks |
| The whole lane, census on | `JINT_WPT_BROWSER_CENSUS=1 dotnet test -c Release Jint.Tests.Browser --filter Jint.Tests.Browser.Wpt` | 395/395 on net8.0 and net10.0 |
| The whole project | `dotnet test -c Release Jint.Tests.Browser` | 2,282 passed net8.0, 2,286 passed net10.0, 0 failed |
| Instruction files | `dotnet test -c Release Jint.Tests --filter AgentInstructionFileTests` | 5/5 |
| Generated bindings | `JINT_DOM_BINDINGS=update`, then `--filter DomBindingsStaleness` | 3/3 |

The census (`html/dom/` 9 → 10 documents, 23,632 → 29,236 tests) was regenerated with `JINT_WPT_BROWSER_CENSUS=update-raising-the-ceiling` and never hand-edited. **The not-passing figure did not move**: it is 1,445 before and after, because the document adds 5,604 registrations and no failures — the raising spelling is needed only because the ceiling check reads the *tests* column alongside it.


The corpus grew, so `Jint.Tests/Wpt/Vendor/README.md`'s **drift-verification recipe** was regenerated too (`JINT_WPT_CENSUS=update dotnet test Jint.Tests -c Release --filter WptCensusTests`): it counts the files and directories the `find` walks, and `WptCensusTests.TheDriftRecipeWalksTheCorpusThatIsVendored` fails while it is stale. The two vendored files this pull request adds were fetched from `raw.githubusercontent.com` at the pinned commit, which is the same bytes that recipe compares.

**Rebased onto `b31a05fd1`** (AngleSharp.Css 1.1.1-beta.308) and re-verified there: the browser wpt lane is **397/397** with `JINT_WPT_BROWSER_CENSUS=1` on net8.0, green. The count moved from the table above because main's #3974 added two tests to the lane; nothing in this branch changed, and the Css bump does not move `<style>`'s `media` behaviour.

## Doubts

`ElementIn` resolves `body` through AngleSharp's `IDocument.Body`. HTML's "body element" is the first `body`-or-`frameset` child of the html element; AngleSharp's property is the same idea, but a document whose body is a `<frameset>` is not covered by any vendored test here, and the corpus explicitly declines to test it.

Part of #3770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
