### PR TITLE
Reflection: the embedded-content elements' attribute table, so all ten of HTML 2.6.1's documents run

### DIFF
--- a/Jint.Browser/Dom/Generated/DomReflected.g.cs
+++ b/Jint.Browser/Dom/Generated/DomReflected.g.cs
@@ -71,6 +71,18 @@ internal static class DomReflected
     internal static readonly ReflectedAttribute HTMLAnchorElementType =
         ReflectedAttribute.Text("HTMLAnchorElement.type", "type");
 
+    /// <summary><c>HTMLAreaElement.noHref</c> reflects <c>nohref</c> as a boolean.</summary>
+    internal static readonly ReflectedAttribute HTMLAreaElementNoHref =
+        ReflectedAttribute.Boolean("HTMLAreaElement.noHref", "nohref");
+
+    /// <summary><c>HTMLAreaElement.ping</c> reflects <c>ping</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLAreaElementPing =
+        ReflectedAttribute.Text("HTMLAreaElement.ping", "ping");
+
+    /// <summary><c>HTMLAreaElement.referrerPolicy</c> reflects <c>referrerpolicy</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLAreaElementReferrerPolicy =
+        ReflectedAttribute.Enumerated("HTMLAreaElement.referrerPolicy", "referrerpolicy", ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"], missing: "", invalid: null);
+
     /// <summary><c>HTMLBRElement.clear</c> reflects <c>clear</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLBRElementClear =
         ReflectedAttribute.Text("HTMLBRElement.clear", "clear");
@@ -115,6 +127,14 @@ internal static class DomReflected
     internal static readonly ReflectedAttribute HTMLButtonElementType =
         ReflectedAttribute.Enumerated("HTMLButtonElement.type", "type", ["submit", "reset", "button"], missing: "submit", invalid: null);
 
+    /// <summary><c>HTMLCanvasElement.height</c> reflects <c>height</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLCanvasElementHeight =
+        ReflectedAttribute.Numeric("HTMLCanvasElement.height", "height", ReflectedKind.UnsignedLong, 150);
+
+    /// <summary><c>HTMLCanvasElement.width</c> reflects <c>width</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLCanvasElementWidth =
+        ReflectedAttribute.Numeric("HTMLCanvasElement.width", "width", ReflectedKind.UnsignedLong, 300);
+
     /// <summary><c>HTMLDivElement.align</c> reflects <c>align</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLDivElementAlign =
         ReflectedAttribute.Text("HTMLDivElement.align", "align");
@@ -146,6 +166,18 @@ internal static class DomReflected
     /// <summary><c>HTMLElement.tabIndex</c> reflects <c>tabindex</c> as a long.</summary>
     internal static readonly ReflectedAttribute HTMLElementTabIndex =
         ReflectedAttribute.Numeric("HTMLElement.tabIndex", "tabindex", ReflectedKind.Long, 0);
+
+    /// <summary><c>HTMLEmbedElement.align</c> reflects <c>align</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLEmbedElementAlign =
+        ReflectedAttribute.Text("HTMLEmbedElement.align", "align");
+
+    /// <summary><c>HTMLEmbedElement.name</c> reflects <c>name</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLEmbedElementName =
+        ReflectedAttribute.Text("HTMLEmbedElement.name", "name");
+
+    /// <summary><c>HTMLEmbedElement.src</c> reflects <c>src</c> as an url.</summary>
+    internal static readonly ReflectedAttribute HTMLEmbedElementSrc =
+        ReflectedAttribute.Url("HTMLEmbedElement.src", "src");
 
     /// <summary><c>HTMLFormElement.action</c> reflects <c>action</c> as an url.</summary>
     internal static readonly ReflectedAttribute HTMLFormElementAction =
@@ -182,6 +214,90 @@ internal static class DomReflected
     /// <summary><c>HTMLHtmlElement.version</c> reflects <c>version</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLHtmlElementVersion =
         ReflectedAttribute.Text("HTMLHtmlElement.version", "version");
+
+    /// <summary><c>HTMLIFrameElement.align</c> reflects <c>align</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementAlign =
+        ReflectedAttribute.Text("HTMLIFrameElement.align", "align");
+
+    /// <summary><c>HTMLIFrameElement.frameBorder</c> reflects <c>frameborder</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementFrameBorder =
+        ReflectedAttribute.Text("HTMLIFrameElement.frameBorder", "frameborder");
+
+    /// <summary><c>HTMLIFrameElement.height</c> reflects <c>height</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementHeight =
+        ReflectedAttribute.Text("HTMLIFrameElement.height", "height");
+
+    /// <summary><c>HTMLIFrameElement.longDesc</c> reflects <c>longdesc</c> as an url.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementLongDesc =
+        ReflectedAttribute.Url("HTMLIFrameElement.longDesc", "longdesc");
+
+    /// <summary><c>HTMLIFrameElement.marginHeight</c> reflects <c>marginheight</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementMarginHeight =
+        ReflectedAttribute.Text("HTMLIFrameElement.marginHeight", "marginheight", legacyNullToEmptyString: true);
+
+    /// <summary><c>HTMLIFrameElement.marginWidth</c> reflects <c>marginwidth</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementMarginWidth =
+        ReflectedAttribute.Text("HTMLIFrameElement.marginWidth", "marginwidth", legacyNullToEmptyString: true);
+
+    /// <summary><c>HTMLIFrameElement.referrerPolicy</c> reflects <c>referrerpolicy</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementReferrerPolicy =
+        ReflectedAttribute.Enumerated("HTMLIFrameElement.referrerPolicy", "referrerpolicy", ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"], missing: "", invalid: null);
+
+    /// <summary><c>HTMLIFrameElement.scrolling</c> reflects <c>scrolling</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementScrolling =
+        ReflectedAttribute.Text("HTMLIFrameElement.scrolling", "scrolling");
+
+    /// <summary><c>HTMLIFrameElement.width</c> reflects <c>width</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLIFrameElementWidth =
+        ReflectedAttribute.Text("HTMLIFrameElement.width", "width");
+
+    /// <summary><c>HTMLImageElement.align</c> reflects <c>align</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementAlign =
+        ReflectedAttribute.Text("HTMLImageElement.align", "align");
+
+    /// <summary><c>HTMLImageElement.border</c> reflects <c>border</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementBorder =
+        ReflectedAttribute.Text("HTMLImageElement.border", "border", legacyNullToEmptyString: true);
+
+    /// <summary><c>HTMLImageElement.crossOrigin</c> reflects <c>crossorigin</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementCrossOrigin =
+        ReflectedAttribute.Enumerated("HTMLImageElement.crossOrigin", "crossorigin", ["anonymous", "use-credentials"], missing: null, invalid: "anonymous");
+
+    /// <summary><c>HTMLImageElement.decoding</c> reflects <c>decoding</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementDecoding =
+        ReflectedAttribute.Enumerated("HTMLImageElement.decoding", "decoding", ["async", "sync", "auto"], missing: "auto", invalid: "auto");
+
+    /// <summary><c>HTMLImageElement.height</c> reflects <c>height</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementHeight =
+        ReflectedAttribute.Numeric("HTMLImageElement.height", "height", ReflectedKind.UnsignedLong, 0);
+
+    /// <summary><c>HTMLImageElement.hspace</c> reflects <c>hspace</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementHspace =
+        ReflectedAttribute.Numeric("HTMLImageElement.hspace", "hspace", ReflectedKind.UnsignedLong, 0);
+
+    /// <summary><c>HTMLImageElement.longDesc</c> reflects <c>longdesc</c> as an url.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementLongDesc =
+        ReflectedAttribute.Url("HTMLImageElement.longDesc", "longdesc");
+
+    /// <summary><c>HTMLImageElement.lowsrc</c> reflects <c>lowsrc</c> as an url.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementLowsrc =
+        ReflectedAttribute.Url("HTMLImageElement.lowsrc", "lowsrc");
+
+    /// <summary><c>HTMLImageElement.name</c> reflects <c>name</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementName =
+        ReflectedAttribute.Text("HTMLImageElement.name", "name");
+
+    /// <summary><c>HTMLImageElement.referrerPolicy</c> reflects <c>referrerpolicy</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementReferrerPolicy =
+        ReflectedAttribute.Enumerated("HTMLImageElement.referrerPolicy", "referrerpolicy", ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"], missing: "", invalid: null);
+
+    /// <summary><c>HTMLImageElement.vspace</c> reflects <c>vspace</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementVspace =
+        ReflectedAttribute.Numeric("HTMLImageElement.vspace", "vspace", ReflectedKind.UnsignedLong, 0);
+
+    /// <summary><c>HTMLImageElement.width</c> reflects <c>width</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLImageElementWidth =
+        ReflectedAttribute.Numeric("HTMLImageElement.width", "width", ReflectedKind.UnsignedLong, 0);
 
     /// <summary><c>HTMLInputElement.align</c> reflects <c>align</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLInputElementAlign =
@@ -295,6 +411,18 @@ internal static class DomReflected
     internal static readonly ReflectedAttribute HTMLMarqueeElementWidth =
         ReflectedAttribute.Text("HTMLMarqueeElement.width", "width");
 
+    /// <summary><c>HTMLMediaElement.crossOrigin</c> reflects <c>crossorigin</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLMediaElementCrossOrigin =
+        ReflectedAttribute.Enumerated("HTMLMediaElement.crossOrigin", "crossorigin", ["anonymous", "use-credentials"], missing: null, invalid: "anonymous");
+
+    /// <summary><c>HTMLMediaElement.loading</c> reflects <c>loading</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLMediaElementLoading =
+        ReflectedAttribute.Enumerated("HTMLMediaElement.loading", "loading", ["lazy", "eager"], missing: "eager", invalid: "eager");
+
+    /// <summary><c>HTMLMediaElement.preload</c> reflects <c>preload</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLMediaElementPreload =
+        ReflectedAttribute.Enumerated("HTMLMediaElement.preload", "preload", ["none", "metadata", "auto"], missing: "auto", invalid: "auto");
+
     /// <summary><c>HTMLMenuElement.compact</c> reflects <c>compact</c> as a boolean.</summary>
     internal static readonly ReflectedAttribute HTMLMenuElementCompact =
         ReflectedAttribute.Boolean("HTMLMenuElement.compact", "compact");
@@ -323,9 +451,65 @@ internal static class DomReflected
     internal static readonly ReflectedAttribute HTMLOListElementStart =
         ReflectedAttribute.Numeric("HTMLOListElement.start", "start", ReflectedKind.Long, 1);
 
+    /// <summary><c>HTMLObjectElement.align</c> reflects <c>align</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementAlign =
+        ReflectedAttribute.Text("HTMLObjectElement.align", "align");
+
+    /// <summary><c>HTMLObjectElement.archive</c> reflects <c>archive</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementArchive =
+        ReflectedAttribute.Text("HTMLObjectElement.archive", "archive");
+
+    /// <summary><c>HTMLObjectElement.border</c> reflects <c>border</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementBorder =
+        ReflectedAttribute.Text("HTMLObjectElement.border", "border", legacyNullToEmptyString: true);
+
+    /// <summary><c>HTMLObjectElement.code</c> reflects <c>code</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementCode =
+        ReflectedAttribute.Text("HTMLObjectElement.code", "code");
+
+    /// <summary><c>HTMLObjectElement.codeBase</c> reflects <c>codebase</c> as an url.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementCodeBase =
+        ReflectedAttribute.Url("HTMLObjectElement.codeBase", "codebase");
+
+    /// <summary><c>HTMLObjectElement.codeType</c> reflects <c>codetype</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementCodeType =
+        ReflectedAttribute.Text("HTMLObjectElement.codeType", "codetype");
+
+    /// <summary><c>HTMLObjectElement.declare</c> reflects <c>declare</c> as a boolean.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementDeclare =
+        ReflectedAttribute.Boolean("HTMLObjectElement.declare", "declare");
+
+    /// <summary><c>HTMLObjectElement.height</c> reflects <c>height</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementHeight =
+        ReflectedAttribute.Text("HTMLObjectElement.height", "height");
+
+    /// <summary><c>HTMLObjectElement.hspace</c> reflects <c>hspace</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementHspace =
+        ReflectedAttribute.Numeric("HTMLObjectElement.hspace", "hspace", ReflectedKind.UnsignedLong, 0);
+
+    /// <summary><c>HTMLObjectElement.standby</c> reflects <c>standby</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementStandby =
+        ReflectedAttribute.Text("HTMLObjectElement.standby", "standby");
+
+    /// <summary><c>HTMLObjectElement.vspace</c> reflects <c>vspace</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementVspace =
+        ReflectedAttribute.Numeric("HTMLObjectElement.vspace", "vspace", ReflectedKind.UnsignedLong, 0);
+
+    /// <summary><c>HTMLObjectElement.width</c> reflects <c>width</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLObjectElementWidth =
+        ReflectedAttribute.Text("HTMLObjectElement.width", "width");
+
     /// <summary><c>HTMLParagraphElement.align</c> reflects <c>align</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLParagraphElementAlign =
         ReflectedAttribute.Text("HTMLParagraphElement.align", "align");
+
+    /// <summary><c>HTMLParamElement.type</c> reflects <c>type</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLParamElementType =
+        ReflectedAttribute.Text("HTMLParamElement.type", "type");
+
+    /// <summary><c>HTMLParamElement.valueType</c> reflects <c>valuetype</c> as a string.</summary>
+    internal static readonly ReflectedAttribute HTMLParamElementValueType =
+        ReflectedAttribute.Text("HTMLParamElement.valueType", "valuetype");
 
     /// <summary><c>HTMLPreElement.width</c> reflects <c>width</c> as a long.</summary>
     internal static readonly ReflectedAttribute HTMLPreElementWidth =
@@ -547,6 +731,10 @@ internal static class DomReflected
     internal static readonly ReflectedAttribute HTMLTimeElementDateTime =
         ReflectedAttribute.Text("HTMLTimeElement.dateTime", "datetime");
 
+    /// <summary><c>HTMLTrackElement.kind</c> reflects <c>kind</c> as an enum.</summary>
+    internal static readonly ReflectedAttribute HTMLTrackElementKind =
+        ReflectedAttribute.Enumerated("HTMLTrackElement.kind", "kind", ["subtitles", "captions", "descriptions", "chapters", "metadata"], missing: "subtitles", invalid: "metadata");
+
     /// <summary><c>HTMLUListElement.compact</c> reflects <c>compact</c> as a boolean.</summary>
     internal static readonly ReflectedAttribute HTMLUListElementCompact =
         ReflectedAttribute.Boolean("HTMLUListElement.compact", "compact");
@@ -554,4 +742,16 @@ internal static class DomReflected
     /// <summary><c>HTMLUListElement.type</c> reflects <c>type</c> as a string.</summary>
     internal static readonly ReflectedAttribute HTMLUListElementType =
         ReflectedAttribute.Text("HTMLUListElement.type", "type");
+
+    /// <summary><c>HTMLVideoElement.height</c> reflects <c>height</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLVideoElementHeight =
+        ReflectedAttribute.Numeric("HTMLVideoElement.height", "height", ReflectedKind.UnsignedLong, 0);
+
+    /// <summary><c>HTMLVideoElement.playsInline</c> reflects <c>playsinline</c> as a boolean.</summary>
+    internal static readonly ReflectedAttribute HTMLVideoElementPlaysInline =
+        ReflectedAttribute.Boolean("HTMLVideoElement.playsInline", "playsinline");
+
+    /// <summary><c>HTMLVideoElement.width</c> reflects <c>width</c> as an unsigned long.</summary>
+    internal static readonly ReflectedAttribute HTMLVideoElementWidth =
+        ReflectedAttribute.Numeric("HTMLVideoElement.width", "width", ReflectedKind.UnsignedLong, 0);
 }

--- a/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Html.g.cs
@@ -645,6 +645,17 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.hreflang");
                     self.Target.TargetLanguage = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.hreflang"); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("noHref",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.noHref", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.noHref");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLAreaElementNoHref.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.noHref", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.noHref");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLAreaElementNoHref.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("origin",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.origin", static (thisObj, args) =>
                 {
@@ -677,7 +688,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.ping", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.ping");
-                    return self.Realm.Wrap(self.Target.Ping);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLAreaElementPing.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.ping", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.ping");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLAreaElementPing.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("port",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.port", static (thisObj, args) =>
@@ -700,6 +716,17 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.protocol");
                     self.Target.Protocol = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLAreaElement.protocol"); return global::Jint.Native.JsValue.Undefined;
+                }))
+            .Accessor("referrerPolicy",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.referrerPolicy", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.referrerPolicy");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLAreaElementReferrerPolicy.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.referrerPolicy", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlAreaElement>(thisObj, "HTMLAreaElement.referrerPolicy");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLAreaElementReferrerPolicy.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("rel",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLAreaElement.rel", static (thisObj, args) =>
@@ -852,12 +879,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.crossOrigin");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CrossOrigin);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLMediaElementCrossOrigin.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.crossOrigin");
-                    self.Target.CrossOrigin = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMediaElement.crossOrigin"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLMediaElementCrossOrigin.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("currentSrc",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.currentSrc", static (thisObj, args) =>
@@ -923,6 +950,17 @@ internal static partial class DomInterfaces
                     self.Target.Load(); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 0)
