### PR TITLE
Reflection: the week and month input types' attribute table, so 1,579 more assertions of HTML 2.6.1 run

### DIFF
--- a/Jint.Browser/Dom/Generated/DomReflected.g.cs
+++ b/Jint.Browser/Dom/Generated/DomReflected.g.cs
@@ -159,6 +159,50 @@ internal static class DomReflected
     internal static readonly ReflectedAttribute HTMLHtmlElementVersion =
         ReflectedAttribute.Text("HTMLHtmlElement.version", "version");
 
+    /// <summary><c>HTMLInputElement.align</c> reflects <c>align</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementAlign =
+        ReflectedAttribute.Text("HTMLInputElement.align", "align");
+
+    /// <summary><c>HTMLInputElement.formAction</c> reflects <c>formaction</c> as an url.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementFormAction =
+        ReflectedAttribute.Url("HTMLInputElement.formAction", "formaction", documentUrlWhenEmpty: true);
+
+    /// <summary><c>HTMLInputElement.formEnctype</c> reflects <c>formenctype</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementFormEnctype =
+        ReflectedAttribute.Enumerated("HTMLInputElement.formEnctype", "formenctype", ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"], missing: "", invalid: "application/x-www-form-urlencoded");
+
+    /// <summary><c>HTMLInputElement.formMethod</c> reflects <c>formmethod</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementFormMethod =
+        ReflectedAttribute.Enumerated("HTMLInputElement.formMethod", "formmethod", ["get", "post"], missing: "", invalid: "get");
+
+    /// <summary><c>HTMLInputElement.height</c> reflects <c>height</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementHeight =
+        ReflectedAttribute.Numeric("HTMLInputElement.height", "height", ReflectedKind.UnsignedLong, 0);
+
+    /// <summary><c>HTMLInputElement.maxLength</c> reflects <c>maxlength</c> as a limited long.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementMaxLength =
+        ReflectedAttribute.Numeric("HTMLInputElement.maxLength", "maxlength", ReflectedKind.LimitedLong, -1);
+
+    /// <summary><c>HTMLInputElement.minLength</c> reflects <c>minlength</c> as a limited long.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementMinLength =
+        ReflectedAttribute.Numeric("HTMLInputElement.minLength", "minlength", ReflectedKind.LimitedLong, -1);
+
+    /// <summary><c>HTMLInputElement.size</c> reflects <c>size</c> as a limited unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementSize =
+        ReflectedAttribute.Numeric("HTMLInputElement.size", "size", ReflectedKind.LimitedUnsignedLong, 20);
+
+    /// <summary><c>HTMLInputElement.src</c> reflects <c>src</c> as an url.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementSrc =
+        ReflectedAttribute.Url("HTMLInputElement.src", "src");
+
+    /// <summary><c>HTMLInputElement.useMap</c> reflects <c>usemap</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementUseMap =
+        ReflectedAttribute.Text("HTMLInputElement.useMap", "usemap");
+
+    /// <summary><c>HTMLInputElement.width</c> reflects <c>width</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLInputElementWidth =
+        ReflectedAttribute.Numeric("HTMLInputElement.width", "width", ReflectedKind.UnsignedLong, 0);
+
     /// <summary><c>HTMLLIElement.type</c> reflects <c>type</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLLIElementType =
         ReflectedAttribute.Text("HTMLLIElement.type", "type");

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -2315,6 +2315,17 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.accept");
                     self.Target.Accept = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.accept"); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("align",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementAlign.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementAlign.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("alt",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.alt", static (thisObj, args) =>
                 {
@@ -2431,12 +2442,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formAction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formAction");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormAction);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementFormAction.Get(self.Realm, self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formAction", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formAction");
-                    self.Target.FormAction = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.formAction"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementFormAction.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("formEncType",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formEncType", static (thisObj, args) =>
@@ -2449,16 +2460,27 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formEncType");
                     self.Target.FormEncType = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.formEncType"); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("formEnctype",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formEnctype", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formEnctype");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementFormEnctype.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formEnctype", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formEnctype");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementFormEnctype.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("formMethod",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formMethod", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formMethod");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.FormMethod);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementFormMethod.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formMethod", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.formMethod");
-                    self.Target.FormMethod = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.formMethod"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementFormMethod.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("formNoValidate",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.formNoValidate", static (thisObj, args) =>
@@ -2486,12 +2508,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.height");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementHeight.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.height");
-                    self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.height"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementHeight.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("indeterminate",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.indeterminate", static (thisObj, args) =>
@@ -2531,12 +2553,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.maxLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.maxLength");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.MaxLength);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementMaxLength.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.maxLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.maxLength");
-                    self.Target.MaxLength = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.maxLength"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementMaxLength.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("min",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.min", static (thisObj, args) =>
@@ -2553,12 +2575,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.minLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.minLength");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.MinLength);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementMinLength.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.minLength", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.minLength");
-                    self.Target.MinLength = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.minLength"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementMinLength.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("multiple",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.multiple", static (thisObj, args) =>
@@ -2679,23 +2701,23 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.size");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Size);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementSize.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.size", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.size");
-                    self.Target.Size = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.size"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementSize.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("src",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.src");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementSrc.Get(self.Realm, self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.src");
-                    self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLInputElement.src"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementSrc.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("step",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.step", static (thisObj, args) =>
@@ -2732,6 +2754,17 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.type");
                     return global::Jint.Browser.Dom.Files.FileTransferMembers.SetInputType(self.Realm, self.Target, args);
+                }))
+            .Accessor("useMap",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.useMap", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.useMap");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementUseMap.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.useMap", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.useMap");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementUseMap.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("validationMessage",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.validationMessage", static (thisObj, args) =>
@@ -2782,12 +2815,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.width");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementWidth.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInputElement>(thisObj, "HTMLInputElement.width");
-                    self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLInputElement.width"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLInputElementWidth.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("willValidate",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLInputElement.willValidate", static (thisObj, args) =>

--- a/Jint.Browser/Dom/ReflectedAttribute.cs
+++ b/Jint.Browser/Dom/ReflectedAttribute.cs
@@ -31,7 +31,6 @@ internal enum ReflectedTarget
 }
 
 /// <summary>Which of HTML §2.6.1's per-type reflection algorithms an IDL attribute takes.</summary>
