### PR TITLE
Add Fetch.getResponseBody for a response-stage pause

### DIFF
--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -103,10 +103,23 @@ target/runtime split and the manifest are there and none of it is repeated here.
   pattern asking for `requestStage: "Response"` pauses with the response's status and headers, and
   `continueResponse`, `fulfillRequest` and `failRequest` answer one — a default pattern still pauses the
   request stage only, that being the protocol's own default, and pausing both would double every pause a
-  recorded client expects. **`IO`, `Fetch.getResponseBody` and `takeResponseBodyAsStream` are still absent,
-  for a different reason than they used to be**: the pause has the response's *headers* while its body is
-  still on the socket, so there are no bytes to hand a client without buffering them first, which is a
-  budget decision rather than a hook. Still absent with a reason: `eventSourceMessageReceived` (a stream is
+  recorded client expects. **`Fetch.getResponseBody` is here**, over the engine's
+  `FetchResponseInterceptionContext`: it is the only thing that ever buffers a paused body, so a pattern that
+  pauses responses copies nothing until a client asks, and what it reads is **replayed ahead of the unread
+  remainder** — the page receives every original byte exactly once whether the read succeeded, was refused or
+  never happened. Both the bytes and the base64 reply are charged to the page's one reservation ledger
+  (`PageNetworkRecorder.TryReserve`, bounded by `BrowserOptions.MaxCapturedResponseBytes` and shared with the
+  `Network` captures, which it evicts and is never evicted by), and the reply's lease is held until the
+  transport has actually written it — `IDevToolsConnection.SendTrackedAsync` reached through
+  `CommandContext.HoldUntilReplyWritten`, which is what stops repeated commands queueing unboundedly many
+  encoded copies behind a slow socket. A body the ledger refuses is `-32000` and **not** a resolved pause. **A
+  read and a terminal decision are serialised per pause**: a `continueResponse`/`fulfillRequest`/`failRequest`
+  arriving mid-read is refused with an explicit invalid-state error, while detach, disable and the fetch's own
+  cancellation always end the pause and are merely deferred for as long as the read lasts — swapping the
+  response's content out from under a read in flight is the one thing the replay cannot survive.
+  **`IO` and `takeResponseBodyAsStream` stay absent**: a stream handle is a second lifetime to bound for a
+  shape no recorded client sends, and that domain's mainstream producers are `Page.printToPDF` and `Tracing`,
+  neither of which exists here. Still absent with a reason: `eventSourceMessageReceived` (a stream is
   observed as bytes rather than as the events they decode into, so its requests are in the log as
   `ResourceType: EventSource` and its messages are nowhere), and the three `webSocketFrame*` events (the
   engine's socket observer is told about the two handshakes and the close, and a frame never reaches it).
@@ -183,7 +196,12 @@ a second truth about the same request.
   debt `FetchObservation.FinalResponse` names, and the body half of it.
 - **The capture is bounded and off by default.** `BrowserOptions.MaxCapturedResponseBytes` bounds the total
   a page holds, the oldest capture is dropped to stay under it, and the copying is armed only while a client
-  has the `Network` domain enabled.
+  has the `Network` domain enabled. **That figure is one ledger with two kinds of holder**: a captured body
+  and a `Fetch.getResponseBody` reservation spend it together, because two allowances would each be a bound
+  and neither would bound the page. A chunk charges before it is copied and evicts the oldest capture to make
+  room; a reservation does the same and is itself **pinned**, since the bytes behind it are owed to a
+  response nobody has received yet — so a capture that no longer fits beside one is dropped rather than
+  allowed to overrun. Neither ever waits for a sibling to let go: a sibling may itself be paused.
 
 **The URL is the runtime's.** `PageRuntime.DocumentUrl` is what `location`, `document.URL` and relative
 resolution read, and `pushState` and a fragment navigation move it without reloading. Writing AngleSharp's

--- a/Jint.Browser/DevTools/FetchDomain.cs
+++ b/Jint.Browser/DevTools/FetchDomain.cs
@@ -211,18 +211,26 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
     /// Holds one response until the client answers it, and turns that answer into a decision.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The same wait <see cref="PauseAsync"/> makes, at the other stage, and bounded by the same nothing of
     /// this domain's own — the fetch carries the page's timeout and the document's token. A pause the token
     /// ends delivers the response, because a fetch that has been abandoned is about to fail anyway.
+    /// </para>
+    /// <para>
+    /// <b>This is also the only place a body can be read</b>, which is why the pause carries the reader: the
+    /// bytes are on the socket exactly while this call has not returned, and
+    /// <see cref="GetResponseBodyAsync"/> is the one thing that ever asks for them.
+    /// </para>
     /// </remarks>
     internal async ValueTask<PageNetworkResponseDecision> PauseResponseAsync(
         PageNetworkRequest request,
         PageNetworkResponse response,
+        PageResponseBodyReader body,
         string frameId,
         CancellationToken cancellationToken)
     {
         var id = "interception-job-" + Interlocked.Increment(ref _lastInterception).ToString(CultureInfo.InvariantCulture);
-        var paused = new PausedResponse();
+        var paused = new PausedResponse { Body = body, Abandoned = cancellationToken };
 
         _pausedResponses[id] = paused;
 
@@ -244,7 +252,7 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
         try
         {
             using var registration = cancellationToken.Register(
-                static state => ((PausedResponse) state!).Answer(PageNetworkResponseDecision.Proceed),
+                static state => ((PausedResponse) state!).Terminate(PageNetworkResponseDecision.Proceed),
                 paused);
 
             return await paused.Completion.Task.ConfigureAwait(false);
@@ -380,11 +388,131 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
             ? Headers(declared)
             : Headers(parameters.BinaryResponseHeaders);
 
-        paused.Answer(headers is null && parameters.ResponseCode is null && parameters.ResponsePhrase is null
-            ? PageNetworkResponseDecision.Proceed
-            : PageNetworkResponseDecision.Continue(parameters.ResponseCode, parameters.ResponsePhrase, headers));
+        Answer(
+            parameters.RequestId,
+            paused,
+            headers is null && parameters.ResponseCode is null && parameters.ResponsePhrase is null
+                ? PageNetworkResponseDecision.Proceed
+                : PageNetworkResponseDecision.Continue(parameters.ResponseCode, parameters.ResponsePhrase, headers),
+            "Fetch.continueResponse");
 
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-getResponseBody — the whole body
+    /// of a response the client is holding at the response stage, base64 always: the bytes are the ones the
+    /// page is about to consume, and encoding them as text would need a second charset policy and would lose
+    /// a binary body.
+    /// </para>
+    /// <para>
+    /// <b>Reading changes nothing the page sees.</b> The bytes taken off the socket are replayed ahead of
+    /// the remainder when the response is released, so the document receives every original byte exactly
+    /// once whether the read happened, was refused, or was never asked for. Repeated reads of the same pause
+    /// answer the same bytes without touching the socket again.
+    /// </para>
+    /// <para>
+    /// <b>It is the only thing that ever buffers a paused body</b>, which is what makes the cost a client's
+    /// own: a pattern that pauses responses copies nothing until this is called. The bytes are charged to
+    /// the page's one allowance — <c>BrowserOptions.MaxCapturedResponseBytes</c>, shared with the
+    /// <c>Network</c> domain's captured bodies — before they are retained, and so is the base64 reply, whose
+    /// reservation is held until that reply has actually been written to the transport. A body the allowance
+    /// refuses is a <c>-32000</c> error and <b>not</b> a resolved pause: the client can still continue,
+    /// fulfil or fail the response afterwards.
+    /// </para>
+    /// <para>
+    /// <b>A read and a terminal decision are serialised.</b> A <c>continueResponse</c>, <c>fulfillRequest</c>
+    /// or <c>failRequest</c> arriving while a read is in flight is refused with an explicit error rather
+    /// than racing the stream; detaching, disabling and the fetch's own cancellation still always end the
+    /// pause, behind the read.
+    /// </para>
+    /// </remarks>
+    protected override async ValueTask<GetResponseBodyResponse> GetResponseBodyAsync(GetResponseBodyRequest parameters, CommandContext context)
+    {
+        if (!_pausedResponses.TryGetValue(parameters.RequestId, out var paused))
+        {
+            // A request-stage or authentication pause is a real identifier naming a moment at which there is
+            // no response yet, which is a different thing from an identifier naming nothing.
+            if (_paused.ContainsKey(parameters.RequestId) || _pausedAuth.ContainsKey(parameters.RequestId))
+            {
+                Throw.ServerError(
+                    "Can only get response body on requests captured after headers received.",
+                    "that identifier names a request-stage pause, where the response does not exist yet");
+            }
+
+            Throw.ServerError("Invalid InterceptionId.");
+        }
+
+        if (!paused!.TryBeginRead())
+        {
+            Throw.ServerError(
+                "Invalid state for Fetch.getResponseBody",
+                "the response has already been answered, or another read of it is still in flight");
+        }
+
+        try
+        {
+            using var abandoned = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken, paused.Abandoned);
+
+            var body = await paused.Body.ReadAsync(abandoned.Token).ConfigureAwait(false);
+            if (body is null)
+            {
+                return Throw.ServerError<GetResponseBodyResponse>(
+                    "Response body exceeds the page's captured-response allowance.",
+                    "see BrowserOptions.MaxCapturedResponseBytes; the response is still paused and can be continued, fulfilled or failed");
+            }
+
+            return Encode(body.Value, paused.Body, context);
+        }
+        finally
+        {
+            paused.EndRead();
+        }
+    }
+
+    /// <summary>Base64-encodes one body, having reserved what the encoded reply will occupy.</summary>
+    /// <remarks>
+    /// <para>
+    /// A retained-payload cap alone is not a memory bound: the reply is a second copy of the body, four
+    /// characters per three bytes and two bytes per character, and the serialized message is a third. Both
+    /// are charged to the same allowance before either exists, and the lease is held until the reply has
+    /// actually left the process rather than until this command returns — which is what stops repeated
+    /// commands queueing unboundedly many encoded copies behind a slow transport.
+    /// </para>
+    /// <para>
+    /// The reservation is released by the session, once, whether the reply was written or the write failed.
+    /// </para>
+    /// </remarks>
+    private static GetResponseBodyResponse Encode(ReadOnlyMemory<byte> body, PageResponseBodyReader reader, CommandContext context)
+    {
+        // 4 characters per 3 bytes, 2 bytes per character, and the same again for the message the reply is
+        // serialized into.
+        var encoded = 4L * ((body.Length + 2L) / 3L);
+        var cost = 4L * encoded;
+
+        IDisposable? lease = null;
+        if (cost > int.MaxValue || !reader.TryReserve((int) cost, out lease))
+        {
+            return Throw.ServerError<GetResponseBodyResponse>(
+                "Response body exceeds the page's captured-response allowance.",
+                "the base64 reply would not fit; see BrowserOptions.MaxCapturedResponseBytes");
+        }
+
+        try
+        {
+            var text = Convert.ToBase64String(body.Span);
+
+            context.HoldUntilReplyWritten(lease);
+            lease = null;
+
+            return new GetResponseBodyResponse { Body = text, Base64Encoded = true };
+        }
+        finally
+        {
+            lease?.Dispose();
+        }
     }
 
     /// <summary>Lets every paused request and response go, which disabling and detaching both do.</summary>
@@ -402,7 +530,9 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
         {
             if (_pausedResponses.TryRemove(id, out var paused))
             {
-                paused.Answer(PageNetworkResponseDecision.Proceed);
+                // Terminate rather than answer: disabling and detaching end a pause whatever else is
+                // happening to it, and a read in flight only defers that by as long as the read lasts.
+                paused.Terminate(PageNetworkResponseDecision.Proceed);
             }
         }
 
@@ -449,10 +579,16 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
         var body = parameters.Body is { } encoded ? Convert.FromBase64String(encoded) : [];
 
         // Either stage: Chrome answers a response-stage pause with this command too, and there the bytes the
-        // server sent are discarded unread rather than never asked for.
-        if (_pausedResponses.TryRemove(parameters.RequestId, out var pausedResponse))
+        // server sent are discarded unread rather than never asked for — including a prefix a body read
+        // took, which is released rather than replayed because nobody will receive this response.
+        if (_pausedResponses.TryGetValue(parameters.RequestId, out var pausedResponse))
         {
-            pausedResponse.Answer(PageNetworkResponseDecision.Fulfill(parameters.ResponseCode, headers, body, parameters.ResponsePhrase));
+            Answer(
+                parameters.RequestId,
+                pausedResponse,
+                PageNetworkResponseDecision.Fulfill(parameters.ResponseCode, headers, body, parameters.ResponsePhrase),
+                "Fetch.fulfillRequest");
+
             return new ValueTask<EmptyResult>(EmptyResult.Instance);
         }
 
@@ -465,9 +601,14 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
     protected override ValueTask<EmptyResult> FailRequestAsync(FailRequestRequest parameters, CommandContext context)
     {
         // Either stage, like fulfillRequest above.
-        if (_pausedResponses.TryRemove(parameters.RequestId, out var pausedResponse))
+        if (_pausedResponses.TryGetValue(parameters.RequestId, out var pausedResponse))
         {
-            pausedResponse.Answer(PageNetworkResponseDecision.Fail(NetworkError(parameters.ErrorReason)));
+            Answer(
+                parameters.RequestId,
+                pausedResponse,
+                PageNetworkResponseDecision.Fail(NetworkError(parameters.ErrorReason)),
+                "Fetch.failRequest");
+
             return new ValueTask<EmptyResult>(EmptyResult.Instance);
         }
 
@@ -488,14 +629,39 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
     }
 
     /// <summary>The paused response one identifier names, or Chrome's own refusal.</summary>
+    /// <remarks>
+    /// It looks up rather than removes, because the claim is the state machine's: a response with a body
+    /// read in flight must be refused rather than quietly taken out of the map and left unanswerable.
+    /// </remarks>
     private PausedResponse TakeResponse(string requestId)
     {
-        if (!_pausedResponses.TryRemove(requestId, out var paused))
+        if (!_pausedResponses.TryGetValue(requestId, out var paused))
         {
             Throw.ServerError("Invalid InterceptionId.");
         }
 
         return paused!;
+    }
+
+    /// <summary>Answers a paused response, or refuses because a body read of it is in flight.</summary>
+    private void Answer(string requestId, PausedResponse paused, PageNetworkResponseDecision decision, string command)
+    {
+        switch (paused.TryAnswer(decision))
+        {
+            case PauseClaim.Taken:
+                _pausedResponses.TryRemove(requestId, out _);
+                return;
+
+            case PauseClaim.Reading:
+                Throw.ServerError(
+                    "Invalid state for " + command,
+                    "a getResponseBody of that response is still in flight; answer it once the read has returned");
+                return;
+
+            default:
+                Throw.ServerError("Invalid InterceptionId.");
+                return;
+        }
     }
 
     /// <summary>Whether one pattern asks about the response stage.</summary>
@@ -642,12 +808,124 @@ internal sealed class FetchDomain : FetchDomainBase, IDetachableDomain
     /// </summary>
     private sealed class PausedResponse
     {
+        private readonly object _gate = new();
+        private bool _reading;
+        private bool _answered;
+        private PageNetworkResponseDecision? _deferred;
+
+        /// <summary>The bounded read of this response's body, valid for as long as the pause is.</summary>
+        internal required PageResponseBodyReader Body { get; init; }
+
+        /// <summary>Cancelled when the fetch this pause belongs to is abandoned or times out.</summary>
+        internal required CancellationToken Abandoned { get; init; }
+
         internal TaskCompletionSource<PageNetworkResponseDecision> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        /// <summary>Answers the pause, ignoring a second answer for the same response.</summary>
-        internal void Answer(PageNetworkResponseDecision decision) => Completion.TrySetResult(decision);
+        /// <summary>Claims the pause for a body read, refusing while one is in flight or after a decision.</summary>
+        internal bool TryBeginRead()
+        {
+            lock (_gate)
+            {
+                if (_reading || _answered)
+                {
+                    return false;
+                }
+
+                _reading = true;
+                return true;
+            }
+        }
+
+        /// <summary>Ends a read, applying whatever decision was deferred behind it.</summary>
+        internal void EndRead()
+        {
+            PageNetworkResponseDecision? apply = null;
+
+            lock (_gate)
+            {
+                _reading = false;
+
+                if (_deferred is { } pending)
+                {
+                    _deferred = null;
+                    _answered = true;
+                    apply = pending;
+                }
+            }
+
+            if (apply is { } decision)
+            {
+                Completion.TrySetResult(decision);
+            }
+        }
+
+        /// <summary>
+        /// A client's terminal command, which is refused rather than raced while a read is in flight.
+        /// </summary>
+        internal PauseClaim TryAnswer(PageNetworkResponseDecision decision)
+        {
+            lock (_gate)
+            {
+                if (_answered)
+                {
+                    return PauseClaim.Gone;
+                }
+
+                if (_reading)
+                {
+                    return PauseClaim.Reading;
+                }
+
+                _answered = true;
+            }
+
+            Completion.TrySetResult(decision);
+            return PauseClaim.Taken;
+        }
+
+        /// <summary>
+        /// Detach, disable and the fetch's own cancellation, which always end the pause.
+        /// </summary>
+        /// <remarks>
+        /// Deferred behind a read rather than racing it: swapping the response's content out from under a
+        /// read in flight is the one thing the replay cannot survive, and the read is bounded by the very
+        /// token that fires here, so the deferral is over as soon as that read gives up.
+        /// </remarks>
+        internal void Terminate(PageNetworkResponseDecision decision)
+        {
+            lock (_gate)
+            {
+                if (_answered)
+                {
+                    return;
+                }
+
+                if (_reading)
+                {
+                    _deferred ??= decision;
+                    return;
+                }
+
+                _answered = true;
+            }
+
+            Completion.TrySetResult(decision);
+        }
     }
-
+
+    /// <summary>What claiming a paused response for one decision answered.</summary>
+    private enum PauseClaim
+    {
+        /// <summary>The pause is this caller's, and has been answered.</summary>
+        Taken,
+
+        /// <summary>A body read of the same response is in flight; the pause is untouched.</summary>
+        Reading,
+
+        /// <summary>Something else has already answered it.</summary>
+        Gone,
+    }
+
     /// <summary>
     /// A challenge's own pause, and a third map for the third thing one identifier space can name.
     /// </summary>

--- a/Jint.Browser/DevTools/PageTarget.Network.cs
+++ b/Jint.Browser/DevTools/PageTarget.Network.cs
@@ -162,6 +162,7 @@ internal sealed partial class PageTarget : IPageNetworkListener
     async ValueTask<PageNetworkResponseDecision> IPageNetworkListener.ResponseWillBeDeliveredAsync(
         PageNetworkRequest request,
         PageNetworkResponse response,
+        PageResponseBodyReader body,
         CancellationToken cancellationToken)
     {
         if (_interceptor is not { } interceptor || !interceptor.WantsResponse(request))
@@ -169,7 +170,7 @@ internal sealed partial class PageTarget : IPageNetworkListener
             return PageNetworkResponseDecision.Proceed;
         }
 
-        return await interceptor.PauseResponseAsync(request, response, FrameId, cancellationToken).ConfigureAwait(false);
+        return await interceptor.PauseResponseAsync(request, response, body, FrameId, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -228,8 +228,12 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
         // entry up in a dictionary and complete a promise: no engine, no JsValue, no node. continueWithAuth
         // is the fifth, and its pause is the same one held at the same point: the challenge arrives on the
         // hop's own response, with the loop blocked on that fetch if a running script started it.
+        // getResponseBody is the sixth, and it is the one that *must* be answered here rather than merely
+        // may be: it reads the socket the loop is blocked on, so answering it on the loop would be the loop
+        // waiting for bytes nothing can ask for until it stops waiting. It reaches no engine either — a
+        // reader over a transport stream, a byte array and a base64 string, and no JsValue and no node.
         "Fetch.continueRequest" or "Fetch.failRequest" or "Fetch.fulfillRequest" or "Fetch.continueResponse"
-            or "Fetch.continueWithAuth" => true,
+            or "Fetch.continueWithAuth" or "Fetch.getResponseBody" => true,
         _ => false,
     };
 

--- a/Jint.Browser/Runtime/PageNetworkListener.cs
+++ b/Jint.Browser/Runtime/PageNetworkListener.cs
@@ -347,16 +347,25 @@ internal interface IPageNetworkListener
     /// </summary>
     /// <param name="request">The request, as its last hop went out.</param>
     /// <param name="response">The response, as the server sent it.</param>
+    /// <param name="body">The bounded read of this response's body, valid only until this call returns.</param>
     /// <param name="cancellationToken">Cancelled when the fetch is abandoned or times out.</param>
     /// <remarks>
+    /// <para>
     /// <b>The ask, and <see cref="ResponseReceived"/> is the notification.</b> They are separate calls and
     /// both happen, in that order, exactly as the engine's own <c>OnResponseAsync</c> and <c>OnResponse</c>
     /// are — so a client that rewrote a status sees its own value in the announcement that follows. The wait
     /// is bounded by the page's own timeouts, and it holds the transport thread the request is on.
+    /// </para>
+    /// <para>
+    /// <b><paramref name="body"/> is offered and never made.</b> A listener that never reads costs the page
+    /// nothing and leaves the response streaming; one that reads spends the page's own allowance, and the
+    /// document receives every original byte exactly once either way.
+    /// </para>
     /// </remarks>
     ValueTask<PageNetworkResponseDecision> ResponseWillBeDeliveredAsync(
         PageNetworkRequest request,
         PageNetworkResponse response,
+        PageResponseBodyReader body,
         CancellationToken cancellationToken);
 
     /// <summary>

--- a/Jint.Browser/Runtime/PageNetworkRecorder.cs
+++ b/Jint.Browser/Runtime/PageNetworkRecorder.cs
@@ -44,7 +44,7 @@ namespace Jint.Browser.Runtime;
 /// would have taken to promise otherwise.
 /// </para>
 /// </remarks>
-internal sealed class PageNetworkRecorder : FetchObserver
+internal sealed class PageNetworkRecorder : FetchObserver, IFetchResponseBodyBudget
 {
     /// <summary>The most bytes of a request body copied for a client to read back.</summary>
     /// <remarks>
@@ -69,6 +69,7 @@ internal sealed class PageNetworkRecorder : FetchObserver
 
     private long _syntheticId;
     private long _capturedBytes;
+    private long _reservedBytes;
     private volatile IPageNetworkListener? _listener;
     private volatile bool _captureBodies;
 
@@ -339,10 +340,12 @@ internal sealed class PageNetworkRecorder : FetchObserver
     /// request-stage one does — which is why the command that releases it is named in
     /// <c>PageTarget.RunsOffThread</c> beside the three that release a request.
     /// </remarks>
-    public override async ValueTask<FetchResponseInterception?> OnResponseAsync(
-        ObservedFetchResponse response,
+    public override async ValueTask<FetchResponseInterception?> OnInterceptedResponseAsync(
+        FetchResponseInterceptionContext context,
         CancellationToken cancellationToken)
     {
+        var response = context.Response;
+
         if (response.IsRedirect || _listener is not { } listener)
         {
             return null;
@@ -366,10 +369,14 @@ internal sealed class PageNetworkRecorder : FetchObserver
             return null;
         }
 
+        // The read is offered, never made: the capability exists for as long as the listener is deciding, and
+        // costs nothing at all until something calls it.
+        var reader = new PageResponseBodyReader(context, this);
+
         PageNetworkResponseDecision decision;
         try
         {
-            decision = await listener.ResponseWillBeDeliveredAsync(hop, described, cancellationToken).ConfigureAwait(false);
+            decision = await listener.ResponseWillBeDeliveredAsync(hop, described, reader, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -942,9 +949,82 @@ internal sealed class PageNetworkRecorder : FetchObserver
             Forget(_captureOrder.Dequeue());
         }
 
-        while (_capturedBytes > _maxCaptureBytes && _captureOrder.Count > 0)
+        while (_capturedBytes + _reservedBytes > _maxCaptureBytes && _captureOrder.Count > 0)
         {
             Forget(_captureOrder.Dequeue());
+        }
+    }
+
+    /// <summary>
+    /// Reserves <paramref name="bytes"/> of the page's one allowance for something that is not a capture —
+    /// a paused response's body, or the encoded reply carrying it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>One ledger, two kinds of holder.</b> A reservation and a captured body spend the same
+    /// <c>BrowserOptions.MaxCapturedResponseBytes</c>, so a client reading a paused body is competing with
+    /// the bodies the <c>Network</c> domain kept — which is the only honest arrangement: two allowances
+    /// would each be a bound and neither would bound the page.
+    /// </para>
+    /// <para>
+    /// <b>A reservation evicts and is never evicted.</b> Completed captures are dropped oldest-first to
+    /// admit one, exactly as a chunk does; a reservation itself is pinned, because the bytes behind it are
+    /// owed to a response that has not been delivered yet. And it never waits for a sibling to let go: a
+    /// sibling may itself be paused, so waiting is a deadlock rather than a delay.
+    /// </para>
+    /// </remarks>
+    public bool TryReserve(int bytes, out IDisposable? lease)
+    {
+        lease = null;
+
+        if (bytes < 0)
+        {
+            return false;
+        }
+
+        if (bytes == 0)
+        {
+            return true;
+        }
+
+        lock (_gate)
+        {
+            while (bytes > _maxCaptureBytes - _capturedBytes - _reservedBytes && _captureOrder.Count > 0)
+            {
+                Forget(_captureOrder.Dequeue());
+            }
+
+            if (bytes > _maxCaptureBytes - _capturedBytes - _reservedBytes)
+            {
+                return false;
+            }
+
+            _reservedBytes += bytes;
+        }
+
+        lease = new Reservation(this, bytes);
+        return true;
+    }
+
+    private void Release(int bytes)
+    {
+        lock (_gate)
+        {
+            _reservedBytes -= bytes;
+        }
+    }
+
+    /// <summary>What gives one reservation back, exactly once.</summary>
+    private sealed class Reservation(PageNetworkRecorder recorder, int bytes) : IDisposable
+    {
+        private int _released;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                recorder.Release(bytes);
+            }
         }
     }
 
@@ -994,9 +1074,17 @@ internal sealed class PageNetworkRecorder : FetchObserver
             return;
         }
 
-        while (chunk.Length > _maxCaptureBytes - _capturedBytes && _captureOrder.Count > 0)
+        while (chunk.Length > _maxCaptureBytes - _capturedBytes - _reservedBytes && _captureOrder.Count > 0)
         {
             Forget(_captureOrder.Dequeue());
+        }
+
+        // A reservation is pinned, so the eviction above cannot always make room: a capture that no longer
+        // fits beside what a paused response is holding is dropped rather than allowed to overrun the page.
+        if (chunk.Length > _maxCaptureBytes - _capturedBytes - _reservedBytes)
+        {
+            DropCapture(entry);
+            return;
         }
 
         // The oldest capture can be this very request. Future chunks must not start it again.

--- a/Jint.Browser/Runtime/PageResponseBodyReader.cs
+++ b/Jint.Browser/Runtime/PageResponseBodyReader.cs
@@ -1,0 +1,58 @@
+using Jint.WebApi.Fetch;
+
+namespace Jint.Browser.Runtime;
+
+#pragma warning disable JINT0002 // the fetch observer is the engine's own network seam; the body read is part of it
+
+/// <summary>
+/// The one bounded read of a paused response's body, as the protocol layer above sees it: the bytes, and the
+/// page's own allowance they are charged to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is valid only while the listener is deciding.</b> The engine seals the read as soon as the response
+/// callback returns, so this must not be captured past the pause it belongs to — the same rule
+/// <c>IPageNetworkListener</c> already states about everything else it is handed.
+/// </para>
+/// <para>
+/// <b>Nothing here is a page value.</b> No engine, no <c>JsValue</c>, no realm, no node — it is a
+/// <c>ReadOnlyMemory&lt;byte&gt;</c> and a reservation, which is what lets it be used from the transport
+/// thread the pause is held on while the page loop is blocked on that very fetch.
+/// </para>
+/// <para>
+/// <b>The allowance is the page's, not the command's.</b> A protocol parameter never widens it: reading a
+/// body and encoding a reply both spend <c>BrowserOptions.MaxCapturedResponseBytes</c>, the same figure the
+/// <c>Network</c> domain's captured bodies spend.
+/// </para>
+/// </remarks>
+internal sealed class PageResponseBodyReader
+{
+    private readonly FetchResponseInterceptionContext _context;
+    private readonly PageNetworkRecorder _ledger;
+
+    internal PageResponseBodyReader(FetchResponseInterceptionContext context, PageNetworkRecorder ledger)
+    {
+        _context = context;
+        _ledger = ledger;
+    }
+
+    /// <summary>
+    /// Reads the whole body, or answers <see langword="null"/> because the page's allowance refused it.
+    /// </summary>
+    /// <param name="cancellationToken">Cancelled when the fetch is abandoned or the client goes away.</param>
+    /// <remarks>
+    /// A refusal is sticky for this response, and whatever was read is replayed to the page either way — the
+    /// engine's own promise, and the reason a read is invisible to the document.
+    /// </remarks>
+    internal ValueTask<ReadOnlyMemory<byte>?> ReadAsync(CancellationToken cancellationToken)
+        => _context.TryReadBodyAsync(_ledger, cancellationToken);
+
+    /// <summary>
+    /// Reserves <paramref name="bytes"/> of the same allowance for something other than the body — the
+    /// encoded copy a reply is built from.
+    /// </summary>
+    /// <param name="bytes">How many bytes are about to be allocated.</param>
+    /// <param name="lease">What gives them back, or <see langword="null"/> when nothing was granted.</param>
+    /// <returns><see langword="true"/> when the allowance had room.</returns>
+    internal bool TryReserve(int bytes, out IDisposable? lease) => _ledger.TryReserve(bytes, out lease);
+}

--- a/Jint.DevTools/AGENTS.md
+++ b/Jint.DevTools/AGENTS.md
@@ -39,11 +39,19 @@ Everything downstream of that follows:
   command on the thread that read it instead, and **the bar for naming a method is that it provably touches
   no engine state, no `JsValue` and no AngleSharp node** — a method that reads any of the three above, an
   `Engine` or a DOM node may never be named, because nothing here would catch it. What it buys is a command
-  answerable while the loop is not: today the three `Fetch` commands that release a paused request
+  answerable while the loop is not: today the `Fetch` commands that release a paused request, and
+  `Fetch.getResponseBody`, which reads the very socket the loop is blocked on
   ([`Jint.Browser/DevTools/AGENTS.md`](../Jint.Browser/DevTools/AGENTS.md)), since the pause holds a
-  transport thread and the loop may be blocked on the very fetch it is about.
+  transport thread and the loop may be blocked on the fetch it is about.
 - **Nothing a command returns may outlive the command.** A `CommandContext` is valid for the command that
-  received it, and must not be captured.
+  received it, and must not be captured. **The one thing that may outlive it is memory the reply itself
+  occupies**, and it has a door of its own: `CommandContext.HoldUntilReplyWritten(lease)` registers something
+  the session disposes once the reply has actually left the process rather than once the dispatch returned.
+  That is what `IDevToolsConnection.SendTrackedAsync` exists for — `SendAsync` completes at the channel
+  enqueue, which says nothing about how long a large encoded payload keeps occupying memory, so a command
+  that reserved for its own reply had no moment at which to release. It completes either way, written or
+  failed: what a caller waits for is "this message is no longer mine". Only a command that registered a lease
+  takes that path; everything else keeps the queue-and-return send it always had.
 - **Serialization happens on the engine thread too**, because that is where the `JsValue` is. That is why
   `ProtocolEvent` carries `ParametersJson` rather than an object: serializing later would mean reflecting
   over a type the session does not know.

--- a/Jint.DevTools/Protocol/Generated/Fetch.g.cs
+++ b/Jint.DevTools/Protocol/Generated/Fetch.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/browser_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, Fetch entries, sha256:4f7250c77f22
+//     manifest: tools/devtools-protocol/manifest.json, Fetch entries, sha256:bfca8d107ac4
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -481,6 +481,12 @@ namespace Jint.DevTools.Domains
                 {
                     var result = await ContinueResponseAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.FetchContinueResponseRequest), context).ConfigureAwait(false);
                     return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "getResponseBody":
+                {
+                    var result = await GetResponseBodyAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.FetchGetResponseBodyRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.FetchGetResponseBodyResponse);
                 }
 
                 // A command manifest.json does not list is method-not-found BEFORE its parameters

--- a/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:6325b5e888f5
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:5a814e01293c
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and

--- a/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:6325b5e888f5
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:5a814e01293c
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -157,6 +157,7 @@ namespace Jint.DevTools.Protocol
             "Fetch.enable",
             "Fetch.failRequest",
             "Fetch.fulfillRequest",
+            "Fetch.getResponseBody",
             "Input.dispatchKeyEvent",
             "Input.dispatchMouseEvent",
             "Input.imeSetComposition",

--- a/Jint.DevTools/Session/CommandContext.cs
+++ b/Jint.DevTools/Session/CommandContext.cs
@@ -17,6 +17,8 @@ namespace Jint.DevTools.Session;
 /// </remarks>
 internal sealed class CommandContext
 {
+    private List<IDisposable>? _held;
+
     internal CommandContext(DevToolsSession session, string? sessionId, CancellationToken cancellationToken)
     {
         Session = session;
@@ -34,4 +36,47 @@ internal sealed class CommandContext
 
     /// <summary>Gets the token cancelled when the client disconnects.</summary>
     internal CancellationToken CancellationToken { get; }
+
+    /// <summary>Gets whether anything is holding memory until this command's reply has been written.</summary>
+    internal bool HoldsUntilReplyWritten => _held is { Count: > 0 };
+
+    /// <summary>
+    /// Keeps <paramref name="lease"/> alive until this command's reply has actually left the process.
+    /// </summary>
+    /// <param name="lease">What to dispose then, or <see langword="null"/> for nothing.</param>
+    /// <remarks>
+    /// <para>
+    /// <b>A result is not free the moment it is returned.</b> A command answering with a large encoded
+    /// payload reserved memory for it, and the reservation has to outlive the command by exactly as long as
+    /// the string does — until the transport has written it. Registering the lease here is what makes the
+    /// session release it at that moment rather than at the end of the dispatch, which is what stops
+    /// repeated commands queueing unboundedly many encoded copies behind a slow socket.
+    /// </para>
+    /// <para>
+    /// The session disposes it exactly once, whether the reply was written, the write failed, or the command
+    /// ended in an error instead. The context itself must still not be captured past the command.
+    /// </para>
+    /// </remarks>
+    internal void HoldUntilReplyWritten(IDisposable? lease)
+    {
+        if (lease is not null)
+        {
+            (_held ??= []).Add(lease);
+        }
+    }
+
+    /// <summary>Disposes what this command was holding. Idempotent, and called by the session alone.</summary>
+    internal void ReleaseHeld()
+    {
+        if (_held is not { } held)
+        {
+            return;
+        }
+
+        _held = null;
+        foreach (var lease in held)
+        {
+            lease.Dispose();
+        }
+    }
 }

--- a/Jint.DevTools/Session/DevToolsSession.cs
+++ b/Jint.DevTools/Session/DevToolsSession.cs
@@ -156,6 +156,7 @@ internal sealed class DevToolsSession
 
         long? id = null;
         string? sessionId = null;
+        CommandContext? context = null;
 
         try
         {
@@ -164,13 +165,25 @@ internal sealed class DevToolsSession
             sessionId = request.SessionId;
 
             var session = Resolve(sessionId);
-            var context = new CommandContext(session, sessionId, cancellationToken);
+            context = new CommandContext(session, sessionId, cancellationToken);
 
             var result = session._gateway is { } gateway
                 ? await gateway.DispatchAsync(session, request, context).ConfigureAwait(false)
                 : await session.DispatchAsync(in request, context).ConfigureAwait(false);
 
-            await SendAsync(ProtocolMessage.WriteResponse(id.Value, result, sessionId), cancellationToken).ConfigureAwait(false);
+            var reply = ProtocolMessage.WriteResponse(id.Value, result, sessionId);
+
+            // A command that reserved memory for its own reply is answered through the tracked send, so the
+            // reservation is released once the string is on the wire rather than once it is queued. Every
+            // other command keeps the queue-and-return send it has always had.
+            if (context.HoldsUntilReplyWritten)
+            {
+                await _root._connection!.SendTrackedAsync(reply, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await SendAsync(reply, cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (ProtocolException exception)
         {
@@ -184,6 +197,9 @@ internal sealed class DevToolsSession
         }
         finally
         {
+            // Whichever way the command ended -- written, refused, or failed before it produced a reply --
+            // nothing it reserved for that reply is still owed anything.
+            context?.ReleaseHeld();
             document.Dispose();
         }
     }

--- a/Jint.DevTools/Transport/IDevToolsConnection.cs
+++ b/Jint.DevTools/Transport/IDevToolsConnection.cs
@@ -20,6 +20,27 @@ internal interface IDevToolsConnection
     /// <summary>Sends one complete protocol message to the client.</summary>
     ValueTask SendAsync(string message, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Sends one message and completes when it has actually left this process, rather than when it was
+    /// queued.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    /// <param name="cancellationToken">Cancelled when the client goes away.</param>
+    /// <remarks>
+    /// <para>
+    /// <b>The difference from <see cref="SendAsync"/> is the whole point.</b> A queue-and-return send says
+    /// nothing about how long the message keeps occupying memory, so a caller holding a reservation for the
+    /// bytes it has just encoded has no moment at which to release it — and repeated commands could queue
+    /// unboundedly many encoded copies behind a slow socket. Awaiting this is that moment.
+    /// </para>
+    /// <para>
+    /// <b>It completes either way.</b> A write that failed, a connection that closed and a queue that was
+    /// abandoned all complete it, because what a caller waits for here is "this message is no longer mine",
+    /// not "the client received it". A transport failure is never thrown out of it.
+    /// </para>
+    /// </remarks>
+    ValueTask SendTrackedAsync(string message, CancellationToken cancellationToken = default);
+
     /// <summary>Gets or sets what one received message is handed to.</summary>
     Func<string, CancellationToken, ValueTask>? MessageReceived { get; set; }
 

--- a/Jint.DevTools/Transport/InProcessConnection.cs
+++ b/Jint.DevTools/Transport/InProcessConnection.cs
@@ -49,6 +49,14 @@ internal sealed class InProcessConnection : IDevToolsConnection
         return default;
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// There is no queue and no socket here, so a message has already left by the time
+    /// <see cref="SendAsync"/> returns and the tracked form is the same call.
+    /// </remarks>
+    public ValueTask SendTrackedAsync(string message, CancellationToken cancellationToken = default)
+        => SendAsync(message, cancellationToken);
+
     /// <summary>Delivers one message as if a client had sent it.</summary>
     internal ValueTask PostAsync(string message, CancellationToken cancellationToken = default)
     {

--- a/Jint.DevTools/Transport/WebSocketConnection.cs
+++ b/Jint.DevTools/Transport/WebSocketConnection.cs
@@ -38,11 +38,12 @@ internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposabl
     private readonly int _maxMessageBytes;
 
     /// <summary>
-    /// What the single writer task drains. A <see langword="null"/> item is the close request: it travels
-    /// the queue like any other message, so everything already queued -- the reply to the very command that
-    /// asked for the close -- reaches the client before the socket goes.
+    /// What the single writer task drains. An item whose <see cref="Outgoing.Message"/> is
+    /// <see langword="null"/> is the close request: it travels the queue like any other message, so
+    /// everything already queued -- the reply to the very command that asked for the close -- reaches the
+    /// client before the socket goes.
     /// </summary>
-    private readonly Channel<string?> _outgoing = Channel.CreateUnbounded<string?>(new UnboundedChannelOptions
+    private readonly Channel<Outgoing> _outgoing = Channel.CreateUnbounded<Outgoing>(new UnboundedChannelOptions
     {
         SingleReader = true,
         SingleWriter = false,
@@ -66,9 +67,37 @@ internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposabl
     /// <inheritdoc/>
     public ValueTask SendAsync(string message, CancellationToken cancellationToken = default)
     {
-        _outgoing.Writer.TryWrite(message);
+        _outgoing.Writer.TryWrite(new Outgoing(message, Written: null));
         return default;
     }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The completion travels with the message rather than being awaited here, because the writer is a
+    /// single task draining one queue and this call may be made from any thread. Every way the item can
+    /// leave the queue completes it -- written, failed, socket already gone, queue abandoned at shutdown --
+    /// so a caller holding a reservation for the encoded bytes is never left holding it.
+    /// </remarks>
+    public ValueTask SendTrackedAsync(string message, CancellationToken cancellationToken = default)
+    {
+        var written = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        if (!_outgoing.Writer.TryWrite(new Outgoing(message, written)))
+        {
+            // The queue is already closed, so nothing will ever drain this one.
+            return default;
+        }
+
+        return new ValueTask(written.Task);
+    }
+
+    /// <summary>One queued message, and whoever is waiting for it to leave.</summary>
+    /// <param name="Message">The message, or <see langword="null"/> for the close request.</param>
+    /// <param name="Written">
+    /// Completed once the message has left the queue one way or another, or <see langword="null"/> when
+    /// nobody is waiting.
+    /// </param>
+    private readonly record struct Outgoing(string? Message, TaskCompletionSource? Written);
 
     /// <summary>
     /// Asks for the connection to close once the command that asked for it has been answered.
@@ -126,7 +155,20 @@ internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposabl
             {
             }
 
+            // The writer may have left early -- a socket already gone -- with items behind it, and a tracked
+            // send racing the close can land after it. Nothing is waiting on this connection once it is over.
+            DrainPending();
+
             RaiseClosed();
+        }
+    }
+
+    /// <summary>Completes every tracked send still queued, because nothing will ever write them.</summary>
+    private void DrainPending()
+    {
+        while (_outgoing.Reader.TryRead(out var abandoned))
+        {
+            abandoned.Written?.TrySetResult();
         }
     }
 
@@ -134,6 +176,7 @@ internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposabl
     public async ValueTask DisposeAsync()
     {
         _outgoing.Writer.TryComplete();
+        DrainPending();
 
         try
         {
@@ -251,7 +294,7 @@ internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposabl
                 if (Volatile.Read(ref _closeRequested) != 0)
                 {
                     // The command's reply is already queued, so the close goes in behind it.
-                    _outgoing.Writer.TryWrite(null);
+                    _outgoing.Writer.TryWrite(new Outgoing(Message: null, Written: null));
                     return;
                 }
             }
@@ -268,18 +311,20 @@ internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposabl
 
     private async Task WriteAsync(CancellationToken cancellationToken)
     {
+        Outgoing outgoing = default;
+
         try
         {
             while (await _outgoing.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                while (_outgoing.Reader.TryRead(out var message))
+                while (_outgoing.Reader.TryRead(out outgoing))
                 {
                     if (_socket.State != WebSocketState.Open)
                     {
                         return;
                     }
 
-                    if (message is null)
+                    if (outgoing.Message is not { } message)
                     {
                         await CloseAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null).ConfigureAwait(false);
                         return;
@@ -287,6 +332,11 @@ internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposabl
 
                     var bytes = Encoding.UTF8.GetBytes(message);
                     await _socket.SendAsync(bytes.AsMemory(), WebSocketMessageType.Text, endOfMessage: true, cancellationToken).ConfigureAwait(false);
+
+                    // The one moment a tracked send is waiting for: the bytes are on the socket and the
+                    // string is nobody's any more.
+                    outgoing.Written?.TrySetResult();
+                    outgoing = default;
                 }
             }
         }
@@ -296,6 +346,18 @@ internal sealed class WebSocketConnection : IDevToolsConnection, IAsyncDisposabl
         catch (WebSocketException)
         {
             // The client went away mid-write. The reader notices too, and the connection ends there.
+        }
+        finally
+        {
+            // Nothing left waiting, whichever way this ended: the message in hand when the socket went, and
+            // everything still queued behind it. A tracked send completes on failure exactly as on success —
+            // what its caller is waiting for is that the message is no longer its own.
+            outgoing.Written?.TrySetResult();
+
+            while (_outgoing.Reader.TryRead(out var abandoned))
+            {
+                abandoned.Written?.TrySetResult();
+            }
         }
     }
 

--- a/Jint.Tests.Browser/DevTools/FetchDomainTests.cs
+++ b/Jint.Tests.Browser/DevTools/FetchDomainTests.cs
@@ -628,6 +628,697 @@ public class FetchDomainTests
             "the default stage is Request, so the response is never paused at");
     }
 
+    // ---------------------------------------------------------------- getResponseBody
+
+    /// <summary>
+    /// The whole body of a response the client is holding, base64 — and the page still receives every one of
+    /// those bytes exactly once afterwards, which is the property the whole read/replay design exists for.
+    /// </summary>
+    [Test]
+    public async Task GetResponseBodyAnswersTheWholeBodyAndThePageStillReceivesIt()
+    {
+        const string Payload = "the whole body, twice over: once to the client and once to the page";
+
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text(Payload));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+
+        var paused = await fixture.PausedAsync();
+        var body = await fixture.GetResponseBodyAsync(paused);
+
+        body.GetProperty("base64Encoded").GetBoolean().Should().BeTrue("bytes are always bytes here");
+        Encoding.UTF8.GetString(Convert.FromBase64String(body.GetProperty("body").GetString()!)).Should().Be(Payload);
+
+        await fixture.ContinueResponseAsync(paused);
+
+        (await fixture.AnswerAsync()).Should().Be(Payload, "the page receives every original byte exactly once");
+    }
+
+    /// <summary>Every byte value, so nothing in the path is a charset in disguise.</summary>
+    [Test]
+    public async Task GetResponseBodyRoundTripsARealBinaryBody()
+    {
+        var payload = new byte[512];
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte) (i % 256);
+        }
+
+        using var server = new LoopbackServer();
+        server.Map("/blob", _ => LoopbackResponse.Raw(payload, "application/octet-stream"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/blob","requestStage":"Response"}]}""");
+
+        await fixture.Page.EvaluateAsync("""
+            window.__answer = null;
+            fetch('/blob')
+                .then(r => r.arrayBuffer())
+                .then(b => { window.__answer = Array.from(new Uint8Array(b)).join(','); },
+                      e => { window.__answer = 'rejected:' + e; });
+            true
+            """);
+
+        var paused = await fixture.PausedAsync();
+        var read = Convert.FromBase64String((await fixture.GetResponseBodyAsync(paused)).GetProperty("body").GetString()!);
+        read.Should().Equal(payload);
+
+        await fixture.ContinueResponseAsync(paused);
+
+        (await fixture.AnswerAsync()).Should().Be(string.Join(",", payload), "the page got the same bytes");
+    }
+
+    /// <summary>Reading twice answers the same bytes rather than reaching for a socket that has moved on.</summary>
+    [Test]
+    public async Task RepeatedReadsOfOnePauseAnswerTheSameBody()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text("read me twice"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+
+        var first = (await fixture.GetResponseBodyAsync(paused)).GetProperty("body").GetString();
+        var second = (await fixture.GetResponseBodyAsync(paused)).GetProperty("body").GetString();
+
+        second.Should().Be(first);
+
+        await fixture.ContinueResponseAsync(paused);
+        (await fixture.AnswerAsync()).Should().Be("read me twice");
+    }
+
+    /// <summary>
+    /// Many replies of the same body do not accumulate: each reply's encoded copy is charged to the page's
+    /// allowance and released once it has been written, so a client that asks twenty times is answered twenty
+    /// times rather than refused on the way.
+    /// </summary>
+    [Test]
+    public async Task RepeatedRepliesDoNotAccumulateEncodedCopies()
+    {
+        var payload = new string('r', 100);
+
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text(payload));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(
+            server,
+            new BrowserOptions { MaxCapturedResponseBytes = 8192 });
+
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+
+        var expected = Convert.ToBase64String(Encoding.UTF8.GetBytes(payload));
+
+        // Each reply reserves about five times the body for its base64 and the message carrying it. Twenty of
+        // those outstanding at once would be far past the page's allowance; twenty in sequence are not.
+        for (var i = 0; i < 20; i++)
+        {
+            (await fixture.GetResponseBodyAsync(paused)).GetProperty("body").GetString()
+                .Should().Be(expected, "reply {0} was refused, so a reservation was never given back", i);
+        }
+
+        await fixture.ContinueResponseAsync(paused);
+        (await fixture.AnswerAsync()).Should().Be(payload);
+    }
+
+    /// <summary>A read then a substitution: the bytes read are discarded and the page sees the client's own.</summary>
+    [Test]
+    public async Task ReadingThenFulfillingDiscardsWhatWasRead()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text("from the server"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+
+        var read = Encoding.UTF8.GetString(Convert.FromBase64String((await fixture.GetResponseBodyAsync(paused)).GetProperty("body").GetString()!));
+        read.Should().Be("from the server");
+
+        await fixture.Session.ResultAsync(
+            "Fetch.fulfillRequest",
+            $$"""
+            {"requestId":"{{paused.GetProperty("requestId").GetString()}}","responseCode":200,
+             "responseHeaders":[{"name":"Content-Type","value":"text/plain"}],
+             "body":"{{Convert.ToBase64String(Encoding.UTF8.GetBytes("from the client"))}}"}
+            """,
+            fixture.Attachment);
+
+        (await fixture.AnswerAsync()).Should().Be("from the client");
+    }
+
+    /// <summary>A read then a failure: the request fails, and the prefix is released rather than replayed.</summary>
+    [Test]
+    public async Task ReadingThenFailingStillFailsTheRequest()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text("never delivered"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+
+        await fixture.GetResponseBodyAsync(paused);
+
+        await fixture.Session.ResultAsync(
+            "Fetch.failRequest",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}","errorReason":"AccessDenied"}""",
+            fixture.Attachment);
+
+        (await fixture.AnswerAsync()).Should().StartWith("rejected:");
+    }
+
+    /// <summary>
+    /// A body the page's allowance refuses is an error and <b>not</b> a resolved pause: the client can still
+    /// answer it, and the page still gets every byte.
+    /// </summary>
+    [Test]
+    public async Task ABodyOverThePagesAllowanceIsRefusedWithoutResolvingThePause()
+    {
+        var payload = new string('x', 4096);
+
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text(payload));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(
+            server,
+            new BrowserOptions { MaxCapturedResponseBytes = 64 });
+
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+
+        var error = await fixture.Session.ErrorAsync(
+            "Fetch.getResponseBody",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment);
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Contain("allowance");
+
+        // Not resolved: the pause is still the client's to answer, and the page loses nothing.
+        await fixture.ContinueResponseAsync(paused);
+        (await fixture.AnswerAsync()).Should().Be(payload, "a refusal never truncates what the page receives");
+    }
+
+    /// <summary>
+    /// Two responses paused at once share one ledger: what the first read is holding is exactly what the
+    /// second does not get, the first's bytes are never evicted to admit the second, and both pages are
+    /// served in full regardless.
+    /// </summary>
+    [Test]
+    public async Task TwoPausesShareOnePageAllowance()
+    {
+        var small = new string('a', 100);
+        var large = new string('b', 6000);
+
+        using var server = new LoopbackServer();
+        server.Map("/small", _ => LoopbackResponse.Text(small));
+        server.Map("/large", _ => LoopbackResponse.Text(large));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(
+            server,
+            new BrowserOptions { MaxCapturedResponseBytes = 8192 });
+
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/small","requestStage":"Response"},{"urlPattern":"*/large","requestStage":"Response"}]}""");
+
+        // Both in flight, so both are paused before either is answered.
+        await fixture.Page.EvaluateAsync("""
+            window.__small = null;
+            window.__large = null;
+            fetch('/small').then(r => r.text()).then(t => { window.__small = t; }, e => { window.__small = 'rejected:' + e; });
+            fetch('/large').then(r => r.text()).then(t => { window.__large = t; }, e => { window.__large = 'rejected:' + e; });
+            true
+            """);
+
+        var first = await fixture.PausedAsync(0);
+        var second = await fixture.PausedAsync(1);
+
+        var (little, big) = first.GetProperty("request").GetProperty("url").GetString()!.EndsWith("/small", StringComparison.Ordinal)
+            ? (first, second)
+            : (second, first);
+
+        (await fixture.GetResponseBodyAsync(little)).GetProperty("body").GetString()
+            .Should().Be(Convert.ToBase64String(Encoding.UTF8.GetBytes(small)));
+
+        (await fixture.Session.ErrorAsync(
+            "Fetch.getResponseBody",
+            $$"""{"requestId":"{{big.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment)).GetProperty("code").GetInt32().Should().Be(
+            -32000,
+            "the ledger is one, and the smaller read is holding part of it");
+
+        // The refusal did not evict what the first read is holding: it answers from the same bytes still.
+        (await fixture.GetResponseBodyAsync(little)).GetProperty("body").GetString()
+            .Should().Be(Convert.ToBase64String(Encoding.UTF8.GetBytes(small)));
+
+        await fixture.ContinueResponseAsync(little);
+        await fixture.ContinueResponseAsync(big);
+
+        (await fixture.AnswerAsync("__small")).Should().Be(small);
+        (await fixture.AnswerAsync("__large")).Should().Be(large, "a refusal costs the page nothing");
+    }
+
+    /// <summary>
+    /// A body read evicts completed <c>Network</c> captures to make room, which is the other half of one
+    /// ledger: a finished capture is the page's cheapest thing to give up, and a paused body is not.
+    /// </summary>
+    [Test]
+    public async Task AReadEvictsACompletedNetworkCaptureToMakeRoom()
+    {
+        var big = new string('b', 8000);
+
+        using var server = new LoopbackServer();
+        server.Map("/first", _ => LoopbackResponse.Text("kept until it is not"));
+        server.Map("/second", _ => LoopbackResponse.Text(big));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(
+            server,
+            new BrowserOptions { MaxCapturedResponseBytes = 8192 });
+
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+
+        await fixture.FetchOnThePageAsync("/first");
+        (await fixture.AnswerAsync()).Should().Be("kept until it is not");
+
+        // The document's own request finished first, so the identifier is looked up by URL rather than by
+        // order.
+        var firstId = fixture.Session
+            .EventsOf("Network.responseReceived", fixture.Attachment)
+            .Select(e => e.GetProperty("params"))
+            .Single(p => p.GetProperty("response").GetProperty("url").GetString()!.EndsWith("/first", StringComparison.Ordinal))
+            .GetProperty("requestId").GetString();
+
+        (await fixture.Session.ResultAsync("Network.getResponseBody", $$"""{"requestId":"{{firstId}}"}""", fixture.Attachment))
+            .GetProperty("body").GetString().Should().Be("kept until it is not", "the capture is there to begin with");
+
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/second","requestStage":"Response"}]}""");
+        await fixture.FetchOnThePageAsync("/second");
+        var paused = await fixture.PausedAsync();
+
+        // Eight kilobytes of body cannot be admitted beside the capture, so the capture goes.
+        await fixture.Session.SendAsync(
+            "Fetch.getResponseBody",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment).WaitAsync(Bound);
+
+        (await fixture.Session.ErrorAsync("Network.getResponseBody", $$"""{"requestId":"{{firstId}}"}""", fixture.Attachment))
+            .GetProperty("code").GetInt32().Should().Be(-32000, "the completed capture was given up to admit the read");
+
+        await fixture.ContinueResponseAsync(paused);
+        (await fixture.AnswerAsync()).Should().Be(big, "and the page is served whatever the ledger decided");
+    }
+
+    /// <summary>A zero allowance refuses every body, and the page is still served.</summary>
+    [Test]
+    public async Task AZeroAllowanceRefusesTheReadAndThePageIsStillServed()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text("still delivered"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(
+            server,
+            new BrowserOptions { MaxCapturedResponseBytes = 0 });
+
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+
+        (await fixture.Session.ErrorAsync(
+            "Fetch.getResponseBody",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment)).GetProperty("code").GetInt32().Should().Be(-32000);
+
+        await fixture.ContinueResponseAsync(paused);
+        (await fixture.AnswerAsync()).Should().Be("still delivered");
+    }
+
+    /// <summary>
+    /// A request-stage pause is a real identifier naming a moment at which there is no response, which is a
+    /// different answer from an identifier naming nothing at all.
+    /// </summary>
+    [Test]
+    public async Task GetResponseBodyIsRefusedAtTheRequestStage()
+    {
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync();
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        var paused = await fixture.PausedAsync();
+
+        var error = await fixture.Session.ErrorAsync(
+            "Fetch.getResponseBody",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment);
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Can only get response body on requests captured after headers received.");
+
+        await fixture.ContinueAsync(paused);
+        await navigation.WaitAsync(Bound);
+    }
+
+    /// <summary>An authentication pause names the same identifier space and has no response body either.</summary>
+    [Test]
+    public async Task GetResponseBodyIsRefusedAtAnAuthenticationPause()
+    {
+        using var server = new LoopbackServer();
+        MapChallenged(server, "/private", "Digest realm=\"jint\", nonce=\"abc\"");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.EnableAsync("""{"handleAuthRequests":true}""");
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/private"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.ContinueAsync(await fixture.PausedAsync());
+
+        var challenged = await fixture.Session.EventAsync("Fetch.authRequired", sessionId: fixture.Attachment, timeoutSeconds: 30);
+
+        var error = await fixture.Session.ErrorAsync(
+            "Fetch.getResponseBody",
+            $$"""{"requestId":"{{challenged.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment);
+
+        error.GetProperty("message").GetString().Should().Be("Can only get response body on requests captured after headers received.");
+
+        await fixture.Session.ResultAsync(
+            "Fetch.continueWithAuth",
+            $$$"""{"requestId":"{{{challenged.GetProperty("requestId").GetString()}}}","authChallengeResponse":{"response":"CancelAuth"}}""",
+            fixture.Attachment);
+
+        await navigation.WaitAsync(Bound);
+    }
+
+    /// <summary>An identifier naming nothing, and one that named a response the client has already released.</summary>
+    [Test]
+    public async Task GetResponseBodyRefusesAnUnknownAndAStaleIdentifier()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text("gone"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        (await fixture.Session.ErrorAsync(
+            "Fetch.getResponseBody",
+            """{"requestId":"interception-job-999"}""",
+            fixture.Attachment)).GetProperty("message").GetString().Should().Be("Invalid InterceptionId.");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+
+        await fixture.ContinueResponseAsync(paused);
+        (await fixture.AnswerAsync()).Should().Be("gone");
+
+        (await fixture.Session.ErrorAsync(
+            "Fetch.getResponseBody",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment)).GetProperty("message").GetString().Should().Be(
+            "Invalid InterceptionId.",
+            "a released pause is gone, whatever it was released with");
+    }
+
+    /// <summary>
+    /// A terminal decision arriving while a read is in flight is refused rather than raced, and the read and
+    /// the release both succeed once it is not.
+    /// </summary>
+    /// <remarks>
+    /// The body is gated on the server side, so the read is genuinely outstanding when the second command
+    /// arrives. Every wait is bounded, and the gate is released whatever the assertions do.
+    /// </remarks>
+    [Test]
+    public async Task ATerminalCommandDuringAReadIsRefusedAndBothSucceedAfterwards()
+    {
+        var payload = Encoding.UTF8.GetBytes("gated body");
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+        server.Map("/gated", _ => new LoopbackResponse
+        {
+            RawBody = payload,
+            WriteBodyAsync = async (stream, token) =>
+            {
+                await release.Task.WaitAsync(Bound, token).ConfigureAwait(false);
+                await stream.WriteAsync(payload, token).ConfigureAwait(false);
+            },
+        }.With("Content-Type", "text/plain; charset=utf-8"));
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+
+        try
+        {
+            await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+            await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/gated","requestStage":"Response"}]}""");
+
+            await fixture.FetchOnThePageAsync("/gated");
+            var paused = await fixture.PausedAsync();
+            var id = paused.GetProperty("requestId").GetString();
+
+            // Started and deliberately not awaited: the body is gated, so this read is still in flight.
+            var reading = fixture.Session.SendAsync("Fetch.getResponseBody", $$"""{"requestId":"{{id}}"}""", fixture.Attachment);
+
+            var refused = await fixture.Session.SendAsync(
+                "Fetch.continueResponse",
+                $$"""{"requestId":"{{id}}"}""",
+                fixture.Attachment).WaitAsync(Bound);
+
+            refused.TryGetProperty("error", out var error).Should().BeTrue("a decision may not race a read");
+            error.GetProperty("code").GetInt32().Should().Be(-32000);
+            error.GetProperty("message").GetString().Should().Be("Invalid state for Fetch.continueResponse");
+
+            // A second read is refused on the same terms: one read of a response at a time.
+            (await fixture.Session.ErrorAsync(
+                "Fetch.getResponseBody",
+                $$"""{"requestId":"{{id}}"}""",
+                fixture.Attachment).WaitAsync(Bound))
+                .GetProperty("message").GetString().Should().Be("Invalid state for Fetch.getResponseBody");
+
+            release.SetResult();
+
+            var body = (await reading.WaitAsync(Bound)).GetProperty("result");
+            Encoding.UTF8.GetString(Convert.FromBase64String(body.GetProperty("body").GetString()!)).Should().Be("gated body");
+
+            await fixture.ContinueResponseAsync(paused);
+            (await fixture.AnswerAsync()).Should().Be("gated body");
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Disabling the domain while a read is in flight still ends the pause — deferred behind the read rather
+    /// than racing it, which is the one thing the replay cannot survive.
+    /// </summary>
+    [Test]
+    public async Task DisablingDuringAReadStillReleasesTheResponse()
+    {
+        var payload = Encoding.UTF8.GetBytes("released anyway");
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var server = new LoopbackServer();
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+        server.Map("/gated", _ => new LoopbackResponse
+        {
+            RawBody = payload,
+            WriteBodyAsync = async (stream, token) =>
+            {
+                await release.Task.WaitAsync(Bound, token).ConfigureAwait(false);
+                await stream.WriteAsync(payload, token).ConfigureAwait(false);
+            },
+        }.With("Content-Type", "text/plain; charset=utf-8"));
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+
+        try
+        {
+            await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+            await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/gated","requestStage":"Response"}]}""");
+
+            await fixture.FetchOnThePageAsync("/gated");
+            var paused = await fixture.PausedAsync();
+
+            var reading = fixture.Session.SendAsync(
+                "Fetch.getResponseBody",
+                $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+                fixture.Attachment);
+
+            await fixture.Session.ResultAsync("Fetch.disable", "{}", fixture.Attachment).WaitAsync(Bound);
+
+            release.SetResult();
+
+            var reply = await reading.WaitAsync(Bound);
+            Encoding.UTF8.GetString(Convert.FromBase64String(reply.GetProperty("result").GetProperty("body").GetString()!))
+                .Should().Be("released anyway", "the read that was already under way finishes");
+
+            (await fixture.AnswerAsync()).Should().Be("released anyway", "and the pause the disable ended delivers it");
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// The one fetch the page loop blocks on rather than pumping through, read while it blocks — the
+    /// threading claim <c>Fetch.getResponseBody</c> makes by being named in <c>PageTarget.RunsOffThread</c>.
+    /// </summary>
+    [Test]
+    public async Task TheOneFetchTheLoopBlocksOnIsReadableWhileItBlocks()
+    {
+        const string Source = "globalThis.__inserted = true;";
+
+        using var server = new LoopbackServer();
+        server.Map("/inserted.js", _ => LoopbackResponse.Script(Source));
+        server.MapHtml("/page", """
+            <html><head><title>Blocked</title><script>
+              var el = document.createElement('script');
+              el.src = '/inserted.js';
+              document.head.appendChild(el);
+            </script></head><body>ok</body></html>
+            """);
+
+        await using var fixture = await InterceptionFixture.OpenAsync(
+            server,
+            new BrowserOptions { SubresourceTimeout = TimeSpan.FromSeconds(8) });
+
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/inserted.js","requestStage":"Response"}]}""");
+
+        var navigation = fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+
+        var paused = await fixture.PausedAsync();
+        paused.GetProperty("responseStatusCode").GetInt32().Should().Be(200);
+
+        var clock = Stopwatch.StartNew();
+        var reply = await fixture.Session.SendAsync(
+            "Fetch.getResponseBody",
+            $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+            fixture.Attachment).WaitAsync(Bound);
+        clock.Stop();
+
+        reply.TryGetProperty("error", out var error).Should().BeFalse(
+            "the read reaches no engine state, so it is answered on the thread that read it rather than queued behind the fetch the loop is blocked on; it answered {0}", error);
+
+        clock.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+
+        Encoding.UTF8.GetString(Convert.FromBase64String(reply.GetProperty("result").GetProperty("body").GetString()!))
+            .Should().Be(Source);
+
+        await fixture.ContinueResponseAsync(paused);
+        await navigation.WaitAsync(Bound);
+
+        (await fixture.Page.EvaluateAsync<bool>("globalThis.__inserted === true")).Should().BeTrue(
+            "the script the client read really did run, from the very bytes it read");
+    }
+
+    /// <summary>
+    /// Reading adds no second announcement of anything: the <c>Network</c> events a request produces are the
+    /// same ones it produced before, because the read is the same transfer seen once.
+    /// </summary>
+    [Test]
+    public async Task ReadingAPausedBodyRaisesNoDuplicateNetworkEvents()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text("counted once"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+        var networkId = paused.GetProperty("networkId").GetString();
+
+        await fixture.GetResponseBodyAsync(paused);
+        await fixture.ContinueResponseAsync(paused);
+        (await fixture.AnswerAsync()).Should().Be("counted once");
+
+        await fixture.Session.EventAsync("Network.loadingFinished", sessionId: fixture.Attachment, timeoutSeconds: 30);
+
+        Count("Network.responseReceived").Should().Be(1);
+        Count("Network.loadingFinished").Should().Be(1);
+        Count("Network.loadingFailed").Should().Be(0);
+
+        // EventsOf answers whole envelopes, so the identifier is one level in.
+        int Count(string method) => fixture.Session
+            .EventsOf(method, fixture.Attachment)
+            .Count(e => e.GetProperty("params").TryGetProperty("requestId", out var id) && id.GetString() == networkId);
+    }
+
+    /// <summary>
+    /// Reading a paused body is not the <c>Network</c> domain's copy of it: that capture is still made, and
+    /// the page's own capture limit is what it always was.
+    /// </summary>
+    [Test]
+    public async Task APausedReadLeavesTheNetworkCaptureAsItWas()
+    {
+        using var server = new LoopbackServer();
+        server.Map("/data", _ => LoopbackResponse.Text("read by the client"));
+        server.MapHtml("/page", "<html><body>ok</body></html>");
+
+        await using var fixture = await InterceptionFixture.OpenAsync(server);
+        await fixture.Page.NavigateAsync(server.Url("/page"), new NavigationOptions { WaitUntil = WaitUntilState.Load });
+        await fixture.EnableAsync("""{"patterns":[{"urlPattern":"*/data","requestStage":"Response"}]}""");
+
+        await fixture.FetchOnThePageAsync("/data");
+        var paused = await fixture.PausedAsync();
+        var networkId = paused.GetProperty("networkId").GetString();
+
+        await fixture.GetResponseBodyAsync(paused);
+        await fixture.ContinueResponseAsync(paused);
+        (await fixture.AnswerAsync()).Should().Be("read by the client");
+
+        await fixture.Session.EventAsync("Network.loadingFinished", sessionId: fixture.Attachment, timeoutSeconds: 30);
+
+        var captured = await fixture.Session.ResultAsync(
+            "Network.getResponseBody",
+            $$"""{"requestId":"{{networkId}}"}""",
+            fixture.Attachment);
+
+        captured.GetProperty("body").GetString().Should().Be("read by the client");
+    }
+
     private sealed class InterceptionFixture : IAsyncDisposable
     {
         private InterceptionFixture(PageSession session, Page page, string attachment, string frameId)
@@ -671,6 +1362,49 @@ public class FetchDomainTests
                 "Fetch.continueRequest",
                 $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
                 Attachment);
+
+        internal Task ContinueResponseAsync(JsonElement paused)
+            => Session.ResultAsync(
+                "Fetch.continueResponse",
+                $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+                Attachment);
+
+        internal Task<JsonElement> GetResponseBodyAsync(JsonElement paused)
+            => Session.ResultAsync(
+                "Fetch.getResponseBody",
+                $$"""{"requestId":"{{paused.GetProperty("requestId").GetString()}}"}""",
+                Attachment);
+
+        /// <summary>
+        /// Starts a <c>fetch</c> on the page and parks its answer, because the expression's own value is a
+        /// promise and the page is what has to await it.
+        /// </summary>
+        internal Task FetchOnThePageAsync(string path)
+            => Page.EvaluateAsync($$"""
+                window.__answer = null;
+                fetch('{{path}}')
+                    .then(r => r.text())
+                    .then(t => { window.__answer = t; }, e => { window.__answer = 'rejected:' + e; });
+                true
+                """);
+
+        /// <summary>What the page's own fetch settled to, waited for within the suite's bound.</summary>
+        internal async Task<string> AnswerAsync(string slot = "__answer")
+        {
+            var deadline = Stopwatch.StartNew();
+
+            while (deadline.Elapsed < Bound)
+            {
+                if (await Page.EvaluateAsync<string?>("window." + slot) is { } answer)
+                {
+                    return answer;
+                }
+
+                await Task.Delay(20).ConfigureAwait(false);
+            }
+
+            throw new TimeoutException("the page's fetch never settled");
+        }
 
         public ValueTask DisposeAsync() => Session.DisposeAsync();
     }

--- a/Jint.Tests.DevTools/Transport/TrackedSendTests.cs
+++ b/Jint.Tests.DevTools/Transport/TrackedSendTests.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Text;
+using Jint.DevTools.Session;
+using Jint.DevTools.Transport;
+
+namespace Jint.Tests.DevTools.Transport;
+
+/// <summary>
+/// The send whose completion is the socket write, and the one thing a command may keep alive past its own
+/// dispatch: the memory its reply occupies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why it exists.</b> <c>SendAsync</c> completes at the channel enqueue, which says nothing about how long
+/// a large encoded payload keeps occupying memory. A command that reserved an allowance for its own reply
+/// therefore had no moment at which to release, and repeated commands could queue unboundedly many encoded
+/// copies behind a slow socket. <c>Fetch.getResponseBody</c> is the first command that needs the moment.
+/// </para>
+/// <para>
+/// <b>Every wait is bounded.</b> A transport test that can hang is a continuous-integration leg that can hang.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public class TrackedSendTests
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(30);
+
+    /// <summary>A lease that says whether and how often it was released.</summary>
+    private sealed class Lease : IDisposable
+    {
+        internal int Releases { get; private set; }
+
+        public void Dispose() => Releases++;
+    }
+
+    // ---------------------------------------------------------------- the session's half
+
+    [Test]
+    public void AContextReleasesWhatItHoldsExactlyOnce()
+    {
+        var lease = new Lease();
+        var context = new CommandContext(session: null!, sessionId: null, CancellationToken.None);
+
+        context.HoldsUntilReplyWritten.Should().BeFalse("a command that reserved nothing takes the ordinary send");
+
+        context.HoldUntilReplyWritten(null);
+        context.HoldsUntilReplyWritten.Should().BeFalse("nothing is not something to hold");
+
+        context.HoldUntilReplyWritten(lease);
+        context.HoldsUntilReplyWritten.Should().BeTrue();
+
+        context.ReleaseHeld();
+        context.ReleaseHeld();
+
+        lease.Releases.Should().Be(1, "the session releases once, whatever happened to the reply");
+    }
+
+    // ---------------------------------------------------------------- the socket's half
+
+    /// <summary>
+    /// A tracked send completes when the bytes are on the socket, not when they are queued — the whole
+    /// distinction the API exists to make.
+    /// </summary>
+    [Test]
+    public async Task ATrackedSendCompletesWhenTheBytesAreOnTheSocket()
+    {
+        await using var pair = await SocketPair.CreateAsync();
+
+        var connection = new WebSocketConnection(pair.Server, maxMessageBytes: 1 << 20);
+        using var stopping = new CancellationTokenSource();
+        var running = connection.RunAsync(stopping.Token);
+
+        var tracked = connection.SendTrackedAsync("{\"id\":1}").AsTask();
+
+        // Nothing has read from the client end yet, so the writer may or may not have flushed; what the test
+        // pins is that reading the frame is enough to complete it, and within the bound.
+        var received = await pair.ReceiveAsync().WaitAsync(Bound);
+        received.Should().Be("{\"id\":1}");
+
+        await tracked.WaitAsync(Bound);
+
+        await stopping.CancelAsync();
+        await pair.CloseAsync();
+
+        try
+        {
+            await running.WaitAsync(Bound);
+        }
+#pragma warning disable CA1031 // the connection ending is what the test just asked for
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+        }
+    }
+
+    /// <summary>
+    /// A tracked send whose message will never be written completes anyway. What a caller waits for is that
+    /// the message is no longer its own, and a reservation nobody releases is a leak.
+    /// </summary>
+    [Test]
+    public async Task ATrackedSendOnAConnectionThatIsGoingAwayStillCompletes()
+    {
+        await using var pair = await SocketPair.CreateAsync();
+
+        var connection = new WebSocketConnection(pair.Server, maxMessageBytes: 1 << 20);
+
+        // Never run, so nothing will ever drain the queue; disposing is what has to answer the caller.
+        var tracked = connection.SendTrackedAsync("{\"id\":1}").AsTask();
+        tracked.IsCompleted.Should().BeFalse("nothing has written it yet");
+
+        await connection.DisposeAsync();
+        await tracked.WaitAsync(Bound);
+
+        // And one made after the queue is closed is answered immediately rather than parked forever.
+        await connection.SendTrackedAsync("{\"id\":2}").AsTask().WaitAsync(Bound);
+    }
+
+    /// <summary>Two ends of one real socket, already upgraded, which is where a connection starts.</summary>
+    private sealed class SocketPair : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly TcpClient _clientSocket;
+        private readonly TcpClient _serverSocket;
+        private readonly WebSocket _client;
+
+        private SocketPair(TcpListener listener, TcpClient clientSocket, TcpClient serverSocket, WebSocket client, WebSocket server)
+        {
+            _listener = listener;
+            _clientSocket = clientSocket;
+            _serverSocket = serverSocket;
+            _client = client;
+            Server = server;
+        }
+
+        internal WebSocket Server { get; }
+
+        internal static async Task<SocketPair> CreateAsync()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+
+            var clientSocket = new TcpClient();
+            var connecting = clientSocket.ConnectAsync(IPAddress.Loopback, ((IPEndPoint) listener.LocalEndpoint).Port);
+            var serverSocket = await listener.AcceptTcpClientAsync().WaitAsync(Bound).ConfigureAwait(false);
+            await connecting.WaitAsync(Bound).ConfigureAwait(false);
+
+            // The handshake belongs to the HTTP layer above; this is the socket as a connection receives it.
+            var server = WebSocket.CreateFromStream(serverSocket.GetStream(), isServer: true, subProtocol: null, Timeout.InfiniteTimeSpan);
+            var client = WebSocket.CreateFromStream(clientSocket.GetStream(), isServer: false, subProtocol: null, Timeout.InfiniteTimeSpan);
+
+            return new SocketPair(listener, clientSocket, serverSocket, client, server);
+        }
+
+        internal async Task<string> ReceiveAsync()
+        {
+            var buffer = new byte[4096];
+            var received = await _client.ReceiveAsync(buffer.AsMemory(), CancellationToken.None).ConfigureAwait(false);
+            return Encoding.UTF8.GetString(buffer, 0, received.Count);
+        }
+
+        internal async Task CloseAsync()
+        {
+            try
+            {
+                if (_client.State == WebSocketState.Open)
+                {
+                    await _client.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, statusDescription: null, CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+#pragma warning disable CA1031 // a socket that will not close politely closes rudely, which is fine here
+            catch (Exception)
+#pragma warning restore CA1031
+            {
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await CloseAsync().ConfigureAwait(false);
+
+            _client.Dispose();
+            Server.Dispose();
+            _clientSocket.Dispose();
+            _serverSocket.Dispose();
+            _listener.Stop();
+        }
+    }
+}

--- a/docs/design/headless-browser.md
+++ b/docs/design/headless-browser.md
@@ -321,15 +321,21 @@ document's request carries the `loaderId` as its `requestId`, which is what make
 response object. A page's `WebSocket` takes the four events the protocol gives a socket — its creation, both
 handshakes and its close — over the engine's own `WebSocketObserver`, and is deliberately *not* in the
 request log, because a socket stays open for as long as the page wants it and an entry would stop
-`networkIdle` firing. What is not there: `Fetch.getResponseBody` and `takeResponseBodyAsStream` and with
-them the `IO` domain, because a response-stage pause has the response's *headers* while its body is still on
-the socket, so handing a client bytes means buffering them first — a budget decision, and
-`Network.getResponseBody` is what answers a body here; the three `webSocketFrame*` events and
+`networkIdle` firing. `Fetch.getResponseBody` answers the whole body of a response-stage pause, base64: the
+bytes are read off the socket through the engine's own seam and then **replayed ahead of the unread
+remainder**, so the page receives every original byte exactly once, and a client that never asks costs the
+page nothing. Both the body and the base64 reply are charged to `BrowserOptions.MaxCapturedResponseBytes` —
+the same allowance `Network`'s captured bodies spend — and a body that does not fit is a `-32000` error
+rather than a resolved pause. What is not there: `Fetch.takeResponseBodyAsStream` and with it the `IO`
+domain, because a stream handle is a second lifetime to bound for a shape no recorded client sends and the
+domain's only mainstream producers are `Page.printToPDF` and `Tracing`, neither of which this browser has;
+the three `webSocketFrame*` events and
 `eventSourceMessageReceived`, because the socket observer is never told about a frame and a stream is
 observed as bytes rather than as the events they decode into; and `Network`'s **timing** document, because
 no phase of a request is measured and a document of zeros reads as a page that loaded instantly. A paused
 request holds the transport thread it is being sent on and never the page loop — the one exception is a
-`<script src>` a running script inserted, which blocks the loop by design.
+`<script src>` a running script inserted, which blocks the loop by design, and which is exactly why the
+commands that release a pause, `getResponseBody` included, are answered off the loop.
 
 **`Emulation` is effective, and the question each command answers is *when*.** The viewport, the emulated
 media type and its Level 5 preference features, touch, focus, geolocation, the user agent and the hardware

--- a/tools/devtools-protocol/manifest.json
+++ b/tools/devtools-protocol/manifest.json
@@ -154,10 +154,15 @@
   //
   // The Fetch response stage is here now, over FetchObserver.OnResponseAsync: a pattern asking for
   // requestStage "Response" pauses, and continueResponse, fulfillRequest and failRequest answer one.
-  // Fetch.getResponseBody, Fetch.takeResponseBodyAsStream and the whole IO domain are still absent, and for
-  // a different reason than they used to be: the pause has the response's *headers* while its body is still
-  // on the socket, so there are no bytes to hand a client without buffering them first, which is a budget
-  // decision rather than a hook. Network.getResponseBody is what answers a body here.
+  // Fetch.getResponseBody is here now, over the engine's FetchResponseInterceptionContext: a response-stage
+  // pause can be asked for the whole body, base64 always, and reading it is invisible to the page because
+  // what was read is replayed ahead of the unread remainder. It is the only thing that ever buffers a paused
+  // body - a pattern that pauses responses copies nothing until a client asks - and both the bytes and the
+  // encoded reply are charged to BrowserOptions.MaxCapturedResponseBytes, the same allowance Network's
+  // captured bodies spend. A body that does not fit is a -32000 error and not a resolved pause.
+  // Fetch.takeResponseBodyAsStream and the whole IO domain stay absent: a stream handle is a second
+  // lifetime to bound for a shape no recorded client sends, and the whole IO domain exists for
+  // Page.printToPDF and Tracing, neither of which this browser has.
   //
   // Fetch.authRequired and continueWithAuth are here now, over FetchObserver.OnAuthRequiredAsync: a 401
   // carrying a WWW-Authenticate pauses when the client asked for handleAuthRequests, and continueWithAuth
@@ -303,6 +308,7 @@
     "Fetch.enable",
     "Fetch.failRequest",
     "Fetch.fulfillRequest",
+    "Fetch.getResponseBody",
     "Input.dispatchKeyEvent",
     "Input.dispatchMouseEvent",
     "Input.imeSetComposition",


### PR DESCRIPTION
Stacked PR 2 of 2 for #3828, on top of **#3977** (`feat/3828-fetch-response-body-seam`) — review that one first; this PR's diff against `main` includes it. Nothing here is reachable without `Fetch.enable` and a `requestStage: "Response"` pattern, and nothing copies a byte until a client calls the command.

Closes #3828.

## What and why

A response-stage pause has the response's *headers* while its body is still on the socket, so a raw-CDP client driving one had no way to read it: the identifier space is the `Fetch` domain's, and `Network.getResponseBody` reads a completed capture rather than a paused response. PR 1 added the engine seam; this adds the one command the issue's scope reduction kept.

## Mechanism

**The read.** `Fetch.getResponseBody` answers the whole body of a response-stage pause, `base64Encoded: true` always — bytes stay bytes, and there is no second charset policy. Repeated reads answer the same bytes without touching the socket again. What the read took is **replayed ahead of the unread remainder** when the pause is released, so the page receives every original byte exactly once whether the read succeeded, was refused, or never happened; `fulfillRequest` and `failRequest` discard it instead, because nobody receives those bytes.

**One page-owned ledger.** `PageNetworkRecorder` now implements `IFetchResponseBodyBudget`, so a reservation and a captured `Network` body spend the same `BrowserOptions.MaxCapturedResponseBytes` — two allowances would each be a bound and neither would bound the page. A reservation evicts completed captures oldest-first to make room, is itself **pinned** (the bytes behind it are owed to a response nobody has received yet), and waits for no sibling, because a sibling may itself be paused. A capture that no longer fits beside a reservation is dropped rather than allowed to overrun.

**The reply is charged too, and released when it is written.** A retained-payload cap alone is not a memory bound: the base64 string is 2.67× the body and the serialized message is another, so `Encode` reserves for both *before* allocating either. Releasing that at the end of the dispatch would be a lie, since the string is still queued — so `Jint.DevTools` gains two additive internal members:

- `IDevToolsConnection.SendTrackedAsync(string, CancellationToken)`, whose completion is the actual socket write rather than the channel enqueue. `WebSocketConnection`'s queue item becomes `(Message, Written)` and the writer completes the waiter after `WebSocket.SendAsync`; every other way an item can leave — write failed, socket gone, queue abandoned at shutdown — completes it too, because what a caller waits for is *this message is no longer mine*, not *the client received it*. `InProcessConnection`'s is the same call, there being no queue.
- `CommandContext.HoldUntilReplyWritten(lease)`, which `DevToolsSession` releases in the tracked send's completion, and in the `finally` for every path that never produced a reply. Only a command that registered a lease takes the tracked path; everything else keeps the send it always had.

Without this, repeated commands could queue unboundedly many encoded copies behind a slow socket.

**A body the ledger refuses is `-32000` and not a resolved pause** — the client can still continue, fulfil or fail the response, and the page loses nothing.

**A per-pause state machine serialises reads against terminal decisions.** A `continueResponse` / `fulfillRequest` / `failRequest` arriving while a read is in flight is refused with an explicit `Invalid state for <command>` rather than racing the stream. Detach, disable and the fetch's own cancellation still *always* end the pause — they are deferred only for as long as the read lasts, which is bounded by the same token, because swapping the response's content out from under a read in flight is the one thing the replay cannot survive.

**It is answered off the page loop**, and there that is not a convenience: `PageTarget.RunsOffThread` names it beside the five commands that release a pause because it reads the very socket the loop blocks on for a `<script src>` a running script inserted. Answering it on the loop would be the loop waiting for bytes nothing can ask for until it stops waiting. It reaches no `Engine`, no `JsValue` and no AngleSharp node — a reader over a transport stream, a byte array and a base64 string.

**Manifest and regeneration.** `Fetch.getResponseBody` was added to `implementedMethods` and the generator re-run; the content diff is exactly three files (the `Fetch` dispatch `case`, the manifest list, two digest headers). `Fetch.takeResponseBodyAsStream` and the `IO` domain stay absent, and the manifest comment now says why in the present tense.

## Failing-first evidence

Each mechanism was removed in turn and the suite re-run, Release `net8.0`; the implementation was restored byte-for-byte after each:

| Mutation | Test that went red |
| --- | --- |
| `PageTarget.RunsOffThread` no longer names `Fetch.getResponseBody` | `TheOneFetchTheLoopBlocksOnIsReadableWhileItBlocks` (times out at `SubresourceTimeout`) |
| The read-versus-decision state machine never answers `Reading` | `ATerminalCommandDuringAReadIsRefusedAndBothSucceedAfterwards` |
| The reply's reservation is never registered, so it is never released | `RepeatedRepliesDoNotAccumulateEncodedCopies` |
| A reservation evicts no completed capture | `AReadEvictsACompletedNetworkCaptureToMakeRoom` |
| Disable *answers* the pause instead of terminating it, so a read in flight swallows it | `DisablingDuringAReadStillReleasesTheResponse` (the page's fetch never settles) |

## What was verified

Release, fresh builds, no `--no-build`, on head `d54d988df`:

- `dotnet build -c Release` (whole solution) — 0 errors, 0 new warnings.
- `dotnet test -c Release Jint.Tests.DevTools/…` — **413/413 net8.0, 415/415 net10.0**. Includes `GeneratedProtocolIsCurrentTests` (the regeneration is byte-identical), `ProtocolManifestTests` (the new method is overridden on a registered domain and nothing else is), the handshake replays, and the new `TrackedSendTests`.
- `dotnet test -c Release Jint.Tests.Browser/… --filter "…DevTools|…Network"` — **196/196 on net8.0 and net10.0** (27 skipped, the client suites behind `JINT_BROWSER_CLIENTS`). `FetchDomainTests` is 37 tests, 23 of them new.
- `dotnet test -c Release Jint.Tests.PublicInterface/…` — **3709 net8.0, 3719 net10.0, 2936 net472**, all passing, including both public-API baselines (unchanged by this PR: nothing here is public).
- `dotnet test -c Release Jint.Tests/…` — the whole engine suite, **12404/12404 on net8.0**.
- `dotnet test -c Release Jint.Tests.Browser/… --filter "FullyQualifiedName!~Wpt"` — everything in the browser suite bar the web-platform-tests corpus: **1906/1906 net8.0, 1910/1910 net10.0** (36 skipped, the gated client suites).

The 23 new protocol tests cover the issue's list: a valid response identifier; a request-stage identifier and an authentication identifier (both `Can only get response body on requests captured after headers received.`); an unknown one and a stale one (`Invalid InterceptionId.`); repeated reads; read-then-`continueResponse`, read-then-`fulfillRequest`, read-then-`failRequest`; a terminal command *during* a read; a real binary round-trip over every byte value; a script-inserted subresource read while the page loop is blocked; no duplicate `Network` events; the `Network` capture unchanged; a body over the allowance; a zero allowance; two simultaneous pauses competing for one ledger; a reservation evicting a completed capture; twenty replies in a row proving the encoded copies do not accumulate; and disabling the domain mid-read, which still ends the pause.

## Deliberately left out

- **`Fetch.takeResponseBodyAsStream` and the `IO` domain**, per the issue's own scope reduction: a stream handle is a second lifetime to bound for a shape no recorded client sends, and `IO`'s mainstream producers are `Page.printToPDF` and `Tracing`, neither of which this browser has.
- **Redirect, request and auth stage reads.** Those pauses have no response body, and each now says so in Chrome's own wording rather than answering `Invalid InterceptionId.`
- **Any new public API.** `IDevToolsConnection`, `CommandContext` and every type touched here are `internal`; the `Jint.DevTools` and `Jint.Browser` public baselines are unchanged, so there is no migration-guide row for this PR (PR 1 carries §5.34 for the engine seam).
- **A text (non-base64) reply.** CDP allows `base64Encoded: false`; answering bytes always is what keeps a binary body intact and avoids a second charset policy.

## Known limitations, stated rather than hidden

- **A read waits for the whole body.** Asking for one on a response that never ends — a server-sent event stream — is bounded only by the page's own fetch timeout. The command is per final response, so a client decides which responses it reads; the pause's own lifetime is what bounds it.
- **The reply's reservation is roughly 5.3× the body** (base64 at 2 bytes per character, plus the serialized message), on top of the body's own buffer. That is deliberate — it is the memory that actually exists — but it means the largest readable body is well under `MaxCapturedResponseBytes` rather than equal to it. PR 1's second commit removes the other half of that pressure by sizing the first buffer reservation from `Content-Length` instead of a fixed step.
- **`Jint.Browser/DevTools/FetchDomain.cs` is the one file in the tree whose committed blob still has CRLF line endings**, so it is re-staged verbatim rather than renormalized: renormalizing it here would bury a 291-line change under 1600 lines of noise, and deciding to normalize it is a separate change. Every other file this PR touches is LF, as the whole tree is.
- **`AReadEvictsACompletedNetworkCaptureToMakeRoom` is the only test that isolates the ledger's pinning**, because for a *successful* read the reply's charge dominates the body's; a mutation that merely stopped a reservation counting against the ledger is not observable through the protocol. Said plainly rather than papered over.

## Upstream findings

None. Nothing here touches AngleSharp or any other third-party repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
