### PR TITLE
Fetch a `data:` subresource, and keep a response URL fragment

### DIFF
--- a/Jint.Browser/Page.Navigation.cs
+++ b/Jint.Browser/Page.Navigation.cs
@@ -4,6 +4,7 @@ using System.Text;
 using AngleSharp.Html.Dom;
 using Jint.Browser.Runtime;
 using Jint.Native;
+using Jint.WebApi.Fetch;
 using Jint.WebApi.Url.Parsing;
 
 namespace Jint.Browser;
@@ -419,7 +420,7 @@ public sealed partial class Page
             {
                 try
                 {
-                    request = request with { InlineContent = ContentOf(href) };
+                    request = request with { InlineContent = ContentOf(target, href) };
                 }
                 catch (NavigationFailedException failure)
                 {
@@ -607,7 +608,7 @@ public sealed partial class Page
         }
         else
         {
-            html = request.InlineContent ?? ContentOf(href);
+            html = request.InlineContent ?? ContentOf(target, href);
             finalUrl = href;
         }
 
@@ -1050,44 +1051,39 @@ public sealed partial class Page
 
     /// <summary>
     /// The markup a URL that reaches no network carries: nothing for <c>about:</c>, and the payload of a
-    /// <c>data:</c> URL, percent-decoded or base64-decoded.
+    /// <c>data:</c> URL.
     /// </summary>
-    private static string ContentOf(string url)
+    /// <remarks>
+    /// The decoding is https://fetch.spec.whatwg.org/#data-url-processor, which is the same algorithm the
+    /// parser driver runs for a <c>&lt;script src="data:…"&gt;</c> — one answer to what a <c>data:</c> URL
+    /// carries rather than two. What that buys over the open-coded version this replaced: forgiving-base64
+    /// rather than <see cref="Convert"/>'s stricter one, percent-decoding that leaves a lone <c>%</c> alone,
+    /// and the <c>charset</c> parameter actually being read.
+    /// </remarks>
+    private static string ContentOf(UrlRecord target, string url)
     {
-        if (url.StartsWith("about:", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(target.Scheme, "about", StringComparison.Ordinal))
         {
             return "";
         }
 
-        if (!url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        if (!DataUrl.Is(target))
         {
             throw new NavigationFailedException(
                 url,
                 "Jint.Browser cannot load '" + url + "': a page loads http, https, about: and data: URLs.");
         }
 
-        var comma = url.IndexOf(',', StringComparison.Ordinal);
-        if (comma < 0)
+        if (!DataUrl.TryProcess(target, out var content))
         {
-            throw new NavigationFailedException(url, "'" + url + "' is not a valid data URL: it has no comma.");
+            throw new NavigationFailedException(
+                url,
+                "'" + url + "' is not a valid data URL: it has no comma, or its base64 payload does not decode.");
         }
 
-        var metadata = url[5..comma];
-        var payload = url[(comma + 1)..];
-
-        try
-        {
-            if (metadata.EndsWith(";base64", StringComparison.OrdinalIgnoreCase))
-            {
-                return Encoding.UTF8.GetString(System.Convert.FromBase64String(payload));
-            }
-
-            return Uri.UnescapeDataString(payload);
-        }
-        catch (FormatException exception)
-        {
-            throw new NavigationFailedException(url, "'" + url + "' is not a valid data URL: " + exception.Message, exception);
-        }
+        // The response's Content-Type is the type the URL claimed, so the document's encoding is decided the
+        // same way a fetched one's is.
+        return new FetchedSubresource(content.Body, content.MimeType.Serialize(), url, target.Fragment, 200).Text();
     }
 
     /// <summary>Where a navigation puts its result in the session history.</summary>

--- a/Jint.Browser/Runtime/Parsing/AGENTS.md
+++ b/Jint.Browser/Runtime/Parsing/AGENTS.md
@@ -115,6 +115,24 @@ is the shape AngleSharp's own processors already test for; the `load` and `error
 dispatched through Jint's dispatcher, because AngleSharp's go into its own listener lists. `integrity` and
 `crossorigin` are accepted and ignored, and say so here rather than in a sentence nobody reads.
 
+**Two schemes reach no socket, and one of them carries a body.** `about:blank` is answered as the empty HTML
+document a frame's `src` most often names. A `data:` URL is answered by
+[Fetch §5.2's processor](https://fetch.spec.whatwg.org/#data-url-processor) — `Jint/WebApi/Fetch/DataUrl.cs`,
+the *only* implementation of it in the repository, which `Page.Navigation` also uses so that a navigation and
+a `<script src="data:…">` cannot disagree about the same URL. It runs before the network-scheme check and
+therefore before the `UrlFilter`, the jar and the redirect budget, because there is nothing there for any of
+them to decide — the same order `fetch`'s `blob` arm takes. **`MaxSubresourceBytes` still applies**: a page
+may not escape a size ceiling by inlining, and nothing is written to `Page.Requests`, because a page that
+opened no socket made no request. Forgiving-base64 and percent-decoding are what the processor uses and the
+BCL's stricter pair is not it: `data:;base64,YQ` decodes in a browser and throws in `Convert`.
+
+**A response URL carries its fragment, and that includes a script's.**
+[Fetch's response URL](https://fetch.spec.whatwg.org/#concept-response-url) is the request's — the fragment
+is left out of the request-target and of nothing else — so `ParserDriver.ResponseUrl` puts
+`SubresourceFetch`'s separately-carried fragment back on every answer rather than only a nested document's.
+It is what [report an exception](https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception)
+names, so without it `<script src="a.js#">` reported a URL its own `src` did not reflect.
+
 **A linked stylesheet completes after CSS processing, not after its fetch.** `PageStylingService` delegates
 the parse to AngleSharp.Css, then hands the completion to the driver. Both `load` and `error` are engine
 tasks: an inserting script and its microtasks finish first, and the processor has assigned `link.sheet`

--- a/Jint.Browser/Runtime/Parsing/ParserDriver.cs
+++ b/Jint.Browser/Runtime/Parsing/ParserDriver.cs
@@ -8,6 +8,7 @@ using AngleSharp.Scripting;
 using Jint.Native;
 using Jint.Runtime;
 using Jint.WebApi.Events;
+using Jint.WebApi.Fetch;
 using Jint.Runtime.Modules;
 using Jint.WebApi.Url.Parsing;
 
@@ -474,8 +475,7 @@ internal sealed class ParserDriver : IDisposable
                 frame,
                 "frame document",
                 PageRequestKind.Frame,
-                handedOver,
-                documentResponse: true);
+                handedOver);
         });
     }
 
@@ -565,12 +565,22 @@ internal sealed class ParserDriver : IDisposable
         IElement source,
         string what,
         PageRequestKind kind,