-
 internal enum ReflectedKind
 {
     /// <summary>A <c>DOMString</c>, transparently and case-preservingly.</summary>
@@ -122,6 +121,7 @@ internal sealed class ReflectedAttribute
     private readonly long _min;
     private readonly long _max;
     private readonly bool _legacyNull;
+    private readonly bool _documentUrlWhenEmpty;
     private readonly ReflectedTarget _target;
 
     private ReflectedAttribute(
@@ -135,6 +135,7 @@ internal sealed class ReflectedAttribute
         long min = 0,
         long max = 0,
         bool legacyNull = false,
+        bool documentUrlWhenEmpty = false,
         ReflectedTarget target = ReflectedTarget.Self)
     {
         Member = member;
@@ -147,6 +148,7 @@ internal sealed class ReflectedAttribute
         _min = min;
         _max = max;
         _legacyNull = legacyNull;
+        _documentUrlWhenEmpty = documentUrlWhenEmpty;
         _target = target;
     }
 
@@ -177,8 +179,16 @@ internal sealed class ReflectedAttribute
             target: target);
 
     /// <summary>A <c>USVString</c> whose content attribute is defined to contain a URL.</summary>
-    internal static ReflectedAttribute Url(string member, string attribute)
-        => new(member, attribute, ReflectedKind.Url);
+    /// <param name="member">The qualified member name.</param>
+    /// <param name="attribute">The content attribute reflected.</param>
+    /// <param name="documentUrlWhenEmpty">
+    /// HTML §4.10.18.6's exception, which <c>form.action</c> and <c>formAction</c> are the only members
+    /// with: "on getting, when the content attribute is missing or its value is the empty string, the
+    /// element's node document's URL must be returned instead". It is the document's URL and not the base
+    /// URL, so a <c>&lt;base href&gt;</c> does not move it.
+    /// </param>
+    internal static ReflectedAttribute Url(string member, string attribute, bool documentUrlWhenEmpty = false)
+        => new(member, attribute, ReflectedKind.Url, documentUrlWhenEmpty: documentUrlWhenEmpty);
 
     /// <summary>An enumerated attribute limited to known values.</summary>
     /// <param name="member">The qualified member name.</param>
@@ -296,6 +306,10 @@ internal sealed class ReflectedAttribute
 
             case ReflectedKind.Nonce:
                 return DomConvert.Text(element is null ? "" : CryptographicNonce.Get(element));
+
+            case ReflectedKind.Url when _documentUrlWhenEmpty && string.IsNullOrEmpty(value):
+                // "...the element's node document's URL must be returned instead."
+                return DomConvert.Text(element?.Owner?.Url ?? "");
 
             case ReflectedKind.Url:
                 return DomConvert.Text(ResolveUrl(value, baseUri));

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -31,14 +31,14 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `dom/lists/` | 5 | 0 | 189 | 5 |
 | `dom/traversal/` | 13 | 0 | 52 | 0 |
 | `dom/ranges/` | 17 | 0 | 82 | 4 |