+            .Accessor("loading",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.loading", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.loading");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLMediaElementLoading.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.loading", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.loading");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLMediaElementLoading.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("loop",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.loop", static (thisObj, args) =>
                 {
@@ -1009,12 +1047,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.preload", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.preload");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Preload);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLMediaElementPreload.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.preload", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlMediaElement>(thisObj, "HTMLMediaElement.preload");
-                    self.Target.Preload = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLMediaElement.preload"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLMediaElementPreload.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("readyState",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLMediaElement.readyState", static (thisObj, args) =>
@@ -1391,12 +1429,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.height");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Height);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLCanvasElementHeight.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.height");
-                    self.Target.Height = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLCanvasElement.height"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLCanvasElementHeight.Set(self.Realm, self.Target, args);
                 }))
             .Method("probablySupportsContext",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.probablySupportsContext", static (thisObj, args) =>
@@ -1423,12 +1461,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.width");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.Width);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLCanvasElementWidth.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLCanvasElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlCanvasElement>(thisObj, "HTMLCanvasElement.width");
-                    self.Target.Width = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLCanvasElement.width"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLCanvasElementWidth.Set(self.Realm, self.Target, args);
                 }))
             .Build();
 
@@ -1640,6 +1678,17 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("HTMLEmbedElement")
             .PerRealmSlot("constructor", enumerable: false)
