### PR TITLE
Playwright: the waitForFunction timeout test's ceiling is a wedge with room on a loaded runner

### DIFF
--- a/Jint.Tests.Browser/Playwright/DirectPlaywrightTests.cs
+++ b/Jint.Tests.Browser/Playwright/DirectPlaywrightTests.cs
@@ -415,11 +415,15 @@ public sealed class DirectPlaywrightTests
         var started = System.Diagnostics.Stopwatch.GetTimestamp();
 
         var wait = async () => await page.WaitForFunctionAsync(
-            "() => { const end = Date.now() + 1000; while (Date.now() < end) {} return false; }",
+            "() => { const end = Date.now() + 4000; while (Date.now() < end) {} return false; }",
             options: new PageWaitForFunctionOptions { Timeout = 50 });
 
         await wait.Should().ThrowAsync<System.TimeoutException>();
-        System.Diagnostics.Stopwatch.GetElapsedTime(started).Should().BeLessThan(TimeSpan.FromMilliseconds(500));
+        // The ceiling is a wedge, not the assertion: it only has to sit well below the four seconds the
+        // synchronous loop would cost if the timeout waited for it. A loaded CI runner has taken 587 ms to
+        // get here on a 500 ms ceiling against a one-second loop, which is the property holding and the
+        // margin failing.
+        System.Diagnostics.Stopwatch.GetElapsedTime(started).Should().BeLessThan(TimeSpan.FromSeconds(2));
     }
 
     [Test]


### PR DESCRIPTION
`WaitForFunctionTimeoutDoesNotWaitForSynchronousEvaluation` asserts that a 50 ms `WaitForFunctionAsync` timeout does not wait for the page's synchronous busy loop. The loop cost one second and the ceiling was 500 ms, so the margin between "the property holds" and "the assertion passes" was a few hundred milliseconds of runner time. On #3982's windows leg (run 34265014877, job 102192071663) the test measured **587 ms** on a change that touches neither Playwright, `WaitForFunction` nor the page loop; the property held and the margin failed.

Per `Jint.Tests/AGENTS.md`, a wall-clock number is either the assertion or a wedge ceiling, never both. This is the wedge case: the loop is four seconds now and the ceiling two, which still sits well below what waiting for the loop would cost while leaving a loaded runner seconds of headroom. A passing run still pays only the 50 ms timeout plus overhead; only a failing run pays the loop.

Verified: Release build of `Jint.Tests.Browser`, both `WaitForFunctionTimeout*` tests pass on net10.0 (559 ms for the pair). Base: `b31a05fd1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