-| `html/dom/` | 12 | 0 | 37,973 | 529 |
+| `html/dom/` | 13 | 0 | 39,552 | 529 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 12 |
 | `custom-elements/` | 16 | 0 | 510 | 247 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **356** | **9** | **47,871** | **1,913** |
+| **total** | **357** | **9** | **49,450** | **1,913** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -176,7 +176,7 @@ a supported name; the collection's named reads remain live.
 
 `dom/nodes/`, `dom/collections/`, `dom/lists/`, `dom/traversal/`, `dom/ranges/` and `html/dom/` are the DOM
 standard's own suites and HTML's DOM half — the corpus every other suite in this lane is written on top of.
-Across the six of them there are 223 documents and 46,454 tests, and **1,568 of those tests do not pass**.
+Across the six of them there are 224 documents and 48,033 tests, and **1,568 of those tests do not pass**.
 Those three figures are live and checked against the census. They arrived together as 207 documents and
 5,247 tests with 1,532 not passing; those arrival figures are historical and deliberately not re-derived.
 
@@ -211,19 +211,20 @@ table needs to be regenerated.
 | 3 | 1 | [#3769](https://github.com/sebastienros/jint/issues/3769) **A `(Node or DOMString)` union parameter takes only a `Node`.** Three `ChildNode.before` rows still reject strings. <!-- cause: a (Node or DOMString) union parameter takes only a Node --> |
 | 2 | 1 | **A Range whose shadow root was removed has the wrong boundary behavior.** These are the two remaining `Range-in-shadow-after-the-shadow-removed.html` rows. <!-- cause: Range's own algorithms --> |
 
-**Seven of HTML's ten reflection documents are cases, and four of the seven pass whole.** HTML §2.6.1's
+**Eight of HTML's ten reflection documents are cases, and five of the eight pass whole.** HTML §2.6.1's
 reflection algorithms are `Jint.Browser/Dom/ReflectedAttribute.cs` and the members that take them are
 `overrides.json`'s `reflected` list, so `reflection-misc.html` (4,877 assertions, 1,866 of them failing
 before), `reflection-text.html` (10,202, 3,360 failing before), `reflection-sections.html` (5,604, 2,189
-failing before) and `reflection-tabular.html` (6,116, 3,552 failing before) pass with **nothing** excluded,
-and `reflection-grouping.html` (5,358, 2,006 failing before), `reflection-metadata.html` (3,110, 1,218 failing
+failing before), `reflection-tabular.html` (6,116, 3,552 failing before) and
+`reflection-forms-weekmonth.html` (1,579, 420 failing before) pass with **nothing** excluded, and
+`reflection-grouping.html` (5,358, 2,006 failing before), `reflection-metadata.html` (3,110, 1,218 failing
 before) and `reflection-obsolete.html` (2,621, 1,483 failing before) have one cause each — and none of the
 three causes is reflection.
 
-109 rows did it, and the first fifteen were mostly the **global** attributes every element carries —
+120 rows did it, and the first fifteen were mostly the **global** attributes every element carries —
 `dir`, `lang`, `tabIndex`, `autofocus`, `inputMode`, `enterKeyHint` — which is why `text` needed only eleven
-rows of its own for 3,360 assertions. The rest are element-specific and that is what the remaining three
-documents need: `align`, `maxLength`, `formEnctype` and their kind, one `reflected` row each. `metadata` took seven of those —
+rows of its own for 3,360 assertions. The rest are element-specific and that is what the remaining two
+documents need: `enctype`, `preload`, `decoding` and their kind, one `reflected` row each. `metadata` took seven of those —
 `link`'s `as`, `crossOrigin`, `referrerPolicy`, `charset` and `target`, and `meta`'s `media` and `scheme` —
 plus one member that is deliberately not reflection at all: **`nonce` answers HTML §2.5.3's
 `[[CryptographicNonce]]` slot**, whose setter writes the slot and leaves the content attribute alone, so a
@@ -251,6 +252,13 @@ It also needed one `skip`: AngleSharp splits `<th>` and `<td>` into two interfac
 the header cell's own `scope` shadowed the reflected `HTMLTableCellElement.scope`, so `<th>` answered the raw
 attribute value while `<td>` answered the enumeration.
 