+            .Accessor("align",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLEmbedElementAlign.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLEmbedElementAlign.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("height",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.height", static (thisObj, args) =>
                 {
@@ -1651,16 +1700,27 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.height");
                     self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLEmbedElement.height"); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("name",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.name", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.name");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLEmbedElementName.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.name", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.name");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLEmbedElementName.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("src",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.src");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Source);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLEmbedElementSrc.Get(self.Realm, self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.src", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlEmbedElement>(thisObj, "HTMLEmbedElement.src");
-                    self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLEmbedElement.src"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLEmbedElementSrc.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("type",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLEmbedElement.type", static (thisObj, args) =>
@@ -2056,6 +2116,17 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("HTMLIFrameElement")
             .PerRealmSlot("constructor", enumerable: false)
+            .Accessor("align",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementAlign.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementAlign.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("allowFullscreen",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.allowFullscreen", static (thisObj, args) =>
                 {
@@ -2090,16 +2161,60 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.contentWindow");
                     return global::Jint.Browser.Dom.DomFrameMembers.ContentWindow(self.Realm, self.Target);
                 }))
+            .Accessor("frameBorder",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.frameBorder", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.frameBorder");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementFrameBorder.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.frameBorder", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.frameBorder");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementFrameBorder.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("height",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.height");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementHeight.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.height");
-                    self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLIFrameElement.height"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementHeight.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("longDesc",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.longDesc", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.longDesc");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementLongDesc.Get(self.Realm, self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.longDesc", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.longDesc");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementLongDesc.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("marginHeight",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.marginHeight", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.marginHeight");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementMarginHeight.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.marginHeight", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.marginHeight");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementMarginHeight.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("marginWidth",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.marginWidth", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.marginWidth");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementMarginWidth.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.marginWidth", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.marginWidth");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementMarginWidth.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("name",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.name", static (thisObj, args) =>
@@ -2116,12 +2231,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.referrerPolicy", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.referrerPolicy");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ReferrerPolicy);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementReferrerPolicy.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.referrerPolicy", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.referrerPolicy");
-                    self.Target.ReferrerPolicy = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLIFrameElement.referrerPolicy"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementReferrerPolicy.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("sandbox",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.sandbox", static (thisObj, args) =>
@@ -2133,6 +2248,17 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.sandbox");
                     return global::Jint.Browser.Dom.Collections.DomTokenListMembers.PutForwards(self.Target, "sandbox", args);
+                }))
+            .Accessor("scrolling",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.scrolling", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.scrolling");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementScrolling.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.scrolling", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.scrolling");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementScrolling.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("seamless",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.seamless", static (thisObj, args) =>
@@ -2171,12 +2297,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.width");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementWidth.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLIFrameElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlInlineFrameElement>(thisObj, "HTMLIFrameElement.width");
-                    self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLIFrameElement.width"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLIFrameElementWidth.Set(self.Realm, self.Target, args);
                 }))
             .Build();
 
@@ -2185,6 +2311,17 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("HTMLImageElement")
             .PerRealmSlot("constructor", enumerable: false)
+            .Accessor("align",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementAlign.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementAlign.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("alt",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.alt", static (thisObj, args) =>
                 {
@@ -2196,6 +2333,17 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.alt");
                     self.Target.AlternativeText = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.alt"); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("border",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.border", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.border");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementBorder.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.border", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.border");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementBorder.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("complete",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.complete", static (thisObj, args) =>
                 {
@@ -2206,12 +2354,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.crossOrigin");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.CrossOrigin);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementCrossOrigin.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.crossOrigin", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.crossOrigin");
-                    self.Target.CrossOrigin = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.crossOrigin"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementCrossOrigin.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("currentSrc",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.currentSrc", static (thisObj, args) =>
@@ -2219,16 +2367,38 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.currentSrc");
                     return global::Jint.Browser.Dom.DomConvert.Text(self.Target.ActualSource);
                 }))
+            .Accessor("decoding",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.decoding", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.decoding");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementDecoding.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.decoding", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.decoding");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementDecoding.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("height",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.height");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementHeight.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.height");
-                    self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLImageElement.height"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementHeight.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("hspace",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.hspace", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.hspace");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementHspace.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.hspace", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.hspace");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementHspace.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("isMap",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.isMap", static (thisObj, args) =>
@@ -2241,6 +2411,39 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.isMap");
                     self.Target.IsMap = global::Jint.Browser.Dom.DomConvert.OptionalBool(args, 0, false); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("longDesc",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.longDesc", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.longDesc");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementLongDesc.Get(self.Realm, self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.longDesc", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.longDesc");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementLongDesc.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("lowsrc",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.lowsrc", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.lowsrc");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementLowsrc.Get(self.Realm, self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.lowsrc", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.lowsrc");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementLowsrc.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("name",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.name", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.name");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementName.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.name", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.name");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementName.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("naturalHeight",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.naturalHeight", static (thisObj, args) =>
                 {
@@ -2252,6 +2455,17 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.naturalWidth");
                     return global::Jint.Browser.Dom.DomConvert.Number(self.Target.OriginalWidth);
+                }))
+            .Accessor("referrerPolicy",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.referrerPolicy", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.referrerPolicy");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementReferrerPolicy.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.referrerPolicy", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.referrerPolicy");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementReferrerPolicy.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("sizes",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.sizes", static (thisObj, args) =>
@@ -2297,16 +2511,27 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.useMap");
                     self.Target.UseMap = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLImageElement.useMap"); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("vspace",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.vspace", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.vspace");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementVspace.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.vspace", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.vspace");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementVspace.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("width",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.width");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementWidth.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLImageElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlImageElement>(thisObj, "HTMLImageElement.width");
-                    self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLImageElement.width"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLImageElementWidth.Set(self.Realm, self.Target, args);
                 }))
             .Build();
 
@@ -3723,6 +3948,39 @@ internal static partial class DomInterfaces
         => new global::Jint.Native.JsObjectShape.Builder()
             .ToStringTag("HTMLObjectElement")
             .PerRealmSlot("constructor", enumerable: false)
+            .Accessor("align",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementAlign.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.align", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.align");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementAlign.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("archive",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.archive", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.archive");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementArchive.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.archive", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.archive");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementArchive.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("border",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.border", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.border");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementBorder.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.border", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.border");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementBorder.Set(self.Realm, self.Target, args);
+                }))
             .Method("checkValidity",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.checkValidity", static (thisObj, args) =>
                 {
@@ -3730,6 +3988,39 @@ internal static partial class DomInterfaces
                     return global::Jint.Browser.Dom.DomConvert.Bool(self.Target.CheckValidity());
                 }),
                 length: 0)