-        bool mayPump,
-        bool documentResponse = false)
+        bool mayPump)
     {
         var target = UrlParser.Parse(url);
 
-        if (target is null || !PageUrl.IsNetworkScheme(target))
+        if (target is null)
+        {
+            FailSubresource(source, url, "'" + url + "' is not a URL a page can load.");
+            return null;
+        }
+
+        if (DataUrl.Is(target))
+        {
+            return FetchDataUrl(target, source, url, what);
+        }
+
+        if (!PageUrl.IsNetworkScheme(target))
         {
             FailSubresource(source, url, "'" + url + "' is not a URL a page can load.");
             return null;
@@ -599,7 +609,7 @@ internal sealed class ParserDriver : IDisposable
         {
             var fetched = mayPump ? _baton.PumpUntil(fetch) : fetch.GetAwaiter().GetResult();
             return PageResourceLoader.Answer(
-                documentResponse ? DocumentUrl(fetched.Url, fetched.Fragment) : fetched.Url,
+                ResponseUrl(fetched.Url, fetched.Fragment),
                 fetched.Bytes,
                 fetched.ContentType);
         }
@@ -621,15 +631,69 @@ internal sealed class ParserDriver : IDisposable
         }
     }
 
-    /// <summary>The response URL a nested document is opened with.</summary>
+    /// <summary>
+    /// https://fetch.spec.whatwg.org/#scheme-fetch's <c>data</c> arm: a URL that carries its own bytes,
+    /// answered without a socket.
+    /// </summary>
     /// <remarks>
+    /// <para>
+    /// <b>It is the one subresource scheme besides <c>http</c> and <c>https</c>, and it is not a network
+    /// position at all.</b> There is nothing here for the context's <c>UrlFilter</c>, the cookie jar, a
+    /// redirect budget or the request log to decide — the bytes were in the document that named them — which
+    /// is the same reason <c>fetch</c>'s <c>blob</c> arm runs before every one of those checks. Nothing is
+    /// recorded in <see cref="Page.Requests"/> for the same reason <c>about:blank</c> records nothing: a
+    /// page that asked for nothing made no request.
+    /// </para>
+    /// <para>
+    /// <b>The one bound that does apply is the size one.</b> A <c>data:</c> URL is as large as the markup
+    /// that carried it, so <see cref="BrowserOptions.MaxSubresourceBytes"/> is checked here exactly as
+    /// <see cref="SubresourceFetch"/> checks it over the wire; a page may not escape it by inlining.
+    /// </para>
+    /// </remarks>
+    private IResponse? FetchDataUrl(UrlRecord target, IElement source, string url, string what)
+    {
+        if (!DataUrl.TryProcess(target, out var content))
+        {
+            FailSubresource(source, url, "The " + what + " '" + url + "' is not a valid data: URL.");
+            return null;
+        }
+
+        if (content.Body.LongLength > _maxBytes)
+        {
+            FailSubresource(
+                source,
+                url,
+                "The " + what + " '" + url + "' carries more than the "
+                    + _maxBytes.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    + " bytes a page may load.");
+            return null;
+        }
+
+        // https://fetch.spec.whatwg.org/#concept-response-url: the response URL is the request's, so the
+        // fragment a data: URL was written with survives into what an error report names.
+        return PageResourceLoader.Answer(target.Serialize(), content.Body, content.MimeType.Serialize());
+    }
+
+    /// <summary>The URL a fetched subresource is answered under.</summary>
+    /// <remarks>
+    /// <para>
     /// Fetch does not send a fragment to the server, and <see cref="SubresourceFetch"/> therefore serializes
     /// its public response URL without one. Its separate fragment preserves the final request URL's three
-    /// states across redirects: absent, explicitly empty, or non-empty. AngleSharp reads the reconstructed
-    /// URL for <c>location</c> and Selectors' <c>:target</c>; script and stylesheet response URLs remain the
-    /// fragment-free transport URL.
+    /// states across redirects: absent, explicitly empty, or non-empty.
+    /// </para>
+    /// <para>
+    /// <b>Every response carries it back, not only a nested document's.</b>
+    /// https://fetch.spec.whatwg.org/#concept-response-url is the request's URL, fragment and all — the
+    /// fragment is left out of the request-target and of nothing else — and
+    /// https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception names the script's own
+    /// URL, so <c>&lt;script src="a.js#"&gt;</c> has to report the <c>#</c> that
+    /// https://url.spec.whatwg.org/#concept-url-serializer keeps for a non-null empty fragment. Answering
+    /// the transport URL instead made <c>onerror</c> disagree with the <c>src</c> the same element
+    /// reflects. AngleSharp reads it for a document's <c>location</c> and Selectors' <c>:target</c>, and for
+    /// a script and a style sheet it is the base URL, which a fragment plays no part in resolving against.
+    /// </para>
     /// </remarks>