+`forms-weekmonth` took eleven, all on `<input>`, and one of them is HTML's only exception to URL reflection:
+**`formAction` answers the element's node document's URL when the content attribute is missing or empty**
+(§4.10.18.6), which is what a form posting to itself reads. `form.action` is the other member with that rule
+and the row model can say it now. Two more are `<input>`'s `width` and `height`, whose *getters* are the
+rendered image dimensions and are not reflection at all — but whose setters are, in as many words, so the
+rows fix the half that is.
+
 **Neither of the two causes left is reflection**, and both are the dependency. Four obsolete elements —
 `<dl>`, `<dir>`, `<font>` and `<frame>` — get an interface of their own from HTML and a plain `HTMLElement`
 from the pinned assemblies, so there is nowhere for `compact`, `color`, `src` and their kind to be reflected
@@ -260,7 +268,7 @@ is not in it, because `DomManualInterfaces` declares `HTMLFrameSetElement` by lo
 not a media query AngleSharp.Css can parse — the exception comes out of `Element.setAttribute` itself,
 through the attribute observer AngleSharp core registers, where Media Queries §2.1 requires an unparseable
 query to be replaced by `not all`. Those 522 rows are the only failures this lane's `html/dom/` figure
-gained, against 33,011 assertions it did not have before.
+gained, against 34,590 assertions it did not have before.
 
 **Four documents did not terminate at all, and that was the finding this campaign put first.**
 `TreeWalker-currentNode.html`, `TreeWalker-previousNodeLastChildReject.html`, `TreeWalker-traversal-reject.html`

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -289,20 +289,22 @@ internal static class WptBrowserExclusions
         ("html/dom/usvstring-reflection.https.html", "needs webrtc/RTCPeerConnection-helper.js and a real RTCPeerConnection to reflect a USVString off"),
 
         // ------------------------------------------------------------ HTML's reflection suite
-        // Ten generated documents, 56,660 assertions. Seven of them are cases now — reflection-misc.html,
-        // reflection-text.html, reflection-sections.html, reflection-tabular.html, reflection-grouping.html,
-        // reflection-metadata.html and reflection-obsolete.html, 37,888 assertions between them — because
-        // HTML §2.6.1's reflection algorithms are implemented (Jint.Browser/Dom/ReflectedAttribute.cs) and
-        // driven by overrides.json's `reflected` list. Four pass whole; what fails in the other three is
-        // never reflection — it is an element interface the pinned assemblies do not have (<dl>, <dir>,
-        // <font>, <frame>) and <style>'s `media`, which AngleSharp.Css refuses from inside setAttribute.
+        // Ten generated documents, 56,660 assertions. Eight of them are cases now — reflection-misc.html,
+        // reflection-text.html, reflection-sections.html, reflection-tabular.html,
+        // reflection-forms-weekmonth.html, reflection-grouping.html, reflection-metadata.html and
+        // reflection-obsolete.html, 39,467 assertions between them — because HTML §2.6.1's reflection
+        // algorithms are implemented (Jint.Browser/Dom/ReflectedAttribute.cs) and driven by overrides.json's
+        // `reflected` list. Five pass whole; what fails in the other three is never reflection — it is an
+        // element interface the pinned assemblies do not have (<dl>, <dir>, <font>, <frame>) and <style>'s
+        // `media`, which AngleSharp.Css refuses from inside setAttribute.
         //
-        // The other three are out for one reason and it is no longer "reflection is not implemented": each
+        // The other two are out for one reason and it is no longer "reflection is not implemented": each
         // needs the per-element attribute table it tests, one `reflected` row per content attribute, which is
-        // #3770's remaining work. The 109 rows written so far started with the GLOBAL attributes every
+        // #3770's remaining work. The 120 rows written so far started with the GLOBAL attributes every
         // element carries (`dir`, `lang`, `tabIndex`, `autofocus`, `inputMode`, `enterKeyHint`), so they have
-        // already moved the three a long way. What is left in them is `align`, `maxLength`, `formEnctype` and
-        // their kind — element-specific attributes, each one row.
+        // already moved the two a long way — and `forms` shares the whole <input> table with the
+        // week-and-month document, which is a case. What is left is `enctype`, `preload`, `decoding` and
+        // their kind.
         //
         // **None of them is slow**: the whole set runs in 22.5 s and the largest (reflection-embedded.html,
         // 8,922 tests) in 7.3 s, well inside the driver's 30 s deadline. What has always kept them out is the
@@ -310,7 +312,6 @@ internal static class WptBrowserExclusions
         // thing — and that is the thing this suite stops needing one family at a time.
         ("html/dom/*-embedded.*", "#3770: the embedded-content elements and their attribute table; 3,774 of 8,922 assertions failed at the measurement in the issue"),
         ("html/dom/*-forms.*", "#3770: the form controls and their attribute table; 2,160 of 8,271"),