+            .Accessor("code",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.code", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.code");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementCode.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.code", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.code");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementCode.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("codeBase",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.codeBase", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.codeBase");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementCodeBase.Get(self.Realm, self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.codeBase", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.codeBase");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementCodeBase.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("codeType",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.codeType", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.codeType");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementCodeType.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.codeType", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.codeType");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementCodeType.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("contentDocument",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.contentDocument", static (thisObj, args) =>
                 {
@@ -3753,6 +4044,17 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.data");
                     self.Target.Source = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLObjectElement.data"); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("declare",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.declare", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.declare");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementDeclare.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.declare", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.declare");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementDeclare.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("form",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.form", static (thisObj, args) =>
                 {
@@ -3763,12 +4065,23 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.height");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementHeight.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.height");
-                    self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLObjectElement.height"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementHeight.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("hspace",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.hspace", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.hspace");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementHspace.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.hspace", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.hspace");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementHspace.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("name",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.name", static (thisObj, args) =>
@@ -3788,6 +4101,17 @@ internal static partial class DomInterfaces
                     self.Target.SetCustomValidity(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLObjectElement.setCustomValidity")); return global::Jint.Native.JsValue.Undefined;
                 }),
                 length: 1)
+            .Accessor("standby",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.standby", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.standby");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementStandby.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.standby", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.standby");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementStandby.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("type",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.type", static (thisObj, args) =>
                 {
@@ -3833,16 +4157,27 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.validity");
                     return self.Realm.Wrap(self.Target.Validity);
                 }))
+            .Accessor("vspace",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.vspace", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.vspace");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementVspace.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.vspace", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.vspace");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementVspace.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("width",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.width");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementWidth.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlObjectElement>(thisObj, "HTMLObjectElement.width");
-                    self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLObjectElement.width"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLObjectElementWidth.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("willValidate",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLObjectElement.willValidate", static (thisObj, args) =>
@@ -4133,6 +4468,17 @@ internal static partial class DomInterfaces
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.name");
                     self.Target.Name = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLParamElement.name"); return global::Jint.Native.JsValue.Undefined;
                 }))
+            .Accessor("type",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.type", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.type");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLParamElementType.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.type", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.type");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLParamElementType.Set(self.Realm, self.Target, args);
+                }))
             .Accessor("value",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.value", static (thisObj, args) =>
                 {
@@ -4143,6 +4489,17 @@ internal static partial class DomInterfaces
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.value");
                     self.Target.Value = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLParamElement.value"); return global::Jint.Native.JsValue.Undefined;
+                }))
+            .Accessor("valueType",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.valueType", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.valueType");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLParamElementValueType.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLParamElement.valueType", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlParamElement>(thisObj, "HTMLParamElement.valueType");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLParamElementValueType.Set(self.Realm, self.Target, args);
                 }))
             .Build();
 
@@ -5717,12 +6074,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.kind", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.kind");
-                    return global::Jint.Browser.Dom.DomConvert.Text(self.Target.Kind);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLTrackElementKind.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.kind", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlTrackElement>(thisObj, "HTMLTrackElement.kind");
-                    self.Target.Kind = global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "HTMLTrackElement.kind"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLTrackElementKind.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("label",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLTrackElement.label", static (thisObj, args) =>
@@ -5816,12 +6173,23 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.height");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayHeight);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLVideoElementHeight.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.height", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.height");
-                    self.Target.DisplayHeight = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLVideoElement.height"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLVideoElementHeight.Set(self.Realm, self.Target, args);
+                }))
+            .Accessor("playsInline",
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.playsInline", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.playsInline");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLVideoElementPlaysInline.Get(self.Target);
+                }),
+                global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.playsInline", static (thisObj, args) =>
+                {
+                    var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.playsInline");
+                    return global::Jint.Browser.Dom.DomReflected.HTMLVideoElementPlaysInline.Set(self.Realm, self.Target, args);
                 }))
             .Accessor("poster",
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.poster", static (thisObj, args) =>
@@ -5850,12 +6218,12 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.width");
-                    return global::Jint.Browser.Dom.DomConvert.Number(self.Target.DisplayWidth);
+                    return global::Jint.Browser.Dom.DomReflected.HTMLVideoElementWidth.Get(self.Target);
                 }),
                 global::Jint.Browser.Dom.DomFailures.Guard("HTMLVideoElement.width", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Html.Dom.IHtmlVideoElement>(thisObj, "HTMLVideoElement.width");
-                    self.Target.DisplayWidth = global::Jint.Browser.Dom.DomConvert.RequiredInt32(args, 0, "HTMLVideoElement.width"); return global::Jint.Native.JsValue.Undefined;
+                    return global::Jint.Browser.Dom.DomReflected.HTMLVideoElementWidth.Set(self.Realm, self.Target, args);
                 }))
             .Build();
 

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -31,14 +31,14 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `dom/lists/` | 5 | 0 | 189 | 5 |
 | `dom/traversal/` | 13 | 0 | 52 | 0 |
 | `dom/ranges/` | 17 | 0 | 82 | 4 |
-| `html/dom/` | 14 | 0 | 47,823 | 547 |
+| `html/dom/` | 15 | 0 | 56,745 | 547 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 12 |
 | `custom-elements/` | 16 | 0 | 510 | 247 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **358** | **9** | **57,721** | **1,931** |
+| **total** | **359** | **9** | **66,643** | **1,931** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -176,7 +176,7 @@ a supported name; the collection's named reads remain live.
 
 `dom/nodes/`, `dom/collections/`, `dom/lists/`, `dom/traversal/`, `dom/ranges/` and `html/dom/` are the DOM
 standard's own suites and HTML's DOM half — the corpus every other suite in this lane is written on top of.
-Across the six of them there are 225 documents and 56,304 tests, and **1,586 of those tests do not pass**.
+Across the six of them there are 226 documents and 65,226 tests, and **1,586 of those tests do not pass**.
 Those three figures are live and checked against the census. They arrived together as 207 documents and
 5,247 tests with 1,532 not passing; those arrival figures are historical and deliberately not re-derived.
 