-    private static string DocumentUrl(string responseUrl, string? fragment)
+    private static string ResponseUrl(string responseUrl, string? fragment)
     {
         if (fragment is null || UrlParser.Parse(responseUrl) is not { } documentUrl)
         {

--- a/Jint.Tests.Browser/Parsing/ScriptLoadingTests.cs
+++ b/Jint.Tests.Browser/Parsing/ScriptLoadingTests.cs
@@ -281,6 +281,96 @@ public class ScriptLoadingTests
     }
 
     [Test]
+    public async Task ADataUrlScriptIsFetchedFromItsOwnBytesAndRuns()
+    {
+        await using var loopback = await LoopbackPage.CreateAsync(server => server
+            .MapHtml("/", """
+                <!doctype html><html><head>
+                <script>window.log = [];</script>
+                <script src="data:text/javascript,window.log.push('percent%20decoded')"></script>
+                <script src="data:text/javascript;base64,d2luZG93LmxvZy5wdXNoKCdiYXNlNjQnKQ=="></script>
+                </head><body>done</body></html>
+                """));
+
+        await loopback.Page.NavigateAsync(loopback.Url("/"));
+
+        // https://fetch.spec.whatwg.org/#data-urls step 10 percent-decodes the body and step 11 base64-decodes
+        // it, so both of these are source text a page runs without a socket ever being opened.
+        (await loopback.Page.EvaluateAsync<string>("window.log.join(',')")).Should().Be("percent decoded,base64");
+        loopback.Page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ADataUrlScriptsExceptionIsReportedAgainstTheDataUrl()
+    {
+        await using var loopback = await LoopbackPage.CreateAsync(server => server
+            .MapHtml("/", """
+                <!doctype html><html><head>
+                <script>
+                  window.reported = null;
+                  window.onerror = function (message, url) { window.reported = url; return true; };
+                </script>
+                <script src="data:text/javascript,undefined_variable;"></script>
+                </head><body>done</body></html>
+                """));
+
+        await loopback.Page.NavigateAsync(loopback.Url("/"));
+
+        // https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception: the filename is the
+        // script's own URL, which for a data: URL is the whole of it.
+        (await loopback.Page.EvaluateAsync("window.reported")).Should().Be("data:text/javascript,undefined_variable;");
+    }
+
+    [Test]
+    public async Task ADataUrlWithNoMimeTypeAtAllStillRunsAsAClassicScript()
+    {
+        await using var loopback = await LoopbackPage.CreateAsync(server => server
+            .MapHtml("/", """
+                <!doctype html><html><head>
+                <script>window.ran = []; window.failed = [];</script>
+                <script src="data:,window.ran.push('bare')" onerror="window.failed.push('bare')"></script>
+                <script src="data:text/plain,window.ran.push('plain')" onerror="window.failed.push('plain')"></script>
+                <script src="data:text/javascript" onerror="window.failed.push('no-comma')"></script>
+                </head><body>done</body></html>
+                """));
+
+        await loopback.Page.NavigateAsync(loopback.Url("/"));
+
+        // https://html.spec.whatwg.org/multipage/scripting.html#fetch-a-classic-script never looks at the
+        // response's MIME type -- only a module script does -- so both of the first two run. The third is
+        // https://fetch.spec.whatwg.org/#data-url-processor step 7's failure: no comma, so no body, so a
+        // network error the element hears as `error`.
+        (await loopback.Page.EvaluateAsync<string>("window.ran.join(',')")).Should().Be("bare,plain");
+        (await loopback.Page.EvaluateAsync<string>("window.failed.join(',')")).Should().Be("no-comma");
+    }
+
+    [Test]
+    public async Task AnExternalScriptsFragmentSurvivesIntoTheErrorReport()
+    {
+        await using var loopback = await LoopbackPage.CreateAsync(server => server
+            .Map("/boom.js", _ => LoopbackResponse.Script("undefined_variable;"))
+            .MapHtml("/", """
+                <!doctype html><html><head>
+                <script>
+                  window.reported = [];
+                  window.onerror = function (message, url) { window.reported.push(url); return true; };
+                </script>
+                <script src="/boom.js#"></script>
+                <script src="/boom.js#frag"></script>
+                </head><body>done</body></html>
+                """));
+
+        await loopback.Page.NavigateAsync(loopback.Url("/"));
+
+        // https://url.spec.whatwg.org/#concept-url-serializer keeps an empty fragment, and Fetch's response
+        // URL is the request URL fragment and all -- so what onerror reports is what script.src reflects.
+        (await loopback.Page.EvaluateAsync<string>("window.reported.join(',')"))
+            .Should().Be(loopback.Url("/boom.js") + "#," + loopback.Url("/boom.js") + "#frag");
+        (await loopback.Page.EvaluateAsync("document.querySelector('script[src=\"/boom.js#\"]').src"))
+            .Should().Be(loopback.Url("/boom.js") + "#");
+    }
+
+    [Test]
     public async Task DocumentWriteAfterTheParseIsRefusedWithAReason()
     {
         await using var loopback = await LoopbackPage.CreateAsync(server => server

--- a/Jint.Tests.Browser/Runtime/PageTests.cs
+++ b/Jint.Tests.Browser/Runtime/PageTests.cs
@@ -224,6 +224,35 @@ public sealed class PageTests
     }
 
     [Test]
+    public async Task ADataUrlIsDecodedByTheStandardsProcessorRatherThanTheBclOne()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        // https://infra.spec.whatwg.org/#forgiving-base64-decode accepts an unpadded payload -- the encoding
+        // of "<p id=x>decoded</p>" with its two "=" removed, twenty-six code points -- where
+        // Convert.FromBase64String throws on a length that does not divide by four, which is what this
+        // navigation used to be decoded with.
+        await page.NavigateAsync("data:text/html;base64,PHAgaWQ9eD5kZWNvZGVkPC9wPg");
+
+        (await page.EvaluateAsync<string>("document.getElementById('x').textContent")).Should().Be("decoded");
+    }
+
+    [Test]
+    public async Task ADataUrlsCharsetParameterDecidesTheEncoding()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        // https://fetch.spec.whatwg.org/#data-url-processor step 13 parses the MIME type, and the response
+        // it produces is what the document's encoding is sniffed from — so a single 0xE9 byte is `é` here
+        // and the replacement character under UTF-8.
+        await page.NavigateAsync("data:text/html;charset=iso-8859-1,<p id='x'>caf%E9</p>");
+
+        (await page.EvaluateAsync<string>("document.getElementById('x').textContent")).Should().Be("café");
+    }
+
+    [Test]
     public async Task ASchemeThePageCannotReachIsRefusedWithASentence()
     {
         await using var browser = new Browser();

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -33,18 +33,12 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `dom/ranges/` | 17 | 0 | 82 | 4 |
 | `html/dom/` | 15 | 0 | 56,745 | 41 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
-| `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 12 |
+| `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
 | `custom-elements/` | 16 | 0 | 513 | 248 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **359** | **9** | **66,646** | **1,165** |
-| `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
-| `custom-elements/` | 16 | 0 | 510 | 247 |
-| `custom-elements/parser/` | 8 | 0 | 20 | 11 |
-| `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
-| `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **358** | **9** | **57,721** | **1,924** |
+| **total** | **359** | **9** | **66,646** | **1,158** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -39,6 +39,12 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
 | **total** | **359** | **9** | **66,646** | **1,165** |
+| `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
+| `custom-elements/` | 16 | 0 | 510 | 247 |
+| `custom-elements/parser/` | 8 | 0 | 20 | 11 |
+| `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
+| `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
+| **total** | **358** | **9** | **57,721** | **1,924** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -67,30 +73,32 @@ passive value, one activation behaviour per click, the detached control's silent
 the window — and the three seams two of them needed in the engine are
 [#3696](https://github.com/sebastienros/jint/pull/3696).
 
-What `NeedsTriage` holds now is four things, each bounded and each named by the exclusion table:
+**Two more left `NeedsTriage` with the script-loading path, and both were about a URL.** A `data:` URL is a
+subresource now: `ParserDriver` answers the `data` arm of
+[scheme fetch](https://fetch.spec.whatwg.org/#scheme-fetch) out of
+[Fetch §5.2's processor](https://fetch.spec.whatwg.org/#data-url-processor) rather than over a socket, so
+`<script src="data:text/javascript,…">` runs and the three `processing-model-2/` documents about it pass.
+And a subresource's response URL carries its fragment, which is what
+[Fetch](https://fetch.spec.whatwg.org/#concept-response-url) says a response URL *is* — the fragment is left
+out of the request-target and of nothing else — so `<script src="support/syntax-error.js#">` reports the `#`
+that the same element's `src` already reflected, instead of losing it to a re-serialization. Five rows and
+two; the same processor also replaced the page's *second*, open-coded `data:` decoder, so a navigation to
+one now reads its `charset` and takes a payload `Convert.FromBase64String` refuses.
 
-1. **A `data:` URL is not fetched as a subresource.** A page navigates to one, so
-   `<script src="data:text/javascript,…">` is the one shape of external script that never runs; three
-   `processing-model-2/` documents are about exactly that script. The report site those documents test works,
-   which their `<script src>` and inline siblings say.
-2. **A URL's fragment is dropped between the element and the error report.** This entry used to be
-   "`script.src` does not reflect a URL" and four rows; [#3770](https://github.com/sebastienros/jint/issues/3770)'s
-   reflection machinery took the member over and two of the four are cases now. The two that remain load
-   `<script src="support/syntax-error.js#">` and the URL `onerror` reports has lost the trailing `#`, so what
-   goes missing is the (empty) fragment rather than the resolution — a re-serialization on the
-   script-loading path, and a change to `Jint.Browser/Runtime/` rather than to the binding.
-3. **A DOM prototype carries no `@@unscopables`.** WebIDL puts one on the interface prototype object of every
+What `NeedsTriage` holds now is two things, each bounded and each named by the exclusion table:
+
+1. **A DOM prototype carries no `@@unscopables`.** WebIDL puts one on the interface prototype object of every
    interface with an `[Unscopable]` member — `Element`'s and `Document`'s `append`, `prepend` and
    `replaceChildren` among them — and the generator emits none, because AngleSharp's metadata does not say
    which members are unscopable. `compile-event-handler-symbol-unscopables.html` never reaches its subject:
    it *writes* to `document[Symbol.unscopables]`.
-4. **A form-associated custom element has no form owner.** `window.customElements` exists now, and the one
+2. **A form-associated custom element has no form owner.** `window.customElements` exists now, and the one
    row of `compile-event-handler-lexical-scopes-form-owner.html` that is left asserts that a compiled handler
    on an `<x-foo static formAssociated>` sees the *form's* lexical scope — which needs the element to be a
    form-associated element and take part in `form.elements`. This package records the flag and nothing
    consults it: there is no `ElementInternals`. The file's other three rows pass.
 
-The twenty-two `<a>`/`<area>` shapes of `Event-dispatch-single-activation-behavior.html` were the fifth, and
+The twenty-two `<a>`/`<area>` shapes of `Event-dispatch-single-activation-behavior.html` were another, and
 they pass now. What kept them red was not the page loop's scheduling but the fragment arm being gated on the
 page's own load having returned and on the navigation gate being free: this file's tests run *during* the
 parse, where neither is true, so every one of their fragment moves was queued as a whole navigation behind

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -832,101 +832,6 @@ internal static class WptBrowserExclusions
         new("html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url.html", "<body onerror> - compile error in <script src=data:...>", WptDivergence.NeedsTriage),
     ];
 
-    // ---------------------------------------------------------------- 3. a URL's fragment is dropped
-    private static readonly WptExclusion[] _3AURLSFragmentIsDropped =
-    [
-        // This group used to be four rows and the cause was `script.src` not reflecting a URL: HTML says the
-        // `src` IDL attribute reflects the content attribute AS A URL, so it answers the resolved absolute
-        // one, and AngleSharp's `IHtmlScriptElement.Source` answered the raw attribute value. #3770's
-        // reflection machinery took the member over and two of the four are cases now.
-        // The two that remain are a different defect wearing the same shape: each loads
-        // `<script src="support/syntax-error.js#">` and the URL `onerror` reports has lost the trailing `#`,
-        // so what goes missing is the (empty) FRAGMENT and not the resolution. That happens on the
-        // script-loading path — the URL is re-serialized between the element and the error report — and is a
-        // change to `Runtime/`, not to the binding.
-        new("html/webappapis/scripting/processing-model-2/compile-error-same-origin-with-hash.html", "window.onerror - compile error in <script src=...> with hash", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-same-origin-with-hash.html", "window.onerror - runtime error in <script src=...> with hash", WptDivergence.NeedsTriage),
-    // ------------------------------------------- 4. an obsolete element interface AngleSharp does not have
-    private static readonly WptExclusion[] _4AnObsoleteElementInterfaceAngleSharpDoesNotHave =
-    [
-        // Four elements, one shape of gap. HTML gives each of them an interface of its own; the pinned
-        // assemblies model each as a plain HTMLElement, so there is nowhere for a `reflected` row to put the
-        // members. Putting them on HTMLElement instead would give `compact` to every element, which is worse
-        // than not having it. Declaring the interface by local name is what DomManualInterfaces does for
-        // <frameset>; doing it for these four is a change of its own, and Dom/divergences.md records it.
-        //
-        // <dl> is the first, and its one member is the obsolete `compact`: there is no IHtmlDListElement and
-        // no [DomName("HTMLDListElement")] anywhere in the pinned assemblies.
-        //
-        // Thirteen rows rather than one `dl.compact: *`, because one of the member's tests passes by
-        // accident and the two-sided rule will not have it covered: `IDL set to true` asserts
-        // `hasAttribute('compact')` is true, and the attribute is still there from the `setAttribute()` half
-        // that ran before it. The expando the assignment really made is invisible to that assertion.
-        new("html/dom/reflection-grouping.html", "dl.compact: typeof IDL attribute", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL get with DOM attribute unset", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: setAttribute() to *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to \"*", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to object \"*", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to undefined", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to 7", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to 1.5", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to false", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to NaN", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to Infinity", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to -Infinity", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to null", WptDivergence.NeedsTriage),
-
-        // <dir>, <font> and <frame> are the other three, and they arrived with
-        // html/dom/reflection-obsolete.html. HtmlDirectoryElement, HtmlFontElement and HtmlFrameElement
-        // are internal sealed classes with no public interface and no [DomName] at all, so each is an
-        // HTMLElement here and there is nowhere to put the members HTML gives them. <frameset> is the
-        // one of the family that is NOT in this group: DomManualInterfaces declares
-        // HTMLFrameSetElement by local name, so its `cols` and `rows` are reflected members now and its
-        // 76 assertions pass.
-        //
-        // Ten whole-member globs and two families of thirteen. A glob is safe for a member that is
-        // absent outright, because every one of its tests fails; a BOOLEAN member has one test that
-        // passes by accident, which is the same `IDL set to true` <dl> has -- it asserts
-        // hasAttribute() is true, and the attribute is still there from the setAttribute() half that
-        // ran before it.
-        new("html/dom/reflection-obsolete.html", "font.color: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "font.face: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "font.size: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.frameBorder: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.longDesc: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.marginHeight: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.marginWidth: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.name: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.scrolling: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.src: *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: typeof IDL attribute", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL get with DOM attribute unset", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: setAttribute() to *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to \"*", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to object \"*", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to undefined", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to 7", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to 1.5", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to false", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to NaN", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to Infinity", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to -Infinity", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to null", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: typeof IDL attribute", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL get with DOM attribute unset", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: setAttribute() to *", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to \"*", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to object \"*", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to undefined", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to 7", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to 1.5", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to false", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to NaN", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to Infinity", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to -Infinity", WptDivergence.NeedsTriage),
-        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to null", WptDivergence.NeedsTriage),
-    ];
-
     // ---------------------------------------------------------------- 8. AngleSharp.Css refuses an unparseable media query
     private static readonly WptExclusion[] _8AngleSharpCssRefusesAnUnparseableMediaQuery =
     [
@@ -1581,8 +1486,6 @@ internal static class WptBrowserExclusions
     [
         new("1. an event interface this browser has not built", _1AnEventInterfaceThisBrowserHasNotBuilt),
         new("2. a `data:` URL subresource", _2ADataURLSubresource),
-        new("3. a URL's fragment is dropped", _3AURLSFragmentIsDropped),
-        new("4. an obsolete element interface AngleSharp does not have", _4AnObsoleteElementInterfaceAngleSharpDoesNotHave),
         new("5. a DOM prototype has no @@unscopables", _5ADOMPrototypeHasNoUnscopables),
         new("8. AngleSharp.Css refuses an unparseable media query", _8AngleSharpCssRefusesAnUnparseableMediaQuery),
         new("9. a double written with .NET's number format", _9ADoubleWrittenWithNETSNumberFormat),

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -846,6 +846,85 @@ internal static class WptBrowserExclusions
         // change to `Runtime/`, not to the binding.
         new("html/webappapis/scripting/processing-model-2/compile-error-same-origin-with-hash.html", "window.onerror - compile error in <script src=...> with hash", WptDivergence.NeedsTriage),
         new("html/webappapis/scripting/processing-model-2/runtime-error-same-origin-with-hash.html", "window.onerror - runtime error in <script src=...> with hash", WptDivergence.NeedsTriage),
+    // ------------------------------------------- 4. an obsolete element interface AngleSharp does not have
+    private static readonly WptExclusion[] _4AnObsoleteElementInterfaceAngleSharpDoesNotHave =
+    [
+        // Four elements, one shape of gap. HTML gives each of them an interface of its own; the pinned
+        // assemblies model each as a plain HTMLElement, so there is nowhere for a `reflected` row to put the
+        // members. Putting them on HTMLElement instead would give `compact` to every element, which is worse
+        // than not having it. Declaring the interface by local name is what DomManualInterfaces does for
+        // <frameset>; doing it for these four is a change of its own, and Dom/divergences.md records it.
+        //
+        // <dl> is the first, and its one member is the obsolete `compact`: there is no IHtmlDListElement and
+        // no [DomName("HTMLDListElement")] anywhere in the pinned assemblies.
+        //
+        // Thirteen rows rather than one `dl.compact: *`, because one of the member's tests passes by
+        // accident and the two-sided rule will not have it covered: `IDL set to true` asserts
+        // `hasAttribute('compact')` is true, and the attribute is still there from the `setAttribute()` half
+        // that ran before it. The expando the assignment really made is invisible to that assertion.
+        new("html/dom/reflection-grouping.html", "dl.compact: typeof IDL attribute", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL get with DOM attribute unset", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: setAttribute() to *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to \"*", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to object \"*", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to undefined", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to 7", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to 1.5", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to false", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to NaN", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to Infinity", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to -Infinity", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-grouping.html", "dl.compact: IDL set to null", WptDivergence.NeedsTriage),
+
+        // <dir>, <font> and <frame> are the other three, and they arrived with
+        // html/dom/reflection-obsolete.html. HtmlDirectoryElement, HtmlFontElement and HtmlFrameElement
+        // are internal sealed classes with no public interface and no [DomName] at all, so each is an
+        // HTMLElement here and there is nowhere to put the members HTML gives them. <frameset> is the
+        // one of the family that is NOT in this group: DomManualInterfaces declares
+        // HTMLFrameSetElement by local name, so its `cols` and `rows` are reflected members now and its
+        // 76 assertions pass.
+        //
+        // Ten whole-member globs and two families of thirteen. A glob is safe for a member that is
+        // absent outright, because every one of its tests fails; a BOOLEAN member has one test that
+        // passes by accident, which is the same `IDL set to true` <dl> has -- it asserts
+        // hasAttribute() is true, and the attribute is still there from the setAttribute() half that
+        // ran before it.
+        new("html/dom/reflection-obsolete.html", "font.color: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "font.face: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "font.size: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.frameBorder: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.longDesc: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.marginHeight: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.marginWidth: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.name: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.scrolling: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.src: *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: typeof IDL attribute", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL get with DOM attribute unset", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: setAttribute() to *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to \"*", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to object \"*", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to undefined", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to 7", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to 1.5", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to false", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to NaN", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to Infinity", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to -Infinity", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "dir.compact: IDL set to null", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: typeof IDL attribute", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL get with DOM attribute unset", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: setAttribute() to *", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to \"*", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to object \"*", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to undefined", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to 7", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to 1.5", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to false", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to NaN", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to Infinity", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to -Infinity", WptDivergence.NeedsTriage),
+        new("html/dom/reflection-obsolete.html", "frame.noResize: IDL set to null", WptDivergence.NeedsTriage),
     ];
 
     // ---------------------------------------------------------------- 8. AngleSharp.Css refuses an unparseable media query
@@ -1503,6 +1582,7 @@ internal static class WptBrowserExclusions
         new("1. an event interface this browser has not built", _1AnEventInterfaceThisBrowserHasNotBuilt),
         new("2. a `data:` URL subresource", _2ADataURLSubresource),
         new("3. a URL's fragment is dropped", _3AURLSFragmentIsDropped),
+        new("4. an obsolete element interface AngleSharp does not have", _4AnObsoleteElementInterfaceAngleSharpDoesNotHave),
         new("5. a DOM prototype has no @@unscopables", _5ADOMPrototypeHasNoUnscopables),
         new("8. AngleSharp.Css refuses an unparseable media query", _8AngleSharpCssRefusesAnUnparseableMediaQuery),
         new("9. a double written with .NET's number format", _9ADoubleWrittenWithNETSNumberFormat),
@@ -1548,9 +1628,9 @@ internal static class WptBrowserExclusions
     /// <b><see cref="WptDivergence.NeedsTriage"/> records bounded causes, not a count of exclusion rows.</b> The eleven
     /// defects this lane first recorded were filed as
     /// https://github.com/sebastienros/jint/issues/3686 to 3695 and are fixed; what is left is named in
-    /// <c>Wpt/README.md</c>, one section per cause, and every one of them is bounded — a scheme a subresource
-    /// cannot fetch, a member AngleSharp reflects wrong, an <c>@@unscopables</c> object the binding does not
-    /// emit, and a custom element.
+    /// <c>Wpt/README.md</c>, one section per cause, and every one of them is bounded — a member AngleSharp
+    /// reflects wrong, an <c>@@unscopables</c> object the binding does not emit, and a form-associated custom
+    /// element.
     /// </para>
     /// <para>
     /// <b>The DOM suites made it much bigger, and every one of those causes is bounded.</b> They now hold

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -820,18 +820,6 @@ internal static class WptBrowserExclusions
         new("dom/events/EventTarget-dispatchEvent.html", "If the event's initialized flag is not set, an InvalidStateError must be thrown (StorageEvent).", WptDivergence.NeedsMoreEventInterfaces),
     ];
 
-    // ---------------------------------------------------------------- 2. a `data:` URL subresource
-    private static readonly WptExclusion[] _2ADataURLSubresource =
-    [
-        // A page navigates to a `data:` URL and cannot fetch one as a subresource, so a
-        // `<script src="data:text/javascript,…">` is never run — which is what "ran expected true got false"
-        // says here. The report site these documents are about works; what is missing is the scheme, and
-        // adding it is `Runtime/SubresourceFetch`'s change rather than this one.
-        new("html/webappapis/scripting/processing-model-2/compile-error-data-url.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/runtime-error-data-url.html", "*", WptDivergence.NeedsTriage),
-        new("html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url.html", "<body onerror> - compile error in <script src=data:...>", WptDivergence.NeedsTriage),
-    ];
-
     // ---------------------------------------------------------------- 8. AngleSharp.Css refuses an unparseable media query
     private static readonly WptExclusion[] _8AngleSharpCssRefusesAnUnparseableMediaQuery =
     [
@@ -1485,7 +1473,6 @@ internal static class WptBrowserExclusions
     internal static readonly WptCause[] Causes =
     [
         new("1. an event interface this browser has not built", _1AnEventInterfaceThisBrowserHasNotBuilt),
-        new("2. a `data:` URL subresource", _2ADataURLSubresource),
         new("5. a DOM prototype has no @@unscopables", _5ADOMPrototypeHasNoUnscopables),
         new("8. AngleSharp.Css refuses an unparseable media query", _8AngleSharpCssRefusesAnUnparseableMediaQuery),
         new("9. a double written with .NET's number format", _9ADoubleWrittenWithNETSNumberFormat),

--- a/Jint.Tests/Runtime/WebApi/DataUrlTests.cs
+++ b/Jint.Tests/Runtime/WebApi/DataUrlTests.cs
@@ -1,0 +1,115 @@
+#if NET8_0_OR_GREATER
+#nullable enable
+
+using System.Text;
+using Jint.WebApi.Fetch;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.Tests.Runtime.WebApi;
+
+/// <summary>
+/// The <c>data:</c> URL processor, https://fetch.spec.whatwg.org/#data-url-processor.
+/// </summary>
+/// <remarks>
+/// It has one implementation in the repository and two callers — a page's navigation and a page's
+/// <c>&lt;script src="data:…"&gt;</c> — so the steps that are easy to get subtly wrong are measured here
+/// rather than through either of them: where the base64 marker ends, what an absent MIME type defaults to,
+/// and which inputs are the specification's failure.
+/// </remarks>
+public class DataUrlTests
+{
+    [TestCase("data:,hello", "hello", "text/plain;charset=US-ASCII")]
+    [TestCase("data:text/plain,hello", "hello", "text/plain")]
+    [TestCase("data:text/javascript,a%20b", "a b", "text/javascript")]
+    [TestCase("data:text/plain;base64,aGVsbG8=", "hello", "text/plain")]
+    // Step 11 leaves the MIME type empty here, and step 12 prepends nothing to an empty string --
+    // so it is step 14's default rather than "text/plain", which is what a browser answers too.
+    [TestCase("data:;base64,aGVsbG8=", "hello", "text/plain;charset=US-ASCII")]
+    [TestCase("data:text/plain;charset=utf-8;base64,aGVsbG8=", "hello", "text/plain;charset=utf-8")]
+    public void TheProcessorAnswersABodyAndAMimeType(string url, string expectedBody, string expectedMimeType)
+    {
+        Process(url, out var body, out var mimeType).Should().BeTrue();
+        body.Should().Be(expectedBody);
+        mimeType.Should().Be(expectedMimeType);
+    }
+
+    [Test]
+    public void TheBase64MarkerIsRecognizedWithSpacesAndInAnyCase()
+    {
+        // Step 11 is ";" then zero or more U+0020 SPACE then an ASCII case-insensitive "base64", and steps
+        // 11.4 to 11.6 remove exactly that much.
+        Process("data:text/plain;   BaSe64,aGVsbG8=", out var body, out var mimeType).Should().BeTrue();
+        body.Should().Be("hello");
+        mimeType.Should().Be("text/plain");
+    }
+
+    [Test]
+    public void AMimeTypeEndingInBase64WithNoSemicolonIsNotTheMarker()
+    {
+        // "x/base64" ends with the six code points and is still an ordinary MIME type, so the body is
+        // percent-decoded and not base64-decoded.
+        Process("data:x/base64,aGVsbG8=", out var body, out var mimeType).Should().BeTrue();
+        body.Should().Be("aGVsbG8=");
+        mimeType.Should().Be("x/base64");
+    }
+
+    [Test]
+    public void AnUnparseableMimeTypeFallsBackToTextPlainUsAscii()
+    {
+        // Step 14: a MIME type that is not a MIME type at all does not fail the URL, it defaults.
+        Process("data:not-a-mime-type,hello", out var body, out var mimeType).Should().BeTrue();
+        body.Should().Be("hello");
+        mimeType.Should().Be("text/plain;charset=US-ASCII");
+    }
+
+    [Test]
+    public void ForgivingBase64AcceptsAnUnpaddedPayload()
+    {
+        // https://infra.spec.whatwg.org/#forgiving-base64-decode, which Convert.FromBase64String is not: a
+        // twenty-six code point payload decodes here and throws there.
+        Process("data:text/plain;base64,PHAgaWQ9eD5kZWNvZGVkPC9wPg", out var body, out _).Should().BeTrue();
+        body.Should().Be("<p id=x>decoded</p>");
+    }
+
+    [Test]
+    public void ALonePercentSignIsKeptRatherThanRefused()
+    {
+        // https://url.spec.whatwg.org/#percent-decode appends a "%" that is not followed by two hex digits
+        // and moves on; Uri.UnescapeDataString throws on the same input.
+        Process("data:text/plain,100%25%20of%20%zz", out var body, out _).Should().BeTrue();
+        body.Should().Be("100% of %zz");
+    }
+
+    [TestCase("data:text/plain")]
+    [TestCase("data:")]
+    [TestCase("data:text/plain;base64,%%%")]
+    public void TheSpecificationsFailuresAreFailures(string url)
+        => Process(url, out _, out _).Should().BeFalse();
+
+    [Test]
+    public void TheFragmentIsNoPartOfTheBody()
+    {
+        // Step 2 serializes with the fragment excluded, and the URL parser has already split it off at the
+        // first "#" — so a "#" in what looks like the payload ends the payload.
+        Process("data:text/plain,before#after", out var body, out _).Should().BeTrue();
+        body.Should().Be("before");
+    }
+
+    private static bool Process(string url, out string body, out string mimeType)
+    {
+        var record = UrlParser.Parse(url);
+        record.Should().NotBeNull();
+
+        if (!DataUrl.TryProcess(record!, out var content))
+        {
+            body = "";
+            mimeType = "";
+            return false;
+        }
+
+        body = Encoding.UTF8.GetString(content.Body);
+        mimeType = content.MimeType.Serialize();
+        return true;
+    }
+}
+#endif

--- a/Jint/WebApi/Fetch/DataUrl.cs
+++ b/Jint/WebApi/Fetch/DataUrl.cs
@@ -1,0 +1,143 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using SystemEncoding = System.Text.Encoding;
+using Jint.WebApi.Base64;
+using Jint.WebApi.Url.Parsing;
+
+namespace Jint.WebApi.Fetch;
+
+/// <summary>
+/// What a <c>data:</c> URL carries, https://fetch.spec.whatwg.org/#data-url-struct — a MIME type and a body.
+/// </summary>
+/// <param name="Body">The bytes, percent-decoded and then base64-decoded when the URL said so.</param>
+/// <param name="MimeType">
+/// The type the URL claimed for them, already defaulted to <c>text/plain;charset=US-ASCII</c> when it
+/// claimed one that does not parse.
+/// </param>
+internal readonly record struct DataUrlContent(byte[] Body, MimeType MimeType);
+
+/// <summary>
+/// The <c>data:</c> URL processor, https://fetch.spec.whatwg.org/#data-url-processor.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It reaches no transport and it is not a policy decision.</b> A <c>data:</c> URL names bytes that are
+/// already in hand, so — exactly as <c>BlobUrlFetch</c> does for the <c>blob</c> arm of scheme fetch — there
+/// is nothing here for an <c>HttpClient</c>, a URL filter, a redirect budget or an observer to decide. What a
+/// caller still owes is its own size ceiling: the body is as large as the URL, and a URL can be very large.
+/// </para>
+/// <para>
+/// <b>It is deliberately not <c>Uri.UnescapeDataString</c> plus <see cref="Convert"/>.</b> The two halves of
+/// the algorithm are WHATWG's own and neither BCL method is it: percent-decoding leaves a lone <c>%</c>
+/// alone where <c>Uri.UnescapeDataString</c> throws on one, and forgiving-base64 accepts padding and
+/// whitespace <see cref="Convert.FromBase64String"/> refuses — <c>data:;base64,YQ</c> decodes in a browser
+/// and throws there. <see cref="ForgivingBase64"/> already had that half.
+/// </para>
+/// </remarks>
+internal static class DataUrl
+{
+    /// <summary>The scheme, as the URL parser records it.</summary>
+    internal const string Scheme = "data";
+
+    /// <summary>The MIME type step 14 falls back to when the URL claimed one that does not parse.</summary>
+    private const string DefaultMimeType = "text/plain;charset=US-ASCII";
+
+    /// <summary>Whether <paramref name="url"/> is a <c>data:</c> URL.</summary>
+    internal static bool Is(UrlRecord url) => string.Equals(url.Scheme, Scheme, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Runs the processor over <paramref name="url"/>, answering <see langword="false"/> for the
+    /// specification's failure — a URL with no comma, or a base64 payload that does not decode.
+    /// </summary>
+    internal static bool TryProcess(UrlRecord url, out DataUrlContent content)
+    {
+        content = default;
+
+        // Steps 2 and 3: the input is the serialization with the fragment excluded, past "data:". The
+        // fragment is therefore no part of the body, however much it looks like one — the URL parser split
+        // it off at the first "#" and it stays split off here.
+        var input = url.Serialize(excludeFragment: true);
+        if (!input.StartsWith(Scheme + ":", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        input = input[(Scheme.Length + 1)..];
+
+        // Steps 5 to 8: everything up to the first "," is the MIME type; no "," at all is failure.
+        var comma = input.IndexOf(',', StringComparison.Ordinal);
+        if (comma < 0)
+        {
+            return false;
+        }
+
+        // Step 6.
+        var mimeType = input[..comma].Trim(AsciiWhitespace);
+
+        // Steps 9 and 10: string percent-decode, which is UTF-8 encode followed by percent-decode.
+        var body = PercentEncoding.Decode(SystemEncoding.UTF8.GetBytes(input[(comma + 1)..]));
+
+        // Step 11: ";" then optional spaces then a case-insensitive "base64", and only at the very end.
+        if (Base64Suffix(mimeType) is { } kept)
+        {
+            if (!ForgivingBase64.TryDecode(IsomorphicDecode(body), out var decoded))
+            {
+                return false;
+            }
+
+            body = decoded;
+            mimeType = mimeType[..kept];
+        }
+
+        // Step 12: a MIME type that is only parameters gets the type the specification gives it.
+        if (mimeType.StartsWith(';'))
+        {
+            mimeType = "text/plain" + mimeType;
+        }
+
+        // Steps 13 and 14.
+        content = new DataUrlContent(body, MimeType.Parse(mimeType) ?? MimeType.Parse(DefaultMimeType)!);
+        return true;
+    }
+
+    /// <summary>https://infra.spec.whatwg.org/#ascii-whitespace, as the trim set step 6 uses.</summary>
+    private static readonly char[] AsciiWhitespace = ['\t', '\n', '\f', '\r', ' '];
+
+    /// <summary>
+    /// The length step 11 leaves the MIME type at when it ends with the base64 marker — the "base64", the
+    /// spaces before it and the ";" all removed — or <see langword="null"/> when it does not end with one.
+    /// </summary>
+    private static int? Base64Suffix(string mimeType)
+    {
+        // Step 11's condition and its steps 11.4 to 11.6 read the same suffix from opposite ends; measuring
+        // it once is what keeps them from disagreeing about how many spaces there were.
+        const string Marker = "base64";
+
+        if (mimeType.Length < Marker.Length + 1
+            || !mimeType.AsSpan(mimeType.Length - Marker.Length).Equals(Marker, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var end = mimeType.Length - Marker.Length;
+        while (end > 0 && mimeType[end - 1] == ' ')
+        {
+            end--;
+        }
+
+        return end > 0 && mimeType[end - 1] == ';' ? end - 1 : null;
+    }
+
+    /// <summary>https://infra.spec.whatwg.org/#isomorphic-decode — one code point per byte.</summary>
+    private static string IsomorphicDecode(byte[] bytes)
+    {
+        return string.Create(bytes.Length, bytes, static (span, source) =>
+        {
+            for (var i = 0; i < source.Length; i++)
+            {
+                span[i] = (char) source[i];
+            }
+        });
+    }
+}
+#endif


### PR DESCRIPTION
**[#3995](https://github.com/sebastienros/jint/pull/3995) stacks on this one.** Merge this first.

## What and why

Two of the four `NeedsTriage` causes in the browser wpt lane's
`html/webappapis/scripting/processing-model-2/` suite, both about the URL a script was loaded from. Seven
rows retired; the suite falls from 12 not passing to 5 and the lane's census total from 1,913 to 1,906.

### 1. A `data:` URL was not a subresource

`ParserDriver.Fetch` refused every scheme but `http`/`https`, so `<script src="data:text/javascript,…">` was
the one shape of external script a page could not load — it never ran and `window.onerror` never heard its
exception. The `data` arm of [scheme fetch](https://fetch.spec.whatwg.org/#scheme-fetch) is now answered by
the [data: URL processor](https://fetch.spec.whatwg.org/#data-url-processor), written once as
`Jint/WebApi/Fetch/DataUrl.cs`.

**Mechanism.** The arm runs before the network-scheme check, and therefore before the browser context's
`UrlFilter`, the cookie jar and the redirect budget — the same order `fetch`'s `blob` arm takes
(`FetchOperation`), and for the same reason: the bytes were in the document that named them, so there is
nothing there for any of those to decide. Two things follow and are stated in the code:

* **`BrowserOptions.MaxSubresourceBytes` still applies.** A page may not escape a size ceiling by inlining,
  so the decoded body is measured against the same bound `SubresourceFetch` enforces over the wire. No bound
  is loosened by this change.
* **Nothing is written to `Page.Requests`,** for the reason `about:blank` writes nothing: a page that opened
  no socket made no request.

**Why not the BCL.** The page already had an open-coded `data:` decoder in `Page.Navigation.ContentOf`, and
neither half of it was the algorithm: [forgiving-base64](https://infra.spec.whatwg.org/#forgiving-base64-decode)
accepts an unpadded payload `Convert.FromBase64String` throws on, and
[percent-decoding](https://url.spec.whatwg.org/#percent-decode) leaves a lone `%` alone where
`Uri.UnescapeDataString` throws. That decoder is replaced by a call to the same processor, so a navigation
and a `<script src="data:…">` cannot disagree about one URL — and a navigation now reads the `charset`
parameter it used to ignore.

**A classic script's MIME type is not checked**, deliberately: HTML's
[fetch a classic script](https://html.spec.whatwg.org/multipage/scripting.html#fetch-a-classic-script) looks
at the response's type only for its charset, and only a *module* script requires a JavaScript MIME type. So
`data:text/plain,…` and `data:,…` both run, which `ADataUrlWithNoMimeTypeAtAllStillRunsAsAClassicScript`
pins alongside step 7's no-comma failure.

### 2. A response URL lost its fragment

`SubresourceFetch` serializes its public response URL without a fragment and carries the fragment beside it,
and only a *nested document's* response put it back. But
[Fetch's response URL](https://fetch.spec.whatwg.org/#concept-response-url) is the request's URL, fragment
and all — the fragment is left out of the request-target and of nothing else — and
[report an exception](https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception) names the
script's own URL. So `<script src="support/syntax-error.js#">` reported a URL that the same element's `src`
already reflected differently, the `#` that
[the URL serializer](https://url.spec.whatwg.org/#concept-url-serializer) keeps for a non-null empty
fragment having gone missing in a re-serialization.

`ParserDriver.ResponseUrl` (was `DocumentUrl`) now reconstructs it for every subresource rather than only a
frame's document. A fragment plays no part in resolving a relative URL against a base, so a script's and a
style sheet's base URL are unchanged; what changes is what an error report and `response.Address` say.

## Failing-first evidence

`ScriptLoadingTests` gains four cases and `PageTests` two. Measured by reverting the three production files
(`DataUrl.cs` removed, `ParserDriver.cs` and `Page.Navigation.cs` restored) with the tests kept:

| Test | Unfixed |
| --- | --- |
| `ADataUrlScriptIsFetchedFromItsOwnBytesAndRuns` | `window.log` is `""` |
| `ADataUrlScriptsExceptionIsReportedAgainstTheDataUrl` | `window.reported` is `null` |
| `ADataUrlWithNoMimeTypeAtAllStillRunsAsAClassicScript` | `window.ran` is `""` |
| `AnExternalScriptsFragmentSurvivesIntoTheErrorReport` | `…/boom.js,…/boom.js` where `script.src` is `…/boom.js#` |
| `ADataUrlsCharsetParameterDecidesTheEncoding` | `caf%E9` |
| `ADataUrlIsDecodedByTheStandardsProcessorRatherThanTheBclOne` | `NavigationFailedException: … not a valid Base-64 string …` |

All six pass with the fix. The last one is worth a note: its first spelling used a payload that *was* a
multiple of four, so it passed on unfixed code — it was rewritten against
`PHAgaWQ9eD5kZWNvZGVkPC9wPg` (twenty-six code points) which `Convert` really refuses, and only then failed
first.

`Jint.Tests/Runtime/WebApi/DataUrlTests.cs` is new-code coverage rather than a regression proof: it measures
the processor's own steps — where the base64 marker ends (spaces, case, and `x/base64` *not* being one),
step 12's prepend, step 14's `text/plain;charset=US-ASCII` default, the lone `%`, the fragment being no part
of the body, and the three inputs that are the specification's failure.

## Exactly what was verified

```
dotnet build -c Release                                      # solution; keeps the Jint/WebApi net8.0 gate airtight
dotnet test Jint.Tests.Browser -c Release                    # 2324 passed (net10.0), 2320 (net8.0), 0 failed
dotnet test Jint.Tests -c Release                            # 12419 passed (net8.0, net10.0), 8509 (net472), 0 failed
dotnet test Jint.Tests.Browser -c Release --filter Wpt       # 400 passed, 0 failed
JINT_WPT_BROWSER_CENSUS=update dotnet test Jint.Tests.Browser -c Release --filter Wpt
```

Single-document triage (`JINT_WPT_DOCUMENT=…`, `--filter WptBrowserTriage`) over the five documents, before
and after:

| Document | Before | After |
| --- | --- | --- |
| `compile-error-data-url.html` | 2 FAIL | 2 PASS |
| `runtime-error-data-url.html` | 2 FAIL | 2 PASS |
| `body-onerror-compile-error-data-url.html` | 1 FAIL, 1 PASS | 2 PASS |
| `compile-error-same-origin-with-hash.html` | 1 FAIL, 1 PASS | 2 PASS |
| `runtime-error-same-origin-with-hash.html` | 1 FAIL, 1 PASS | 2 PASS |

The two cause groups (`2. a data: URL subresource`, `3. a URL's fragment is dropped`) are removed from
`WptBrowserExclusions.Causes` — the runner refuses an exclusion that covers nothing failing, so leaving
either would have failed the lane. The census was regenerated with `=update`, never hand-edited, and only
the `processing-model-2/` row and the total moved.

## What was deliberately left out

* **`fetch()`, `XMLHttpRequest` and `EventSource` still do not take a `data:` URL.** The processor is shared
  and ready, but wiring it into the engine's own lanes is a decision about `Options.WebApi.Fetch` — what
  `AllowedSchemes` means for a scheme with no transport, and what a `FetchObserver` is told about a request
  that never happens — and belongs in its own change with its own tests.
* **A `data:` subresource is not recorded in `Page.Requests`.** A row there is a reference the document made
  over the network; the alternative (a synthetic completed request) would put a thing with no timing, no
  status line and no headers into a log a protocol client reads.
* **The MIME type is not enforced for a classic script**, which is HTML's rule rather than an omission —
  see above.
* **Module scripts** take `PageModuleScriptLoader`, not this path; a `data:` module specifier is untouched.

## Upstream (AngleSharp) findings

None. Everything here is Jint's own: the parser driver's fetch, the page's navigation, and the engine's
Fetch subtree. AngleSharp asks the resource loader for a `data:` URL exactly as it asks for any other, which
is why answering it needed no change on that side.

## Base

`bd8058d55` — *Reflection: the form controls' attribute table (#3987)*. Rebased three times since opening as
main moved; against that base the census total goes 1,931 → 1,924 and only the `processing-model-2/` row
moves with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