-        ("html/dom/*-forms-weekmonth.*", "#3770: the week and month input types and their attribute table; 420 of 1,579"),
         ("html/dom/reflection-original.html", "the same suite in the aggregating spelling, which reports only failures rather than one test per assertion — a second answer to what reflection-*.html already say"),
         ("html/dom/elements-aria-enumerated.js", "the attribute table of aria-attribute-reflection-enumerated.tentative.html, which tests a proposal the specification has not adopted"),
 
@@ -764,6 +765,7 @@ internal static class WptBrowserExclusions
         ["html/dom/aria-element-reflection-disconnected.html"] = 2,
         ["html/dom/aria-element-reflection.html"] = 27,
         ["html/dom/historical.html"] = 13,
+        ["html/dom/reflection-forms-weekmonth.html"] = 1579,
         ["html/dom/reflection-grouping.html"] = 5358,
         ["html/dom/reflection-metadata.html"] = 3110,
         ["html/dom/reflection-misc.html"] = 4877,

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -385,7 +385,7 @@ corpus.
 | `dom/traversal/` | 13 `.html` | `NodeIterator` and `TreeWalker`; four of them are the walks that used to run forever ([#3765](https://github.com/sebastienros/jint/issues/3765)) |
 | `dom/traversal/support/` | 1 `.html`, 1 `.js` | An empty document a filter's realm comes from, and the node assertions |
 | `dom/ranges/` | 17 `.html` | The `Range` and `StaticRange` documents that do not load `dom/common.js`; the twenty-four that do are not-vendored rows |
-| `html/dom/` | 12 `.html`, 10 `.js` | ARIA reflection, `accessKeyLabel`, HTML's historical members, and `reflection-misc.html`, `-text.html`, `-grouping.html`, `-metadata.html`, `-sections.html`, `-obsolete.html` and `-tabular.html` with the helpers they load — seven of HTML's ten reflection documents. The other three are the browser lane's README |
+| `html/dom/` | 13 `.html`, 11 `.js` | ARIA reflection, `accessKeyLabel`, HTML's historical members, and `reflection-misc.html`, `-text.html`, `-grouping.html`, `-metadata.html`, `-sections.html`, `-obsolete.html`, `-tabular.html` and `-forms-weekmonth.html` with the helpers they load — eight of HTML's ten reflection documents. The other two are the browser lane's README |
 | `dom/constants.js` | 1 | The `Node` and `NodeFilter` constant tables, shared by `dom/nodes/` and `dom/traversal/` |
 | `dom/common.js` is *not* here | — | It calls `document.createCDATASection` at file scope, which the bindings do not have, so every document that loads it reports nothing at all |
 
@@ -1635,8 +1635,8 @@ find . -type f \( $TYPES \) | sort | while read -r f; do
 done
 ```
 
-Silence is a clean corpus, and at this pin there are 896 files in 79 directories to be silent
-about — 365 of them the documents the browser lane navigates to, the rest the scripts, payloads and
+Silence is a clean corpus, and at this pin there are 898 files in 79 directories to be silent
+about — 366 of them the documents the browser lane navigates to, the rest the scripts, payloads and
 sidecars every lane reads.
 
 <!-- end generated -->

--- a/Jint.Tests/Wpt/Vendor/html/dom/elements-forms-weekmonth.js
+++ b/Jint.Tests/Wpt/Vendor/html/dom/elements-forms-weekmonth.js
@@ -1,0 +1,42 @@
+var formElements = {
+  input: {
+    // Conforming
+    accept: "string",
+    alt: "string",
+    autocomplete: {type: "string", customGetter: true},
+    defaultChecked: {type: "boolean", domAttrName: "checked"},
+    dirName: "string",
+    disabled: "boolean",
+    // "formAction" has magic hard-coded in reflection.js
+    formAction: "url",
+    formEnctype: {type: "enum", keywords: ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"], invalidVal: "application/x-www-form-urlencoded"},
+    formMethod: {type: "enum", keywords: ["get", "post"], invalidVal: "get"},
+    formNoValidate: "boolean",
+    formTarget: "string",
+    height: {type: "unsigned long", customGetter: true},
+    max: "string",
+    maxLength: "limited long",
+    min: "string",
+    minLength: "limited long",
+    multiple: "boolean",
+    name: "string",
+    pattern: "string",
+    placeholder: "string",
+    readOnly: "boolean",
+    required: "boolean",
+    // https://html.spec.whatwg.org/#attr-input-size
+    size: {type: "limited unsigned long", defaultVal: 20},
+    src: "url",
+    step: "string",
+    type: {type: "enum", keywords: ["month", "week"],
+      defaultVal: "text"},
+    width: {type: "unsigned long", customGetter: true},
+    defaultValue: {type: "string", domAttrName: "value"},
+
+    // Obsolete
+    align: "string",
+    useMap: "string",
+  },
+};
+
+mergeElements(formElements);

--- a/Jint.Tests/Wpt/Vendor/html/dom/reflection-forms-weekmonth.html
+++ b/Jint.Tests/Wpt/Vendor/html/dom/reflection-forms-weekmonth.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>HTML5 reflection tests: week and month input types</title>
+<meta name=timeout content=long>
+<p>Implementers looking to fix bugs might want to use the <a
+href=reflection-original.html>original version</a> of this suite's test
+framework, which conveniently aggregates similar errors and only reports
+failures.  This file is (part of) the authoritative conformance test suite, and
+is suitable for incorporation into automated test suites.
+
+<div id=log></div>
+
+<script src="/resources/testharness.js"></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=original-harness.js></script>
+<script src=new-harness.js></script>
+<script src=elements-forms-weekmonth.js></script>
+<script src=reflection.js></script>

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
@@ -596,7 +596,8 @@ internal sealed class ModelBuilder
 
         if (entry.Type == "url")
         {
-            factory = "ReflectedAttribute.Url(" + qualified + ", " + attribute + ")";
+            factory = "ReflectedAttribute.Url(" + qualified + ", " + attribute
+                + (entry.DocumentUrlWhenEmpty ? ", documentUrlWhenEmpty: true" : "") + ")";
             return true;
         }
 
@@ -612,6 +613,14 @@ internal sealed class ModelBuilder
         {
             factory = "ReflectedAttribute.Nonce(" + qualified + ", " + attribute + ")";
             return true;
+        }
+
+        if (entry.DocumentUrlWhenEmpty)
+        {
+            _model.Diagnostics.Add(
+                "overrides.json reflects " + model.DomName + "." + entry.Member + " (" + entry.Reason
+                + ") as '" + entry.Type + "' with documentUrlWhenEmpty, which HTML only puts on a URL attribute.");
+            return false;
         }
 
         if (entry.LegacyNullToEmptyString)

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/Overrides.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/Overrides.cs
@@ -268,6 +268,13 @@ internal sealed class Overrides
         public bool LegacyNullToEmptyString { get; init; }
 
         /// <summary>
+        /// HTML §4.10.18.6's exception on a URL attribute: a missing or empty content attribute answers the
+        /// element's node document's URL. Only <c>form.action</c> and <c>formAction</c> have it.
+        /// </summary>
+        [JsonPropertyName("documentUrlWhenEmpty")]
+        public bool DocumentUrlWhenEmpty { get; init; }
+
+        /// <summary>
         /// Which element the content attribute lives on, when it is not the one the IDL attribute was read
         /// from: <c>documentElement</c> or <c>body</c>. HTML has six such members and all six are on
         /// <c>Document</c>.

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -1899,6 +1899,89 @@
       "reason": "HTML \u00a716.2: `htmlFor` reflects `for`, the one member of this group whose IDL name and content attribute name differ. AngleSharp has no member for it."
     },
     {
+      "interface": "HTMLInputElement",
+      "member": "formAction",
+      "attribute": "formaction",
+      "type": "url",
+      "documentUrlWhenEmpty": true,
+      "reason": "HTML \u00a74.10.18.6: `formAction` reflects the content attribute as a URL, EXCEPT that a missing or empty attribute answers the element's node document's URL instead. AngleSharp's FormAction is the raw attribute value, so `input.formAction` answered \"\" where every browser answers the page's address -- which is what a form posting to itself reads."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "formEnctype",
+      "attribute": "formenctype",
+      "type": "enum",
+      "keywords": ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"],
+      "invalid": "application/x-www-form-urlencoded",
+      "reason": "HTML \u00a74.10.18.6: an enumerated attribute whose invalid value default is the URL-encoded form and whose missing value default is the empty string -- the two differ, which is the whole reason the row carries both. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "formMethod",
+      "attribute": "formmethod",
+      "type": "enum",
+      "keywords": ["get", "post"],
+      "invalid": "get",
+      "reason": "HTML \u00a74.10.18.6: an enumerated attribute with an invalid value default of `get` and an empty missing value default. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "maxLength",
+      "attribute": "maxlength",
+      "type": "limited long",
+      "reason": "HTML \u00a74.10.5.3.1: `maxLength` is a long limited to only non-negative numbers, so its default is -1 and a negative IDL set is an IndexSizeError. AngleSharp types it as an Int32 with .NET's own parse and no refusal."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "minLength",
+      "attribute": "minlength",
+      "type": "limited long",
+      "reason": "HTML \u00a74.10.5.3.2: the same algorithm as maxLength. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "size",
+      "attribute": "size",
+      "type": "limited unsigned long",
+      "default": 20,
+      "reason": "HTML \u00a74.10.5.3.5: `size` is an unsigned long limited to only positive numbers, with a default of 20 -- so zero is an IndexSizeError on setting and anything unparseable or out of range reads back as 20. AngleSharp types it as an Int32 whose default is 0."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "src",
+      "attribute": "src",
+      "type": "url",
+      "reason": "HTML \u00a74.10.5.1.19 reflects `src` as a URL, so it answers the absolute URL the attribute resolves to. AngleSharp's Source is the raw attribute value, the same divergence script.src had."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "height",
+      "attribute": "height",
+      "type": "unsigned long",
+      "reason": "HTML \u00a74.10.5.1.20: the GETTER is the rendered height of the image and is not reflection, but the SETTER is -- \"on setting, they must reflect the respective content attributes of the same name\". This package renders no image, so the getter answers the content attribute either way; what the row fixes is the setter, which AngleSharp implements as an Int32 write, so `input.height = 4294967295` wrote \"-1\"."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "width",
+      "attribute": "width",
+      "type": "unsigned long",
+      "reason": "HTML \u00a74.10.5.1.20 again, and the same halves: the setter reflects and the getter is the rendered width, which there is none of here."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "align",
+      "attribute": "align",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLInputElement",
+      "member": "useMap",
+      "attribute": "usemap",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
       "interface": "HTMLModElement",
       "member": "cite",
       "attribute": "cite",


### PR DESCRIPTION
`html/dom/reflection-forms-weekmonth.html` becomes a case and **passes whole**, so **1,579 more assertions of HTML §2.6.1 run** with nothing excluded. 420 failed at the measurement in #3770 and 359 on today's `main`.

**Stacks on #3984**, which stacks on #3983 → #3981 → #3979. The base is `main` only because a cross-fork pull request cannot target a branch this repository does not have — so **the diff below contains all five commits, and the one to review here is the fifth, `Reflection: the week and month input types' attribute table`.** They merge in order: metadata → sections → obsolete → tabular → **forms-weekmonth** → forms → embedded.

## What and why

Despite the name, this document is HTML's **whole `<input>` attribute table**, run against the `week` and `month` types — the same table `reflection-forms.html` runs against all twenty-one. So the eleven rows here are most of what the next one in the stack needs too, which is why it comes first.

## Mechanism

Eleven `reflected` rows, and one of them needed the row model to learn HTML's only exception to URL reflection.

### `formAction` answers the document's URL when the attribute is missing or empty

[HTML §4.10.18.6](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formaction): *"The `formAction` IDL attribute must reflect the content attribute of the same name, except that on getting, when the content attribute is missing or its value is the empty string, the element's node document's URL must be returned instead."*

That is what a form posting to itself reads, and AngleSharp's `FormAction` is the raw attribute value, so `input.formAction` answered `""`. `documentUrlWhenEmpty` is the flag on the `url` row; it is the **document's** URL and not the base URL, so a `<base href>` does not move it. `form.action` is the only other member in HTML with the rule, and it is in the next PR.

### `width` and `height` are the halves case

[§4.10.5.1.20](https://html.spec.whatwg.org/multipage/input.html#dom-input-width): the *getter* is the rendered image dimension and is not reflection; the *setter* is, in as many words. This package renders no image, so the getter answers the content attribute either way — which is what AngleSharp already did — and what the rows fix is the setter: AngleSharp writes an `Int32`, so `input.height = 4294967295` wrote `"-1"` where HTML's unsigned-long rule writes the default. The corpus marks both members `customGetter` for exactly this reason and tests only the direction that is reflection.

### The rest

| Member | HTML | What AngleSharp did |
| --- | --- | --- |
| `formEnctype` | §4.10.18.6: enumerated, **invalid** value default `application/x-www-form-urlencoded`, **missing** value default `""` — the two differ | absent |
| `formMethod` | §4.10.18.6: enumerated, invalid `get`, missing `""` | absent |
| `maxLength` | §4.10.5.3.1: a `long` limited to non-negative numbers — default −1, negative IDL set is `IndexSizeError` | `Int32` with .NET's parse and no refusal |
| `minLength` | §4.10.5.3.2: the same | absent |
| `size` | §4.10.5.3.5: an `unsigned long` limited to positive numbers, **default 20** — zero throws, out of range reads 20 | `Int32` whose default is 0 |
| `src` | §4.10.5.1.19: reflected as a **URL** | the raw attribute value — the divergence `script.src` had |
| `align`, `useMap` | §16.3.3: obsolete reflected `DOMString`s | absent |

## Failing-first evidence

Vendoring the document with **no** rows written and **no** exclusions — 359 of its 1,579 tests fail:

```
68 input.formEnctype   50 input.formMethod   50 input.minLength
40 input.formAction    40 input.src          38 input.align
38 input.useMap        18 input.size         13 input.maxLength
 2 input.height         2 input.width
```

With the eleven rows: **0**.

The two `height` and two `width` rows are worth calling out: they are `IDL set to 2147483648` and `IDL set to 4294967295`, and they are visible *because* #3983 fixed the unsigned-long range rule in the shared implementation — a member with no row of its own still went through AngleSharp's `Int32` setter, so this is the same defect showing up on a member the previous PR did not cover.

## Remaining exclusions

None. `WptBrowserExclusions` gains no row for this document.

## Upstream (AngleSharp) findings

* **`IHtmlInputElement.FormAction` is the raw attribute value**, so an `<input formaction>`-less submit button reports `""` where every browser reports the page's address. The same is true of `IHtmlFormElement.Action`.
* **`Size`, `MaxLength` and `MinLength`-shaped members are plain `Int32` properties** with .NET's parse: no default of 20 or −1, no `IndexSizeError` on a refused value, no out-of-range fallback, and U+000B is treated as whitespace where HTML's rules for parsing integers do not.
* **`formEnctype`, `formMethod`, `minLength`, `align` and `useMap` are not projected at all.**
* **`DisplayWidth`/`DisplayHeight` write an `Int32`,** so an out-of-range assignment writes a negative number into the content attribute.

Recorded in `Jint.Browser/Dom/divergences.md` where they were not already. No issues were opened on AngleSharp's repositories.

## Deliberately left out

* **`input.type`.** The week-and-month document tests only two of its keywords and already passes; the full twenty-one-keyword enumeration belongs with `reflection-forms.html`, the next PR in the stack.
* **`input.autocomplete`, `option.label`, `option.value`, `meter`'s six doubles.** All `customGetter` in the corpus, and none of them is in this document's failures.
* **A real rendered `width`/`height`.** There is no layout for an image, which `Wpt/AGENTS.md` already calls `NeedsLayout`.

## Verified

| What | Command | Result |
| --- | --- | --- |
| Solution builds | `dotnet build -c Release` | 0 errors |
| The document | `dotnet test -c Release Jint.Tests.Browser --filter RunsTheHtmlDomSuite` | 13/13, both frameworks |
| The whole lane, census on | `JINT_WPT_BROWSER_CENSUS=1 dotnet test -c Release Jint.Tests.Browser --filter Jint.Tests.Browser.Wpt` | 398/398 on net8.0 and net10.0 |
| The whole project | `dotnet test -c Release Jint.Tests.Browser` | 2,285 passed net8.0, 2,289 passed net10.0, 0 failed |
| Instruction files | `dotnet test -c Release Jint.Tests --filter AgentInstructionFileTests` | 5/5 |
| Generated bindings | `JINT_DOM_BINDINGS=update`, then `--filter DomBindingsStaleness` | 3/3 |

The census (`html/dom/` 12 → 13 documents, 37,973 → 39,552 tests) was regenerated with `JINT_WPT_BROWSER_CENSUS=update-raising-the-ceiling` and never hand-edited. **The not-passing figure did not move**: 1,913 before and after.


The corpus grew, so `Jint.Tests/Wpt/Vendor/README.md`'s **drift-verification recipe** was regenerated too (`JINT_WPT_CENSUS=update dotnet test Jint.Tests -c Release --filter WptCensusTests`): it counts the files and directories the `find` walks, and `WptCensusTests.TheDriftRecipeWalksTheCorpusThatIsVendored` fails while it is stale. The two vendored files this pull request adds were fetched from `raw.githubusercontent.com` at the pinned commit, which is the same bytes that recipe compares.

**Rebased onto `b31a05fd1`** (AngleSharp.Css 1.1.1-beta.308) and re-verified there: the browser wpt lane is **400/400** with `JINT_WPT_BROWSER_CENSUS=1` on net8.0, green. The count moved from the table above because main's #3974 added two tests to the lane; nothing in this branch changed, and the Css bump does not move `<style>`'s `media` behaviour.

## Doubts

`documentUrlWhenEmpty` reads `element.Owner.Url`, which is AngleSharp's document address. The page runtime keeps its own `BaseUri` for the *base* URL because AngleSharp's cached one can go stale; the document's own address is not cached the same way, but a reviewer who knows `PageRuntime` better than I do should confirm there is no navigation shape where `Owner.Url` lags.

Part of #3770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