@@ -212,20 +212,22 @@ table needs to be regenerated.
 | 3 | 1 | [#3769](https://github.com/sebastienros/jint/issues/3769) **A `(Node or DOMString)` union parameter takes only a `Node`.** Three `ChildNode.before` rows still reject strings. <!-- cause: a (Node or DOMString) union parameter takes only a Node --> |
 | 2 | 1 | **A Range whose shadow root was removed has the wrong boundary behavior.** These are the two remaining `Range-in-shadow-after-the-shadow-removed.html` rows. <!-- cause: Range's own algorithms --> |
 
-**Nine of HTML's ten reflection documents are cases, and five of the nine pass whole.** HTML §2.6.1's
-reflection algorithms are `Jint.Browser/Dom/ReflectedAttribute.cs` and the members that take them are
-`overrides.json`'s `reflected` list, so `reflection-misc.html` (4,877 assertions, 1,866 of them failing
-before), `reflection-text.html` (10,202, 3,360 failing before), `reflection-sections.html` (5,604, 2,189
-failing before), `reflection-tabular.html` (6,116, 3,552 failing before) and
-`reflection-forms-weekmonth.html` (1,579, 420 failing before) pass with **nothing** excluded, and
-`reflection-grouping.html` (5,358, 2,006 failing before), `reflection-metadata.html` (3,110, 1,218 failing
-before), `reflection-obsolete.html` (2,621, 1,483 failing before) and `reflection-forms.html` (8,271, 2,160
-failing before) have one cause each — and none of the four causes is reflection.
+**All ten of HTML's reflection documents are cases, and six of the ten pass whole**
+([#3770](https://github.com/sebastienros/jint/issues/3770)). HTML §2.6.1's reflection algorithms are
+`Jint.Browser/Dom/ReflectedAttribute.cs` and the members that take them are `overrides.json`'s `reflected`
+list, so `reflection-misc.html` (4,877 assertions, 1,866 of them failing before), `reflection-text.html`
+(10,202, 3,360 failing before), `reflection-sections.html` (5,604, 2,189 failing before),
+`reflection-tabular.html` (6,116, 3,552 failing before), `reflection-forms-weekmonth.html` (1,579, 420
+failing before) and `reflection-embedded.html` (8,922, 3,774 failing before) pass with **nothing** excluded,
+and `reflection-grouping.html` (5,358, 2,006 failing before), `reflection-metadata.html` (3,110, 1,218
+failing before), `reflection-obsolete.html` (2,621, 1,483 failing before) and `reflection-forms.html` (8,271,
+2,160 failing before) have one cause each — and none of the four causes is reflection. **22,028 of 56,660
+assertions failed when the suite was measured; 540 do now.**
 
-135 rows did it, and the first fifteen were mostly the **global** attributes every element carries —
+185 rows did it, and the first fifteen were mostly the **global** attributes every element carries —
 `dir`, `lang`, `tabIndex`, `autofocus`, `inputMode`, `enterKeyHint` — which is why `text` needed only eleven
-rows of its own for 3,360 assertions. The rest are element-specific and that is what the remaining
-document needs: `preload`, `decoding`, `kind` and their kind, one `reflected` row each. `metadata` took seven of those —
+rows of its own for 3,360 assertions. The rest are element-specific, one `reflected` row each.
+`metadata` took seven of those —
 `link`'s `as`, `crossOrigin`, `referrerPolicy`, `charset` and `target`, and `meta`'s `media` and `scheme` —
 plus one member that is deliberately not reflection at all: **`nonce` answers HTML §2.5.3's
 `[[CryptographicNonce]]` slot**, whose setter writes the slot and leaves the content attribute alone, so a
@@ -268,6 +270,14 @@ than zero. `select.size` defaults to 0 where `input.size` defaults to 20, and `b
 `dialog` keyword `input.formMethod` does not — three facts about three members that no CLR signature carries
 and the `reflected` list has to state.
 
+`embedded` took the last fifty, over ten interfaces, and was the largest single table: `<img>`'s twelve,
+`<object>`'s twelve, `<iframe>`'s nine, and the media elements' `preload`, `crossOrigin` and `loading` on
+`HTMLMediaElement` rather than on `<video>` and `<audio>` separately, which is where HTML puts them.
+`track.kind` is the suite's clearest case for stating **both** defaults — its missing value default is
+`subtitles` and its invalid value default is `metadata` — and `preload`'s are implementation-defined among
+its three states, which is why the row picks `auto` and the corpus asserts membership of an array rather than
+one value.
+
 **None of the three causes left is reflection**, and all three are the dependency. Four obsolete elements —
 `<dl>`, `<dir>`, `<font>` and `<frame>` — get an interface of their own from HTML and a plain `HTMLElement`
 from the pinned assemblies, so there is nowhere for `compact`, `color`, `src` and their kind to be reflected
@@ -279,7 +289,7 @@ through the attribute observer AngleSharp core registers, where Media Queries §
 query to be replaced by `not all`. And `<meter>`'s six setters write a `double` with .NET's number format,
 so `-0` keeps its sign and an exponent is `1E-10` where HTML wants ECMAScript's `1e-10` — three values per
 member, and their *getters* are not reflection and are right, which is why there is no row for them. Those
-540 rows are the only failures this lane's `html/dom/` figure gained, against 42,861 assertions it did not
+540 rows are the only failures this lane's `html/dom/` figure gained, against 51,783 assertions it did not
 have before.
 
 **Four documents did not terminate at all, and that was the finding this campaign put first.**

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -289,25 +289,21 @@ internal static class WptBrowserExclusions
         ("html/dom/usvstring-reflection.https.html", "needs webrtc/RTCPeerConnection-helper.js and a real RTCPeerConnection to reflect a USVString off"),
 
         // ------------------------------------------------------------ HTML's reflection suite
-        // Ten generated documents, 56,660 assertions. Nine of them are cases now — every one but
-        // reflection-embedded.html, 47,738 assertions between them — because HTML §2.6.1's reflection
-        // algorithms are implemented (Jint.Browser/Dom/ReflectedAttribute.cs) and driven by overrides.json's
-        // `reflected` list. Five pass whole; what fails in the other four is never reflection — it is an
+        // **All ten generated documents are cases**, 56,660 assertions, because HTML §2.6.1's reflection
+        // algorithms are implemented (Jint.Browser/Dom/ReflectedAttribute.cs) and 185 `reflected` rows in
+        // overrides.json state, per member, which of them it takes. Six of the ten pass whole; the 540 rows
+        // the other four still need are never reflection and every one of them is the dependency — an
         // element interface the pinned assemblies do not have (<dl>, <dir>, <font>, <frame>), <style>'s
         // `media`, which AngleSharp.Css refuses from inside setAttribute, and <meter>'s six setters, which
         // write a double with .NET's number format.
         //
-        // The last one is out for one reason and it is no longer "reflection is not implemented": it needs
-        // the per-element attribute table it tests, one `reflected` row per content attribute, which is
-        // #3770's remaining work. The 135 rows written so far started with the GLOBAL attributes every
-        // element carries (`dir`, `lang`, `tabIndex`, `autofocus`, `inputMode`, `enterKeyHint`), so they have
-        // already moved it a long way. What is left is `preload`, `decoding`, `kind` and their kind.
+        // The issue that vendored them is #3770, and what kept them out was never that they are slow: the
+        // whole set runs in about 22 s, the largest (reflection-embedded.html, 8,922 tests) in 7.3 s, well
+        // inside the driver's 30 s deadline. It was the artefact — the smallest table of patterns covering
+        // 22,028 failures was over four thousand rows, every one of them saying the same thing — and the
+        // answer was to write the attribute tables one family at a time instead.
         //
-        // **None of them is slow**: the whole set runs in 22.5 s and the largest (reflection-embedded.html,
-        // 8,922 tests) in 7.3 s, well inside the driver's 30 s deadline. What has always kept them out is the
-        // artefact — a table of patterns naming thousands of failures, every one of them saying the same
-        // thing — and that is the thing this suite stops needing one family at a time.
-        ("html/dom/*-embedded.*", "#3770: the embedded-content elements and their attribute table; 3,774 of 8,922 assertions failed at the measurement in the issue"),
+        // Two files here are not part of that and stay out.
         ("html/dom/reflection-original.html", "the same suite in the aggregating spelling, which reports only failures rather than one test per assertion — a second answer to what reflection-*.html already say"),
         ("html/dom/elements-aria-enumerated.js", "the attribute table of aria-attribute-reflection-enumerated.tentative.html, which tests a proposal the specification has not adopted"),
 
@@ -761,6 +757,7 @@ internal static class WptBrowserExclusions
         ["html/dom/aria-element-reflection-disconnected.html"] = 2,
         ["html/dom/aria-element-reflection.html"] = 27,
         ["html/dom/historical.html"] = 13,
+        ["html/dom/reflection-embedded.html"] = 8922,
         ["html/dom/reflection-forms-weekmonth.html"] = 1579,
         ["html/dom/reflection-forms.html"] = 8271,
         ["html/dom/reflection-grouping.html"] = 5358,

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -385,7 +385,7 @@ corpus.
 | `dom/traversal/` | 13 `.html` | `NodeIterator` and `TreeWalker`; four of them are the walks that used to run forever ([#3765](https://github.com/sebastienros/jint/issues/3765)) |
 | `dom/traversal/support/` | 1 `.html`, 1 `.js` | An empty document a filter's realm comes from, and the node assertions |
 | `dom/ranges/` | 17 `.html` | The `Range` and `StaticRange` documents that do not load `dom/common.js`; the twenty-four that do are not-vendored rows |
-| `html/dom/` | 14 `.html`, 12 `.js` | ARIA reflection, `accessKeyLabel`, HTML's historical members, and `reflection-misc.html`, `-text.html`, `-grouping.html`, `-metadata.html`, `-sections.html`, `-obsolete.html`, `-tabular.html`, `-forms-weekmonth.html` and `-forms.html` with the helpers they load — nine of HTML's ten reflection documents. The last one is the browser lane's README |
+| `html/dom/` | 15 `.html`, 13 `.js` | ARIA reflection, `accessKeyLabel`, HTML's historical members, and **all ten** of HTML's reflection documents with the helpers they load — 56,660 assertions over every content attribute of every HTML element, which is the largest single body of conformance data this package runs |
 | `dom/constants.js` | 1 | The `Node` and `NodeFilter` constant tables, shared by `dom/nodes/` and `dom/traversal/` |
 | `dom/common.js` is *not* here | — | It calls `document.createCDATASection` at file scope, which the bindings do not have, so every document that loads it reports nothing at all |
 
@@ -1635,8 +1635,8 @@ find . -type f \( $TYPES \) | sort | while read -r f; do
 done
 ```
 
-Silence is a clean corpus, and at this pin there are 900 files in 79 directories to be silent
-about — 367 of them the documents the browser lane navigates to, the rest the scripts, payloads and
+Silence is a clean corpus, and at this pin there are 902 files in 79 directories to be silent
+about — 368 of them the documents the browser lane navigates to, the rest the scripts, payloads and
 sidecars every lane reads.
 
 <!-- end generated -->

--- a/Jint.Tests/Wpt/Vendor/html/dom/elements-embedded.js
+++ b/Jint.Tests/Wpt/Vendor/html/dom/elements-embedded.js
@@ -1,0 +1,158 @@
+var embeddedElements = {
+  picture: {},
+  img: {
+    // Conforming
+    alt: "string",
+    src: "url",
+    srcset: "string",
+    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}, isNullable: true, defaultVal: null, invalidVal: "anonymous"},
+    useMap: "string",
+    isMap: "boolean",
+    width: {type: "unsigned long", customGetter: true},
+    height: {type: "unsigned long", customGetter: true},
+    referrerPolicy: {type: "enum", keywords: ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"]},
+    decoding: {type: "enum", keywords: ["async", "sync", "auto"], defaultVal: "auto", invalidVal: "auto"},
+
+    // Obsolete
+    name: "string",
+    lowsrc: {type: "url"},
+    align: "string",
+    hspace: "unsigned long",
+    vspace: "unsigned long",
+    longDesc: "url",
+    border: {type: "string", treatNullAsEmptyString: true},
+  },
+  iframe: {
+    // Conforming
+    src: "url",
+    srcdoc: "string",
+    name: "string",
+    sandbox: "settable tokenlist",
+    allowFullscreen: "boolean",
+    width: "string",
+    height: "string",
+    referrerPolicy: {type: "enum", keywords: ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"]},
+
+    // Obsolete
+    align: "string",
+    scrolling: "string",
+    frameBorder: "string",
+    longDesc: "url",
+    marginHeight: {type: "string", treatNullAsEmptyString: true},
+    marginWidth: {type: "string", treatNullAsEmptyString: true}
+  },
+  embed: {
+    // Conforming
+    src: "url",
+    type: "string",
+    width: "string",
+    height: "string",
+
+    // Obsolete
+    align: "string",
+    name: "string"
+  },
+  object: {
+    // Conforming
+    data: "url",
+    type: "string",
+    name: "string",
+    useMap: "string",
+    width: "string",
+    height: "string",
+
+    // Obsolete
+    align: "string",
+    archive: "string",
+    code: "string",
+    declare: "boolean",
+    hspace: "unsigned long",
+    standby: "string",
+    vspace: "unsigned long",
+    codeBase: "url",
+    codeType: "string",
+    border: {type: "string", treatNullAsEmptyString: true}
+  },
+  param: {
+    // Conforming
+    name: "string",
+    value: "string",
+
+    // Obsolete
+    type: "string",
+    valueType: "string"
+  },
+  video: {
+    // HTMLMediaElement
+    src: "url",
+    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}, isNullable: true, defaultVal: null, invalidVal: "anonymous"},
+    // Missing/Invalid value is implementation defined but must be one of the keywords
+    preload: {type: "enum", keywords: ["none", "metadata", "auto"], nonCanon: {"": "auto"}, defaultVal: ["none", "metadata", "auto"]},
+    autoplay: "boolean",
+    loop: "boolean",
+    controls: "boolean",
+    controlsList: {type: "tokenlist", domAttrName: "controlsList"},
+    defaultMuted: {type: "boolean", domAttrName: "muted"},
+    loading: {type: "enum", keywords: ["lazy", "eager"], defaultVal: "eager", invalidVal: "eager"},
+
+    width: "unsigned long",
+    height: "unsigned long",
+    poster: "url",
+    playsInline: "boolean",
+  },
+  audio: {
+    // HTMLMediaElement
+    src: "url",
+    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}, isNullable: true, defaultVal: null, invalidVal: "anonymous"},
+    // Missing/Invalid value is implementation defined but must be one of the keywords
+    preload: {type: "enum", keywords: ["none", "metadata", "auto"], nonCanon: {"": "auto"}, defaultVal: ["none", "metadata", "auto"]},
+    autoplay: "boolean",
+    loop: "boolean",
+    controls: "boolean",
+    defaultMuted: {type: "boolean", domAttrName: "muted"},
+    loading: {type: "enum", keywords: ["lazy", "eager"], defaultVal: "eager", invalidVal: "eager"},
+  },
+  source: {
+    src: "url",
+    type: "string",
+    srcset: "string",
+    sizes: "string",
+    media: "string"
+  },
+  track: {
+    kind: {type: "enum", keywords: ["subtitles", "captions", "descriptions", "chapters", "metadata"], defaultVal: "subtitles", invalidVal: "metadata"},
+    src: "url",
+    srclang: "string",
+    label: "string",
+    "default": "boolean"
+  },
+  canvas: {
+    width: {type: "unsigned long", defaultVal: 300},
+    height: {type: "unsigned long", defaultVal: 150}
+  },
+  map: {
+    name: "string"
+  },
+  area: {
+    // Conforming
+    alt: "string",
+    coords: "string",
+    shape: "string",
+    target: "string",
+    download: "string",
+    ping: "string",
+    rel: "string",
+    relList: {type: "tokenlist", domAttrName: "rel"},
+    referrerPolicy: {type: "enum", keywords: ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"]},
+    hreflang: "string",
+    type: "string",
+
+    // HTMLHyperlinkElementUtils
+    href: "url",
+
+    // Obsolete
+    noHref: "boolean"
+  },
+};
+
+mergeElements(embeddedElements);

--- a/Jint.Tests/Wpt/Vendor/html/dom/reflection-embedded.html
+++ b/Jint.Tests/Wpt/Vendor/html/dom/reflection-embedded.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>HTML5 reflection tests: embedded elements</title>
+<meta name=timeout content=long>
+<p>Implementers looking to fix bugs might want to use the <a
+href=reflection-original.html>original version</a> of this suite's test
+framework, which conveniently aggregates similar errors and only reports
+failures.  This file is (part of) the authoritative conformance test suite, and
+is suitable for incorporation into automated test suites.
+
+<div id=log></div>
+
+<script src="/resources/testharness.js"></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=original-harness.js></script>
+<script src=new-harness.js></script>
+<script src=elements-embedded.js></script>
+<script src=reflection.js></script>

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -2172,6 +2172,383 @@
       "reason": "HTML \u00a716.3.3: `width` on <marquee> is a reflected DOMString and not a dimension. AngleSharp has no member for it."
     },
     {
+      "interface": "HTMLImageElement",
+      "member": "referrerPolicy",
+      "attribute": "referrerpolicy",
+      "type": "enum",
+      "keywords": ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"],
+      "reason": "HTML \u00a72.6.7: a referrer policy attribute is an enumerated attribute whose keywords are the Referrer Policy specification's, with an empty invalid and missing value default. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "decoding",
+      "attribute": "decoding",
+      "type": "enum",
+      "keywords": ["async", "sync", "auto"],
+      "missing": "auto",
+      "invalid": "auto",
+      "reason": "HTML \u00a74.8.3: `decoding` is an enumerated attribute whose missing and invalid value defaults are both `auto`. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "crossOrigin",
+      "attribute": "crossorigin",
+      "type": "enum",
+      "keywords": ["anonymous", "use-credentials"],
+      "nullable": true,
+      "invalid": "anonymous",
+      "reason": "HTML \u00a72.6.7: a CORS settings attribute is an enumerated attribute whose IDL type is DOMString?, so an absent attribute is null and any unknown value -- the empty string included -- is the Anonymous state. AngleSharp's CrossOrigin hands back the raw value."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "hspace",
+      "attribute": "hspace",
+      "type": "unsigned long",
+      "reason": "HTML \u00a716.3.3: a reflected unsigned long, so HTML's rules for parsing non-negative integers decide it and anything else is 0. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "vspace",
+      "attribute": "vspace",
+      "type": "unsigned long",
+      "reason": "HTML \u00a716.3.3: a reflected unsigned long, so HTML's rules for parsing non-negative integers decide it and anything else is 0. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "lowsrc",
+      "attribute": "lowsrc",
+      "type": "url",
+      "reason": "HTML \u00a716.3.3: an obsolete attribute reflected as a URL, so it answers the absolute URL the attribute resolves to. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "longDesc",
+      "attribute": "longdesc",
+      "type": "url",
+      "reason": "HTML \u00a716.3.3: an obsolete attribute reflected as a URL, so it answers the absolute URL the attribute resolves to. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "name",
+      "attribute": "name",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "border",
+      "attribute": "border",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute, [LegacyNullToEmptyString] so a null write is the empty string. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "align",
+      "attribute": "align",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "width",
+      "attribute": "width",
+      "type": "unsigned long",
+      "reason": "HTML \u00a74.8.3: the GETTER is the rendered width of the image and is not reflection, but the SETTER is. This package renders no image, so the getter answers the content attribute either way; what the row fixes is the setter, which AngleSharp implements as an Int32 write."
+    },
+    {
+      "interface": "HTMLImageElement",
+      "member": "height",
+      "attribute": "height",
+      "type": "unsigned long",
+      "reason": "HTML \u00a74.8.3, and the same halves as width's."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "referrerPolicy",
+      "attribute": "referrerpolicy",
+      "type": "enum",
+      "keywords": ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"],
+      "reason": "HTML \u00a72.6.7: a referrer policy attribute is an enumerated attribute whose keywords are the Referrer Policy specification's, with an empty invalid and missing value default. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "longDesc",
+      "attribute": "longdesc",
+      "type": "url",
+      "reason": "HTML \u00a716.3.3: an obsolete attribute reflected as a URL, so it answers the absolute URL the attribute resolves to. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "height",
+      "attribute": "height",
+      "type": "string",
+      "reason": "HTML \u00a74.8.5: `height` on <iframe> is a reflected DOMString and not a dimension. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "width",
+      "attribute": "width",
+      "type": "string",
+      "reason": "HTML \u00a74.8.5: `width` on <iframe> is a reflected DOMString and not a dimension. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "scrolling",
+      "attribute": "scrolling",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "frameBorder",
+      "attribute": "frameborder",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "marginWidth",
+      "attribute": "marginwidth",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute, [LegacyNullToEmptyString] so a null write is the empty string. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "marginHeight",
+      "attribute": "marginheight",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute, [LegacyNullToEmptyString] so a null write is the empty string. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLIFrameElement",
+      "member": "align",
+      "attribute": "align",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLEmbedElement",
+      "member": "src",
+      "attribute": "src",
+      "type": "url",
+      "reason": "HTML \u00a74.8.6 reflects `src` as a URL, so it answers the absolute URL the attribute resolves to. AngleSharp's Source is the raw attribute value."
+    },
+    {
+      "interface": "HTMLEmbedElement",
+      "member": "name",
+      "attribute": "name",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLEmbedElement",
+      "member": "align",
+      "attribute": "align",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "hspace",
+      "attribute": "hspace",
+      "type": "unsigned long",
+      "reason": "HTML \u00a716.3.3: a reflected unsigned long, so HTML's rules for parsing non-negative integers decide it and anything else is 0. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "vspace",
+      "attribute": "vspace",
+      "type": "unsigned long",
+      "reason": "HTML \u00a716.3.3: a reflected unsigned long, so HTML's rules for parsing non-negative integers decide it and anything else is 0. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "codeBase",
+      "attribute": "codebase",
+      "type": "url",
+      "reason": "HTML \u00a716.3.3: an obsolete attribute reflected as a URL, so it answers the absolute URL the attribute resolves to. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "code",
+      "attribute": "code",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "border",
+      "attribute": "border",
+      "type": "string",
+      "legacyNullToEmptyString": true,
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute, [LegacyNullToEmptyString] so a null write is the empty string. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "standby",
+      "attribute": "standby",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "declare",
+      "attribute": "declare",
+      "type": "boolean",
+      "reason": "HTML \u00a716.3.3: an obsolete boolean attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "height",
+      "attribute": "height",
+      "type": "string",
+      "reason": "HTML \u00a74.8.7: `height` on <object> is a reflected DOMString and not a dimension. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "width",
+      "attribute": "width",
+      "type": "string",
+      "reason": "HTML \u00a74.8.7: `width` on <object> is a reflected DOMString and not a dimension. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "codeType",
+      "attribute": "codetype",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "archive",
+      "attribute": "archive",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLObjectElement",
+      "member": "align",
+      "attribute": "align",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLParamElement",
+      "member": "type",
+      "attribute": "type",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLParamElement",
+      "member": "valueType",
+      "attribute": "valuetype",
+      "type": "string",
+      "reason": "HTML \u00a716.3.3: an obsolete presentational attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLMediaElement",
+      "member": "preload",
+      "attribute": "preload",
+      "type": "enum",
+      "keywords": ["none", "metadata", "auto"],
+      "missing": "auto",
+      "invalid": "auto",
+      "reason": "HTML \u00a74.8.11.5: `preload` is an enumerated attribute limited to only known values whose missing AND invalid value defaults are implementation-defined among the three states -- `auto` is the choice here, and it is what makes the empty string (a synonym for the Automatic state) read back as `auto` rather than as itself. AngleSharp hands back the raw attribute value."
+    },
+    {
+      "interface": "HTMLMediaElement",
+      "member": "crossOrigin",
+      "attribute": "crossorigin",
+      "type": "enum",
+      "keywords": ["anonymous", "use-credentials"],
+      "nullable": true,
+      "invalid": "anonymous",
+      "reason": "HTML \u00a72.6.7: a CORS settings attribute is an enumerated attribute whose IDL type is DOMString?, so an absent attribute is null and any unknown value -- the empty string included -- is the Anonymous state. AngleSharp hands back the raw value on both <video> and <audio>."
+    },
+    {
+      "interface": "HTMLVideoElement",
+      "member": "playsInline",
+      "attribute": "playsinline",
+      "type": "boolean",
+      "reason": "HTML \u00a74.8.9: a boolean attribute AngleSharp has no member for."
+    },
+    {
+      "interface": "HTMLVideoElement",
+      "member": "width",
+      "attribute": "width",
+      "type": "unsigned long",
+      "reason": "HTML \u00a74.8.9: `width` on <video> is a reflected unsigned long. AngleSharp types it as an Int32 with .NET's own parse."
+    },
+    {
+      "interface": "HTMLVideoElement",
+      "member": "height",
+      "attribute": "height",
+      "type": "unsigned long",
+      "reason": "HTML \u00a74.8.9: `height` on <video> is a reflected unsigned long. AngleSharp types it as an Int32 with .NET's own parse."
+    },
+    {
+      "interface": "HTMLTrackElement",
+      "member": "kind",
+      "attribute": "kind",
+      "type": "enum",
+      "keywords": ["subtitles", "captions", "descriptions", "chapters", "metadata"],
+      "missing": "subtitles",
+      "invalid": "metadata",
+      "reason": "HTML \u00a74.8.11.1: an enumerated attribute whose missing value default (`subtitles`) and invalid value default (`metadata`) DIFFER, which is the clearest case in the suite for stating both. AngleSharp hands back the raw attribute value."
+    },
+    {
+      "interface": "HTMLCanvasElement",
+      "member": "width",
+      "attribute": "width",
+      "type": "unsigned long",
+      "default": 300,
+      "reason": "HTML \u00a74.12.5: a reflected unsigned long whose default is 300. AngleSharp types it as an Int32 with .NET's own parse and a default of 0."
+    },
+    {
+      "interface": "HTMLCanvasElement",
+      "member": "height",
+      "attribute": "height",
+      "type": "unsigned long",
+      "default": 150,
+      "reason": "HTML \u00a74.12.5: a reflected unsigned long whose default is 150."
+    },
+    {
+      "interface": "HTMLAreaElement",
+      "member": "referrerPolicy",
+      "attribute": "referrerpolicy",
+      "type": "enum",
+      "keywords": ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"],
+      "reason": "HTML \u00a72.6.7: a referrer policy attribute is an enumerated attribute whose keywords are the Referrer Policy specification's, with an empty invalid and missing value default. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLAreaElement",
+      "member": "noHref",
+      "attribute": "nohref",
+      "type": "boolean",
+      "reason": "HTML \u00a716.3.3: an obsolete boolean attribute the standard still requires the IDL attribute for. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLAreaElement",
+      "member": "ping",
+      "attribute": "ping",
+      "type": "string",
+      "reason": "HTML \u00a74.8.14: `ping` is a reflected DOMString. AngleSharp has no member for it."
+    },
+    {
+      "interface": "HTMLMediaElement",
+      "member": "loading",
+      "attribute": "loading",
+      "type": "enum",
+      "keywords": ["lazy", "eager"],
+      "missing": "eager",
+      "invalid": "eager",
+      "reason": "HTML \u00a74.8.11.5: `loading` is a lazy loading attribute, which is an enumerated attribute over `lazy` and `eager` whose missing and invalid value defaults are both `eager`. It is on the media element and not only on <img> and <iframe>, which is easy to read past. AngleSharp has no member for it."
+    },
+    {
       "interface": "HTMLMenuElement",
       "member": "compact",
       "attribute": "compact",


### PR DESCRIPTION
`html/dom/reflection-embedded.html` becomes a case and **passes whole**, so **8,922 more assertions of HTML §2.6.1 run** with nothing excluded — the largest of the ten documents, and the last one. 3,774 failed at the measurement in #3770 and 2,487 on today's `main`.

**All ten of HTML's reflection documents are cases now**: 56,660 assertions over every content attribute of every HTML element, which is the largest single body of conformance data this package runs. **22,028 of them failed when the suite was measured; 540 do now** — and every one of those 540 is the dependency rather than reflection.

**Stacks on #3987**, which stacks on #3986 → #3984 → #3983 → #3981 → #3979. The base is `main` only because a cross-fork pull request cannot target a branch this repository does not have — so **the diff below contains all seven commits, and the one to review here is the seventh, `Reflection: the embedded-content elements' attribute table`.** They merge in order: metadata → sections → obsolete → tabular → forms-weekmonth → forms → **embedded**.

## Mechanism

Fifty `reflected` rows over ten interfaces, the largest table of the seven families.

| Element | Rows | What is in them |
| --- | ---: | --- |
| `<img>` | 12 | `referrerPolicy`, `decoding`, `crossOrigin`, `hspace`, `vspace`, `lowsrc`, `longDesc`, `name`, `border`, `align`, and the `width`/`height` pair |
| `<object>` | 12 | `hspace`, `vspace`, `codeBase`, `code`, `border`, `standby`, `declare`, `height`, `width`, `codeType`, `archive`, `align` |
| `<iframe>` | 9 | `referrerPolicy`, `longDesc`, `height`, `width`, `scrolling`, `frameBorder`, `marginWidth`, `marginHeight`, `align` |
| media | 5 | `preload`, `crossOrigin` and `loading` on **`HTMLMediaElement`**; `playsInline`, `width`, `height` on `<video>` |
| `<area>` | 3 | `referrerPolicy`, `noHref`, `ping` |
| `<embed>` | 3 | `src`, `name`, `align` |
| `<canvas>` | 2 | `width` (default **300**), `height` (default **150**) |
| `<param>` | 2 | `type`, `valueType` |
| `<track>` | 1 | `kind` |

Three of them are worth naming individually.

* **`loading` is on the media element**, not only on `<img>` and `<iframe>`. [HTML §4.8.11.5](https://html.spec.whatwg.org/multipage/media.html#dom-media-loading) declares `attribute DOMString loading` on `HTMLMediaElement` as a lazy loading attribute — enumerated over `lazy` and `eager` with both defaults `eager`. I read the IDL block from a truncated fetch first and concluded the corpus was testing a member the standard does not have; it is not, and the row goes where HTML puts it, so one row serves `<video>` and `<audio>` both.
* **`preload`'s defaults are implementation-defined.** HTML lets the missing *and* invalid value defaults be any of `none`, `metadata` or `auto`, and the corpus asserts membership of that array rather than one value. The row picks `auto` — which is also what stops the empty string, a synonym for the Automatic state, reading back as itself, since the corpus separately asserts that an enumeration never answers in a non-canonical representation.
* **`track.kind` is the suite's clearest case for stating both defaults**: its missing value default is `subtitles` and its invalid value default is `metadata`. Two different answers from one keyword list, which is exactly what a CLR property cannot carry.

`<img>`'s `width` and `height` are the halves case again (getter is the rendered image size, setter reflects), the same as `<input>`'s in #3986.

## Failing-first evidence

Vendoring the document with **no** rows written and **no** exclusions — 2,487 of its 8,922 tests fail:

```
128 img.referrerPolicy   128 area.referrerPolicy   108 iframe.referrerPolicy
 85 track.kind            73 img.hspace/vspace, object.hspace/vspace
 70 img.decoding          61 audio.preload, video.preload
 58 crossOrigin ×3, loading ×2
 44 img.lowsrc, img.longDesc, iframe.longDesc, object.codeBase
 40 embed.src             38 × 31 members that are absent outright
 14 canvas.width/height, video.width/height
  2 img.width, img.height
```

| State | Failing, of 8,922 |
| --- | ---: |
| The measurement in #3770 | 3,774 |
| Today's `main` (the global rows), vendored with no exclusions | **2,487** |
| \+ forty-nine rows | **116** — exactly `video.loading` and `audio.loading` |
| \+ `HTMLMediaElement.loading` | **0** |

## Remaining exclusions

None. `WptBrowserExclusions` gains no row for this document, and its `NotVendored` reflection block shrinks to the two files that were never part of the suite: `reflection-original.html` (the same tests in the aggregating spelling) and `elements-aria-enumerated.js` (the table of a proposal the standard has not adopted).

## Upstream (AngleSharp) findings

* **`referrerPolicy` is projected on no element.** `<a>`, `<area>`, `<img>`, `<iframe>`, `<link>` and `<script>` all have it in HTML; AngleSharp has none of the six, and where it has a raw-value member the enumeration's canonicalisation is missing.
* **`IHtmlMediaElement.CrossOrigin` and `.Preload` are raw attribute values**, so `preload=""` — a synonym for the Automatic state — reads back as `""`, which is not one of the three keywords the state machine has.
* **There is no `loading` on the media element**, no `decoding` on `<img>`, no `playsInline` on `<video>`, and no `kind` canonicalisation on `<track>`.
* **`<canvas>`'s `width` and `height` default to 0** where HTML says 300 and 150 — the one pair in the suite where the wrong default is visible without any parsing at all.
* **Thirty-one obsolete members are absent across `<img>`, `<iframe>`, `<object>`, `<embed>`, `<param>` and `<area>`.**

Recorded in `Jint.Browser/Dom/divergences.md`. No issues were opened on AngleSharp's repositories.

## Deliberately left out

* **`img.loading` and `iframe.loading`.** HTML has both; the corpus's tables for those two elements do not, so a row would be one nothing runs. The media element's is here because the corpus tests it.
* **`video.controlsList`, `iframe.sandbox`, `area.relList`.** `tokenlist` and `settable tokenlist` are not in `reflection.js`'s own `typeMap`, so the corpus skips them and they are not in the numbers either way.
* **A real rendered `width`/`height`.** `Wpt/AGENTS.md` already calls that `NeedsLayout`.
* **The two files still not vendored** — `reflection-original.html` and `elements-aria-enumerated.js`, both for the reasons their rows have carried since the suite arrived.

## Verified

| What | Command | Result |
| --- | --- | --- |
| Solution builds | `dotnet build -c Release` | 0 errors |
| The document | `dotnet test -c Release Jint.Tests.Browser --filter RunsTheHtmlDomSuite` | 15/15, both frameworks |
| The whole lane, census on | `JINT_WPT_BROWSER_CENSUS=1 dotnet test -c Release Jint.Tests.Browser --filter Jint.Tests.Browser.Wpt` | 400/400 on net8.0 and net10.0 |
| The whole project | `dotnet test -c Release Jint.Tests.Browser` | 2,287 passed net8.0, 2,291 passed net10.0, 0 failed |
| Instruction files | `dotnet test -c Release Jint.Tests --filter AgentInstructionFileTests` | 5/5 |
| Generated bindings | `JINT_DOM_BINDINGS=update`, then `--filter DomBindingsStaleness` | 3/3 |

The census (`html/dom/` 14 → 15 documents, 47,823 → 56,745 tests) was regenerated with `JINT_WPT_BROWSER_CENSUS=update-raising-the-ceiling` and never hand-edited. **The not-passing figure did not move**: 1,931 before and after.


The corpus grew, so `Jint.Tests/Wpt/Vendor/README.md`'s **drift-verification recipe** was regenerated too (`JINT_WPT_CENSUS=update dotnet test Jint.Tests -c Release --filter WptCensusTests`): it counts the files and directories the `find` walks, and `WptCensusTests.TheDriftRecipeWalksTheCorpusThatIsVendored` fails while it is stale. The two vendored files this pull request adds were fetched from `raw.githubusercontent.com` at the pinned commit, which is the same bytes that recipe compares. Across the stack the recipe goes from 888 files to 902.

**Rebased onto `b31a05fd1`** (AngleSharp.Css 1.1.1-beta.308) and re-verified there: the browser wpt lane is **402/402** with `JINT_WPT_BROWSER_CENSUS=1` on net8.0, green. The count moved from the table above because main's #3974 added two tests to the lane; nothing in this branch changed, and the Css bump does not move `<style>`'s `media` behaviour.

## Where the suite ends up

| Document | Assertions | Failing before | Failing now |
| --- | ---: | ---: | ---: |
| `reflection-text.html` | 10,202 | 3,360 | **0** |
| `reflection-embedded.html` | 8,922 | 3,774 | **0** |
| `reflection-forms.html` | 8,271 | 2,160 | 18 |
| `reflection-tabular.html` | 6,116 | 3,552 | **0** |
| `reflection-sections.html` | 5,604 | 2,189 | **0** |
| `reflection-grouping.html` | 5,358 | 2,006 | 38 |
| `reflection-misc.html` | 4,877 | 1,866 | **0** |
| `reflection-metadata.html` | 3,110 | 1,218 | 16 |
| `reflection-obsolete.html` | 2,621 | 1,483 | 468 |
| `reflection-forms-weekmonth.html` | 1,579 | 420 | **0** |
| **total** | **56,660** | **22,028** | **540** |

Closes #3770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
