### PR TITLE
Web platform tests: a browser-lane document runs once per declared variant

### DIFF
--- a/Jint.Tests.Browser/Wpt/AGENTS.md
+++ b/Jint.Tests.Browser/Wpt/AGENTS.md
@@ -68,6 +68,21 @@ document, and only two of them are cases:
   appears in no census column, because neither counts anything about a document that reports nothing. What
   holds a frame body to its job is the case that loads it.
 
+**And a case is a path *at one variant*.** A document may declare
+[`<meta name="variant" content="?query">`](https://web-platform-tests.org/writing-tests/testharness.html#variants),
+and upstream's manifest then makes one test per declaration, at that path with the string appended; the
+document reads which one it is out of `location.search`. `WptBrowserVariants` is the port of
+`SourceFile.test_variants` — a document's `<meta>` elements read off a real parse, a wrapped `.any.js`
+file's `// META: variant=` lines, upstream's two validity rules, and `[""]` for a file that declares
+none — and a case name is the path and the variant, spelled as the manifest spells it
+(`dom/events/handler-count.html?element`). So **every key in this lane is a case and never a document**: a
+minimum-test entry, an exclusion, a cause's file. There is deliberately **no spelling that means every
+variant**, because two variants are two runs and a divergence measured in one is not evidence about the
+other — which is also why the census's `Documents` and `Synthesized` columns keep counting *files*, so a
+variant moves `Tests` and leaves those two alone. The engine lane ignores `// META: variant=` for the
+opposite and equally correct reason: a shard variant selects a subset of the same tests and one unsharded
+run is their union, which a query the document itself branches on is not.
+
 **The dedicated-worker wrapper is deliberately not generated.** `WorkersHandler`'s document creates a *classic*
 worker whose generated body opens with `importScripts("/resources/testharness.js")`, and Jint runs module
 workers only — so it would throw before registering a test, which is why `workers/*.worker.js` is a

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -25,29 +25,22 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 
 | Suite | Documents | Synthesized | Tests | Not passing |
 | --- | --- | --- | --- | --- |
-| `dom/events/` | 56 | 9 | 544 | 11 |
+| `dom/events/` | 56 | 9 | 548 | 11 |
 | `dom/nodes/` | 168 | 0 | 8,115 | 736 |
-| `dom/events/` | 56 | 9 | 548 | 15 |
-| `dom/nodes/` | 168 | 0 | 8,115 | 808 |
 | `dom/collections/` | 8 | 0 | 43 | 0 |
 | `dom/lists/` | 5 | 0 | 189 | 2 |
 | `dom/traversal/` | 13 | 0 | 52 | 0 |
-| `dom/ranges/` | 17 | 0 | 82 | 4 |
+| `dom/ranges/` | 17 | 0 | 84 | 2 |
 | `html/dom/` | 15 | 0 | 56,745 | 36 |
 | `html/infrastructure/common-dom-interfaces/collections/` | 1 | 0 | 41 | 0 |
 | `html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/` | 1 | 0 | 2 | 0 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 2 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
-| `dom/ranges/` | 17 | 0 | 84 | 2 |
-| `html/dom/` | 15 | 0 | 56,745 | 41 |
-| `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
-| `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 12 |
 | `custom-elements/` | 16 | 0 | 513 | 248 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **361** | **9** | **66,689** | **1,110** |
-| **total** | **359** | **9** | **66,652** | **1,202** |
+| **total** | **361** | **9** | **66,695** | **1,108** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -258,8 +251,7 @@ has the upstream half of each, and `Dom/AGENTS.md` says which override list carr
 
 `dom/nodes/`, `dom/collections/`, `dom/lists/`, `dom/traversal/`, `dom/ranges/` and `html/dom/` are the DOM
 standard's own suites and HTML's DOM half — the corpus every other suite in this lane is written on top of.
-Across the six of them there are 226 documents and 65,226 tests, and **778 of those tests do not pass**.
-Across the six of them there are 226 documents and 65,228 tests, and **856 of those tests do not pass**.
+Across the six of them there are 226 documents and 65,228 tests, and **776 of those tests do not pass**.
 Those three figures are live and checked against the census. They arrived together as 207 documents and
 5,247 tests with 1,532 not passing; those arrival figures are historical and deliberately not re-derived.
 
@@ -285,17 +277,9 @@ table needs to be regenerated.
 | 16 | 1 | **AngleSharp.Css refuses an unparseable media query, from inside `Element.setAttribute`.** `<style>` registers an attribute observer that assigns the sheet's `MediaList.mediaText`, whose setter throws where Media Queries §2.1 requires `not all`; the sixteen rows are the values it cannot parse and the member's other thirty tests pass. `Dom/divergences.md` records it. <!-- cause: 8. AngleSharp.Css refuses an unparseable media query --> |
 | 8 | 2 | **The selector engine's escapes, `:scope` and `:has` differ.** `ParentNode-querySelector-escapes.html` contributes five rows and `Element-closest.html` three. <!-- cause: the selector engine: escapes, :scope and :has --> |
 | 4 | 2 | **`MutationObserver` records differ**, and both halves are AngleSharp's. Its HTML parser inserts nodes without queueing a record, so a document observer hears nothing about the parse; and its `OuterHtml` setter inserts the replacement and then removes the element, which a page sees as two `childList` records where HTML's "replace this with fragment within parent" is one. <!-- cause: MutationObserver's records --> |
-| 2 | 1 | **A document upstream runs once per `<meta name=variant>`.** `Range-in-shadow-after-the-shadow-removed.html` reads its shadow-root mode out of `location.search`, and this lane serves the bare path — so `mode` is `null` and `attachShadow({mode: null})` is the `TypeError` WebIDL owes a browser too. Nothing about `Range` is reached. <!-- cause: a document upstream runs once per variant --> |
 | 2 | 1 | **A live range is not adjusted once its container moves to another document.** The two `Range-adopt-test.html` rows whose container is moved with `appendChild` — AngleSharp keeps its ranges on the document, so DOM's remove steps reach none of them. The two rows whose container never moves pass. <!-- cause: Range's own algorithms --> |
 | 2 | 1 | **`relList` on an element AngleSharp gives no interface.** SVG 2 puts `relList` on `SVGAElement` and this corpus asks a MathML `<a>` for one too; AngleSharp builds a bare `SvgElement` and a `MathElement` and declares neither interface, so there is no member to project. `Dom/divergences.md` records it. <!-- cause: relList on an element AngleSharp gives no interface --> |
 | 1 | 1 | **A saved implementation detached from its document answers null**, which needs a frame that runs script of its own. Every other half of this cause is gone: a document with no browsing context has no `location`, `characterSet`/`charset`/`inputEncoding` answer the Encoding Standard's name, and `createHTMLDocument` builds DOM's skeleton. <!-- cause: a document with no browsing context --> |
-| 6 | 1 | **Members the standard removed are still here**, which is exactly what `html/dom/historical.html` exists to find. <!-- cause: a member the standard removed and this browser still has --> |
-| 5 | 2 | [#3712](https://github.com/sebastienros/jint/issues/3712) **A nullable `DOMString` answers the string `"null"`.** The remaining rows are `CharacterData.data` and `Node.nodeValue` writes. <!-- cause: a nullable DOMString answers the string "null" --> |
-| 5 | 1 | [#3767](https://github.com/sebastienros/jint/issues/3767) **`DOMTokenList` has five remaining interface-shape differences.** They are the legacy `DOMSettableTokenList` surfaces and two namespace-specific `relList` rows. <!-- cause: DOMTokenList: the token validation, the indexed access and the iteration --> |
-| 4 | 2 | **`MutationObserver` records differ.** A document observer misses parser mutations, and an `outerHTML` replacement reports a different record set. <!-- cause: MutationObserver's records --> |
-| 3 | 1 | [#3769](https://github.com/sebastienros/jint/issues/3769) **A `(Node or DOMString)` union parameter takes only a `Node`.** Three `ChildNode.before` rows still reject strings. <!-- cause: a (Node or DOMString) union parameter takes only a Node --> |
-| 2 | 2 | **`createHTMLDocument` builds a different skeleton**, and a saved implementation detached from its document answers null. The `location` and encoding-alias halves of this cause are gone: a document with no browsing context has no `location` now, and `characterSet`/`charset`/`inputEncoding` answer the Encoding Standard's name. <!-- cause: a document with no browsing context --> |
-| 2 | 1 | **A live range is not adjusted once its container moves to another document.** The two `Range-adopt-test.html` rows whose container is moved with `appendChild` — AngleSharp keeps its ranges on the document, so DOM's remove steps reach neither. The two rows whose container never moves pass, which is what says the algorithm is right and the bookkeeping is not. <!-- cause: Range's own algorithms --> |
 
 **The XML-document cause is gone, and it was four different things.** It arrived as a scope decision —
 "a page here parses HTML, AngleSharp builds no XML document" — and by the time it was re-measured that

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -27,6 +27,8 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | --- | --- | --- | --- | --- |
 | `dom/events/` | 56 | 9 | 544 | 11 |
 | `dom/nodes/` | 168 | 0 | 8,115 | 736 |
+| `dom/events/` | 56 | 9 | 548 | 15 |
+| `dom/nodes/` | 168 | 0 | 8,115 | 808 |
 | `dom/collections/` | 8 | 0 | 43 | 0 |
 | `dom/lists/` | 5 | 0 | 189 | 2 |
 | `dom/traversal/` | 13 | 0 | 52 | 0 |
@@ -36,11 +38,16 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/` | 1 | 0 | 2 | 0 |
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 2 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
+| `dom/ranges/` | 17 | 0 | 84 | 2 |
+| `html/dom/` | 15 | 0 | 56,745 | 41 |
+| `html/webappapis/scripting/events/` | 12 | 0 | 37 | 5 |
+| `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 12 |
 | `custom-elements/` | 16 | 0 | 513 | 248 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
 | **total** | **361** | **9** | **66,689** | **1,110** |
+| **total** | **359** | **9** | **66,652** | **1,202** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -57,6 +64,21 @@ JINT_WPT_BROWSER_CENSUS=update dotnet test Jint.Tests.Browser -c Release
 
 `JINT_WPT_BROWSER_CENSUS=update-raising-the-ceiling` is the one spelling that may write a *larger*
 not-passing figure, for a corpus bump that genuinely arrives with new failures.
+
+**A case is a document *at one variant*, and that is why `Tests` can move without `Documents` moving.**
+A document may carry [`<meta name="variant" content="?query">`](https://web-platform-tests.org/writing-tests/testharness.html#variants)
+elements; upstream's manifest then makes one test per declaration, at the document's path with that
+string appended, and the document reads which one it is out of `location.search`. This lane enumerates
+them the same way and names a case exactly as the manifest names it —
+`dom/ranges/Range-in-shadow-after-the-shadow-removed.html?mode=open` — so an exclusion, a minimum-test
+entry and a cause all key on the *case*, and there is deliberately no spelling that means every variant:
+two variants are two runs, and a divergence measured in one is not evidence about the other. Two vendored
+documents declare any, and both pass at every one of their five variants between them:
+`dom/events/handler-count.html` (`?document`, `?window`, `?element`) and
+`dom/ranges/Range-in-shadow-after-the-shadow-removed.html` (`?mode=closed`, `?mode=open`). The engine
+lane's answer is the opposite one and is not a contradiction: `// META: variant=` sharding is ignored
+there because one unsharded run of a `.any.js` file is the union of its `?1-1000` shards, while a query a
+document branches on selects *different* tests that no single run is the union of.
 
 ## What this corpus says about this browser
 
@@ -237,6 +259,7 @@ has the upstream half of each, and `Dom/AGENTS.md` says which override list carr
 `dom/nodes/`, `dom/collections/`, `dom/lists/`, `dom/traversal/`, `dom/ranges/` and `html/dom/` are the DOM
 standard's own suites and HTML's DOM half — the corpus every other suite in this lane is written on top of.
 Across the six of them there are 226 documents and 65,226 tests, and **778 of those tests do not pass**.
+Across the six of them there are 226 documents and 65,228 tests, and **856 of those tests do not pass**.
 Those three figures are live and checked against the census. They arrived together as 207 documents and
 5,247 tests with 1,532 not passing; those arrival figures are historical and deliberately not re-derived.
 
@@ -266,6 +289,13 @@ table needs to be regenerated.
 | 2 | 1 | **A live range is not adjusted once its container moves to another document.** The two `Range-adopt-test.html` rows whose container is moved with `appendChild` — AngleSharp keeps its ranges on the document, so DOM's remove steps reach none of them. The two rows whose container never moves pass. <!-- cause: Range's own algorithms --> |
 | 2 | 1 | **`relList` on an element AngleSharp gives no interface.** SVG 2 puts `relList` on `SVGAElement` and this corpus asks a MathML `<a>` for one too; AngleSharp builds a bare `SvgElement` and a `MathElement` and declares neither interface, so there is no member to project. `Dom/divergences.md` records it. <!-- cause: relList on an element AngleSharp gives no interface --> |
 | 1 | 1 | **A saved implementation detached from its document answers null**, which needs a frame that runs script of its own. Every other half of this cause is gone: a document with no browsing context has no `location`, `characterSet`/`charset`/`inputEncoding` answer the Encoding Standard's name, and `createHTMLDocument` builds DOM's skeleton. <!-- cause: a document with no browsing context --> |
+| 6 | 1 | **Members the standard removed are still here**, which is exactly what `html/dom/historical.html` exists to find. <!-- cause: a member the standard removed and this browser still has --> |
+| 5 | 2 | [#3712](https://github.com/sebastienros/jint/issues/3712) **A nullable `DOMString` answers the string `"null"`.** The remaining rows are `CharacterData.data` and `Node.nodeValue` writes. <!-- cause: a nullable DOMString answers the string "null" --> |
+| 5 | 1 | [#3767](https://github.com/sebastienros/jint/issues/3767) **`DOMTokenList` has five remaining interface-shape differences.** They are the legacy `DOMSettableTokenList` surfaces and two namespace-specific `relList` rows. <!-- cause: DOMTokenList: the token validation, the indexed access and the iteration --> |
+| 4 | 2 | **`MutationObserver` records differ.** A document observer misses parser mutations, and an `outerHTML` replacement reports a different record set. <!-- cause: MutationObserver's records --> |
+| 3 | 1 | [#3769](https://github.com/sebastienros/jint/issues/3769) **A `(Node or DOMString)` union parameter takes only a `Node`.** Three `ChildNode.before` rows still reject strings. <!-- cause: a (Node or DOMString) union parameter takes only a Node --> |
+| 2 | 2 | **`createHTMLDocument` builds a different skeleton**, and a saved implementation detached from its document answers null. The `location` and encoding-alias halves of this cause are gone: a document with no browsing context has no `location` now, and `characterSet`/`charset`/`inputEncoding` answer the Encoding Standard's name. <!-- cause: a document with no browsing context --> |
+| 2 | 1 | **A live range is not adjusted once its container moves to another document.** The two `Range-adopt-test.html` rows whose container is moved with `appendChild` — AngleSharp keeps its ranges on the document, so DOM's remove steps reach neither. The two rows whose container never moves pass, which is what says the algorithm is right and the bookkeeping is not. <!-- cause: Range's own algorithms --> |
 
 **The XML-document cause is gone, and it was four different things.** It arrived as a scope decision —
 "a page here parses HTML, AngleSharp builds no XML document" — and by the time it was re-measured that
@@ -299,6 +329,16 @@ fifth with `document.all` becoming a real `HTMLAllCollection`, whose supported n
 from one of the fourteen "all"-named elements and `applet` is not among them. The one that is left is somebody
 else's cause — `cssFloat` is not one of the ten properties `ResolvedStyle` answers an initial value for — so the
 row this file used to have is gone rather than shrunk.
+**Half of the `Range` row is gone, and that half was never about `Range`.**
+`Range-in-shadow-after-the-shadow-removed.html` takes its shadow-root mode from
+`<meta name="variant" content="?mode=open">` and its closed sibling, and the lane used to serve the bare
+path — so `mode` was `null`, `attachShadow({mode: null})` raised the `TypeError` WebIDL's enum conversion
+owes a browser too, and both of the file's tests failed before either reached a `Range` at all. Running a
+document once per declared variant is what removed them: four assertions over two cases now, all passing,
+nothing excluded, and what is left under that cause is the `Range-adopt-test.html` pair, which really is
+the bookkeeping. It is worth naming as a shape — a share of a cause that turns out to be the *lane*
+rather than the engine, whose fix is therefore a change to how a case is enumerated and not to the
+subject the document was about.
 
 **All ten of HTML's reflection documents are cases, and six of the ten pass whole**
 ([#3770](https://github.com/sebastienros/jint/issues/3770)). HTML §2.6.1's reflection algorithms are
@@ -509,8 +549,10 @@ upstream's automation API onto the same `InputDispatcher` the `Input` domain rea
 `testdriver-vendor.js` slot upstream ships empty for a vendor to fill (`AGENTS.md` has the rules). Its seven
 documents were then re-examined one at a time, and **five are cases now** —
 `Event-dispatch-redispatch.html`, `focus-event-document-move.html`, `handler-count.html`,
-`no-focus-events-at-clicking-editable-content-in-link.html` and `pointer-event-document-move.html`, ten tests
-between them, all passing, none excluded. Two still cannot report, and neither reason was ever the driver's:
+`no-focus-events-at-clicking-editable-content-in-link.html` and `pointer-event-document-move.html`,
+fourteen tests between them, all passing, none excluded — fourteen rather than ten because
+`handler-count.html` declares three variants and is three cases. Two still cannot report, and neither
+reason was ever the driver's:
 `Event-dispatch-on-disabled-elements.html` spends five of its nine tests waiting for CSS transition and
 animation events on a disabled control, so it never completes and never reaches its testdriver-driven test at
 all; and `click-on-absolute-pseudo.html` reads `event.pseudoTarget` and `element.pseudo('::after')`, which

--- a/Jint.Tests.Browser/Wpt/WptBrowserCauses.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserCauses.cs
@@ -173,7 +173,11 @@ internal static class WptBrowserCauses
 
                     already[i] = true;
                     tests++;
-                    documents.Add(exclusion.File);
+
+                    // An exclusion names a case and a case carries its variant, so two variants of one
+                    // document are two rows and still one document — which is what the census's own
+                    // Documents column counts and what this column has to mean beside it.
+                    documents.Add(WptBrowserVariants.DocumentOf(exclusion.File));
 
                     if (IsCounted(exclusion.File))
                     {

--- a/Jint.Tests.Browser/Wpt/WptBrowserCensus.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserCensus.cs
@@ -23,7 +23,9 @@ namespace Jint.Tests.Browser.Wpt;
 /// </para>
 /// <para>
 /// <b>Three equalities and a ceiling.</b> <c>Documents</c> and <c>Synthesized</c> are read off the embedded
-/// corpus, and <c>Tests</c> counts <i>registrations</i> — a document registers its cases as its scripts run,
+/// corpus and count <i>files</i> — a document that declares <c>&lt;meta name="variant"&gt;</c> is run once
+/// per variant and is still one document, so only the two counted columns move when a variant is added —
+/// and <c>Tests</c> counts <i>registrations</i> — a document registers its cases as its scripts run,
 /// and a document that cannot finish is a harness error that invalidates the measured census as well as its
 /// own suite. <c>Not passing</c> is the only column that counts <i>outcomes</i>,
 /// so a rise fails as a regression naming the suite and the size of it, a fall fails as staleness, and
@@ -181,9 +183,12 @@ internal static class WptBrowserCensus
             var tests = 0;
             var notPassing = 0;
 
-            foreach (var path in WptBrowserCorpus.Cases(suite))
+            // Documents and Synthesized count files — the table says of itself that they do — while Tests
+            // and Not passing count what ran. A document that declares `<meta name="variant">` is one file
+            // and several runs, so it is counted once here and once per variant below.
+            foreach (var document in WptBrowserCorpus.Documents(suite))
             {
-                if (WptBrowserCorpus.IsVendored(path))
+                if (WptBrowserCorpus.IsVendored(document))
                 {
                     documents++;
                 }
@@ -191,8 +196,11 @@ internal static class WptBrowserCensus
                 {
                     synthesized++;
                 }
+            }
 
-                if (measured)
+            if (measured)
+            {
+                foreach (var path in WptBrowserCorpus.Cases(suite))
                 {
                     var counts = observations![path];
                     tests += counts.Tests;
@@ -259,13 +267,17 @@ internal static class WptBrowserCensus
         {
             var name = suite.TrimEnd('/');
 
-            foreach (var path in WptBrowserCorpus.Cases(name))
+            // Documents are files and tests are runs, exactly as the rendered table counts them.
+            foreach (var document in WptBrowserCorpus.Documents(name))
             {
-                if (WptBrowserCorpus.IsVendored(path))
+                if (WptBrowserCorpus.IsVendored(document))
                 {
                     documents++;
                 }
+            }
 
+            foreach (var path in WptBrowserCorpus.Cases(name))
+            {
                 if (observations.TryGetValue(path, out var counts))
                 {
                     tests += counts.Tests;

--- a/Jint.Tests.Browser/Wpt/WptBrowserCorpus.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserCorpus.cs
@@ -22,12 +22,21 @@ namespace Jint.Tests.Browser.Wpt;
 /// the two lanes can disagree about it: a divergence that only a document exposes is exactly what this lane
 /// exists to find.
 /// </para>
+/// <para>
+/// A path is not the whole of a case either, because a document may declare
+/// <c>&lt;meta name="variant"&gt;</c> and upstream's manifest then makes one test per declaration, at the
+/// document's path with the variant appended. So a case is a path <i>and</i> a variant and its name is the
+/// two spelled as upstream spells them —
+/// <c>dom/ranges/Range-in-shadow-after-the-shadow-removed.html?mode=open</c>; <see cref="WptBrowserVariants"/>
+/// is the rule and the reason.
+/// </para>
 /// </remarks>
 internal static class WptBrowserCorpus
 {
     /// <summary>
     /// Every case of one suite, vendored documents first and then the synthesized wrappers, each group
-    /// ordered by path so the theory's cases are stable.
+    /// ordered by path — and each document followed by its own variants, in the order it declares them, so
+    /// the theory's cases are stable.
     /// </summary>
     internal static IReadOnlyList<string> Cases(string suite)
     {
@@ -39,20 +48,58 @@ internal static class WptBrowserCorpus
             // it as one is a page that registers no test. WptBrowserExclusions.FrameBodies argues it.
             if (!IsFrameBody(file))
             {
-                cases.Add(file);
+                AddVariants(cases, file);
             }
         }
 
-        cases.AddRange(SynthesizedCases(suite));
+        foreach (var wrapper in SynthesizedCases(suite))
+        {
+            AddVariants(cases, wrapper);
+        }
+
         return cases;
+    }
+
+    /// <summary>
+    /// The distinct documents one suite's cases are of, in the order the cases name them.
+    /// </summary>
+    /// <remarks>
+    /// The census's <c>Documents</c> and <c>Synthesized</c> columns count files rather than runs — the README
+    /// says so of itself — so a document that declares three variants is three cases and still one document.
+    /// </remarks>
+    internal static IReadOnlyList<string> Documents(string suite)
+    {
+        var documents = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var name in Cases(suite))
+        {
+            var document = WptBrowserVariants.DocumentOf(name);
+            if (seen.Add(document))
+            {
+                documents.Add(document);
+            }
+        }
+
+        return documents;
+    }
+
+    private static void AddVariants(List<string> cases, string document)
+    {
+        foreach (var variant in WptBrowserVariants.Of(document))
+        {
+            cases.Add(document + variant);
+        }
     }
 
     /// <summary>Whether the path is one <see cref="WptBrowserExclusions.FrameBodies"/> names.</summary>
     internal static bool IsFrameBody(string path)
     {
+        var document = WptBrowserVariants.DocumentOf(path);
+
         foreach (var (body, _) in WptBrowserExclusions.FrameBodies)
         {
-            if (string.Equals(body, path, StringComparison.Ordinal))
+            if (string.Equals(body, document, StringComparison.Ordinal))
             {
                 return true;
             }
@@ -83,5 +130,5 @@ internal static class WptBrowserCorpus
     }
 
     /// <summary>Whether a case is a document this repository holds, rather than one the server makes up.</summary>
-    internal static bool IsVendored(string path) => WptCorpus.Contains(path);
+    internal static bool IsVendored(string path) => WptCorpus.Contains(WptBrowserVariants.DocumentOf(path));
 }

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -1291,19 +1291,6 @@ internal static class WptBrowserExclusions
         new("dom/nodes/DOMImplementation-createDocument.html", "createDocument test: *\"http://example.com/\",\";:a\",null*", WptDivergence.NeedsTriage),
     ];
 
-    // ---------------------------------------------------------------- a document upstream runs once per variant
-    private static readonly WptExclusion[] _aDocumentUpstreamRunsOncePerVariant =
-    [
-        // Not about Range at all, which is what triaging the two rows one at a time said. The document
-        // declares `<meta name="variant" content="?mode=open">` and its closed sibling, and reads the mode
-        // out of location.search; upstream's runner turns each variant into a case of its own and this lane
-        // serves the bare path, so `mode` is null and `attachShadow({mode: null})` is the TypeError WebIDL's
-        // enum conversion owes a browser too. Running variants changes how a case is enumerated -- the case
-        // source, the minimum-test keys, the exclusion keys and both census columns -- so it is a change to
-        // the lane rather than to the engine.
-        new("dom/ranges/Range-in-shadow-after-the-shadow-removed.html", "*", WptDivergence.NeedsTriage),
-    ];
-
     // ---------------------------------------------------------------- Range's own algorithms
     private static readonly WptExclusion[] _rangeSOwnAlgorithms =
     [
@@ -1491,7 +1478,6 @@ internal static class WptBrowserExclusions
         new("a member of a DOM interface the bindings do not have", _aMemberOfADOMInterfaceTheBindingsDoNotHave),
         new("DOM's validate-and-extract, and the XML name productions", _dOMSValidateAndExtractAndTheXMLNameProductions),
         new("a name AngleSharp refuses that the standard allows", _aNameAngleSharpRefusesThatTheStandardAllows),
-                new("a document upstream runs once per variant", _aDocumentUpstreamRunsOncePerVariant),
         new("a tag query's namespace and local-name identity", _aTagQuerySNamespaceAndLocalNameIdentity),
         new("Range's own algorithms", _rangeSOwnAlgorithms),
         new("a document with no browsing context", _aDocumentWithNoBrowsingContext),

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -583,7 +583,11 @@ internal static class WptBrowserExclusions
         ["dom/events/event-handler-attribute-replace-preserves-passive.html"] = 2,
         ["dom/events/event-src-element-nullable.html"] = 1,
         ["dom/events/focus-event-document-move.html"] = 1,
-        ["dom/events/handler-count.html"] = 2,
+        // Three variants, three cases: the file reads `location.search` and hangs its two tests
+        // off the target the query names.
+        ["dom/events/handler-count.html?document"] = 2,
+        ["dom/events/handler-count.html?element"] = 2,
+        ["dom/events/handler-count.html?window"] = 2,
         ["dom/events/label-default-action.html"] = 1,
         ["dom/events/mouse-event-retarget.html"] = 1,
         ["dom/events/no-focus-events-at-clicking-editable-content-in-link.html"] = 2,
@@ -777,7 +781,8 @@ internal static class WptBrowserExclusions
         ["dom/ranges/Range-detach.html"] = 1,
         ["dom/ranges/Range-extractContents-dynamic-end.html"] = 1,
         ["dom/ranges/Range-extractContents-in-ShadowRoot.html"] = 4,
-        ["dom/ranges/Range-in-shadow-after-the-shadow-removed.html"] = 2,
+        ["dom/ranges/Range-in-shadow-after-the-shadow-removed.html?mode=closed"] = 2,
+        ["dom/ranges/Range-in-shadow-after-the-shadow-removed.html?mode=open"] = 2,
         ["dom/ranges/Range-intersectsNode-2.html"] = 1,
         ["dom/ranges/Range-intersectsNode-binding.html"] = 1,
         ["dom/ranges/Range-intersectsNode-shadow.html"] = 1,

--- a/Jint.Tests.Browser/Wpt/WptBrowserHarness.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserHarness.cs
@@ -146,8 +146,12 @@ internal sealed class WptBrowserHarness : IDisposable
     /// Runs one document and answers every result it reported, or the harness error that stopped it.
     /// </summary>
     /// <param name="path">
-    /// A path in the wpt tree: a vendored document (<c>dom/events/Event-propagation.html</c>) or a wrapper the
-    /// server synthesizes for a vendored script (<c>dom/events/Event-constructors.any.html</c>).
+    /// A case name: a path in the wpt tree — a vendored document (<c>dom/events/Event-propagation.html</c>)
+    /// or a wrapper the server synthesizes for a vendored script
+    /// (<c>dom/events/Event-constructors.any.html</c>) — with the variant it is being run at appended when
+    /// the document declares any (<c>dom/events/handler-count.html?element</c>). The query reaches the page's
+    /// own <c>location.search</c>, which is what such a document branches on, while the server finds the file
+    /// from the path alone exactly as wptserve's <c>filesystem_path</c> does.
     /// </param>
     internal async Task<WptBrowserOutcome> RunAsync(string path)
     {
@@ -300,12 +304,15 @@ internal sealed class WptBrowserHarness : IDisposable
             return Timeout.InfiniteTimeSpan;
         }
 
-        var sourcePath = WptServerWrappers.IsWrapperPath(path)
-            ? WptServerWrappers.UnderlyingFile(path)
-            : path;
+        // The deadline belongs to the document, not to the variant it is being run at: upstream's
+        // `timeout=long` metadata is a property of the file and its manifest entries all carry it.
+        var document = WptBrowserVariants.DocumentOf(path);
+        var sourcePath = WptServerWrappers.IsWrapperPath(document)
+            ? WptServerWrappers.UnderlyingFile(document)
+            : document;
         var source = WptCorpus.Read(sourcePath);
 
-        if (WptServerWrappers.IsWrapperPath(path))
+        if (WptServerWrappers.IsWrapperPath(document))
         {
             foreach (var (key, value) in WptServerWrappers.ReadScriptMetadata(source))
             {

--- a/Jint.Tests.Browser/Wpt/WptBrowserTestRunner.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserTestRunner.cs
@@ -5,9 +5,9 @@ using Jint.Tests.Wpt;
 namespace Jint.Tests.Browser.Wpt;
 
 /// <summary>
-/// Runs the vendored web-platform-tests <b>documents</b> — one theory case per <c>.html</c> file and per
-/// synthesized <c>.any.html</c> wrapper — in a real <see cref="Page"/>, under upstream's own
-/// <c>testharness.js</c>.
+/// Runs the vendored web-platform-tests <b>documents</b> — one theory case per <c>.html</c> file, per
+/// synthesized <c>.any.html</c> wrapper, and per <c>&lt;meta name="variant"&gt;</c> either of them declares —
+/// in a real <see cref="Page"/>, under upstream's own <c>testharness.js</c>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -147,6 +147,14 @@ public class WptBrowserTestRunner
         var problems = new List<string>();
         var cases = new HashSet<string>(AllCases(), StringComparer.Ordinal);
 
+        // A case name carries the variant it is run at, so "is this document reached?" is asked of the
+        // documents the cases are of rather than of the case names themselves.
+        var documents = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var name in cases)
+        {
+            documents.Add(WptBrowserVariants.DocumentOf(name));
+        }
+
         foreach (var path in WptCorpus.Paths)
         {
             foreach (var (pattern, reason) in WptBrowserExclusions.NotVendored)
@@ -166,7 +174,7 @@ public class WptBrowserTestRunner
             // a helper the cases load, which is why WptCorpus.BrowserTestFiles never descends. A frame body
             // is the third answer: directly under a suite, vendored, served and deliberately never run.
             if (Array.Exists(WptCorpus.BrowserSuites, suite => string.Equals(WptCorpus.DirectoryOf(path), suite, StringComparison.Ordinal))
-                && !cases.Contains(path)
+                && !documents.Contains(path)
                 && !WptBrowserCorpus.IsFrameBody(path))
             {
                 problems.Add($"{path} is vendored under a browser-lane suite but no theory case reaches it");
@@ -198,7 +206,7 @@ public class WptBrowserTestRunner
         {
             if (!cases.Contains(declared))
             {
-                problems.Add($"{declared} has a minimum-test entry but is not a case of any suite");
+                problems.Add($"{declared} has a minimum-test entry but is not a case of any suite{WptBrowserVariants.HintFor(declared)}");
             }
         }
 
@@ -206,7 +214,7 @@ public class WptBrowserTestRunner
         {
             if (!cases.Contains(exclusion.File))
             {
-                problems.Add($"{exclusion.File} carries an exclusion but is not a case of any suite");
+                problems.Add($"{exclusion.File} carries an exclusion but is not a case of any suite{WptBrowserVariants.HintFor(exclusion.File)}");
             }
         }
 
@@ -323,9 +331,13 @@ public class WptBrowserTestRunner
     {
         var synthesized = 0;
 
-        foreach (var path in AllCases())
+        foreach (var name in AllCases())
         {
-            if (WptBrowserCorpus.IsVendored(path))
+            // The wrapper is the document half of a case; the variant is a query the server never sees when
+            // it decides what to synthesize.
+            var path = WptBrowserVariants.DocumentOf(name);
+
+            if (WptBrowserCorpus.IsVendored(name))
             {
                 WptServerWrappers.IsWrapperPath(path).Should().BeFalse(
                     $"{path} is a vendored document, so nothing should be synthesizing it");

--- a/Jint.Tests.Browser/Wpt/WptBrowserTriage.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserTriage.cs
@@ -29,6 +29,18 @@ namespace Jint.Tests.Browser.Wpt;
 /// A path is what the server serves: a vendored document (<c>dom/events/Event-propagation.html</c>) or a
 /// wrapper it synthesizes for a vendored script (<c>dom/events/Event-constructors.any.html</c>).
 /// </example>
+/// <example>
+/// <b>A variant is part of the name</b>, because it is part of the case: a document that declares
+/// <c>&lt;meta name="variant"&gt;</c> is one case per declaration and the query is what it branches on
+/// (<see cref="WptBrowserVariants"/>). Naming the bare path runs it with no query, which for such a document
+/// is a run the lane does not have.
+/// <code>
+/// JINT_WPT_DOCUMENT='dom/events/handler-count.html?element;dom/events/handler-count.html?document' \
+///   dotnet test Jint.Tests.Browser/Jint.Tests.Browser.csproj -c Release -nr:false \
+///     --filter "FullyQualifiedName~WptBrowserTriage" -l "console;verbosity=detailed"
+/// </code>
+/// Separate several with <c>;</c> rather than <c>,</c> whenever a variant carries a comma of its own.
+/// </example>
 /// </remarks>
 [Explicit("Triage: prints every result of the documents JINT_WPT_DOCUMENT names, and records them in the census.")]
 [NonParallelizable]
@@ -46,7 +58,9 @@ public class WptBrowserTriage
         {
             Assert.Ignore(
                 $"Set {Variable} to the wpt path to triage — for example "
-                + $"{Variable}=dom/nodes/Node-cloneNode.html — separating several with ';' or ','.");
+                + $"{Variable}=dom/nodes/Node-cloneNode.html — separating several with ';' or ','. A document "
+                + "that declares <meta name=\"variant\"> is a case per variant, so name the query too: "
+                + $"{Variable}=dom/events/handler-count.html?element");
         }
 
         foreach (var path in documents)

--- a/Jint.Tests.Browser/Wpt/WptBrowserVariantTests.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserVariantTests.cs
@@ -1,0 +1,257 @@
+using Jint.Tests.Wpt;
+
+namespace Jint.Tests.Browser.Wpt;
+
+/// <summary>
+/// Holds <see cref="WptBrowserVariants"/> to <c>SourceFile.test_variants</c>, and the lane's case list to
+/// the variants the vendored corpus actually declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The corpus-facing tests are the ones a bump will meet.</b> A document that arrives declaring a variant
+/// is a document upstream runs several times, and a lane that served the bare path would run one of them and
+/// call that the file — which is exactly what
+/// <c>dom/ranges/Range-in-shadow-after-the-shadow-removed.html</c> did until this existed, failing both its
+/// tests on an <c>attachShadow({mode: null})</c> the document never meant to make.
+/// </para>
+/// <para>
+/// <b>The parsing tests use synthetic sources on purpose.</b> Two vendored documents declare variants today
+/// and between them they exercise one shape; upstream's rules cover several more, and a rule nothing runs is
+/// a rule that will be wrong the first time the corpus needs it.
+/// </para>
+/// </remarks>
+public class WptBrowserVariantTests
+{
+    private const string Range = "dom/ranges/Range-in-shadow-after-the-shadow-removed.html";
+    private const string HandlerCount = "dom/events/handler-count.html";
+
+    /// <summary>
+    /// The two vendored documents that declare variants are one case per declaration, and the bare path is
+    /// not a case of either.
+    /// </summary>
+    /// <remarks>
+    /// The bare path matters as much as the variants do: it is the run this lane used to have, and a case
+    /// list that kept it would run a document at a query its own script has no branch for.
+    /// </remarks>
+    [Test]
+    public void ADocumentThatDeclaresVariantsIsOneCasePerVariant()
+    {
+        var ranges = WptBrowserCorpus.Cases("dom/ranges");
+        ranges.Should().Contain(Range + "?mode=closed").And.Contain(Range + "?mode=open");
+        ranges.Should().NotContain(Range, "the bare path is not a run upstream has");
+
+        var events = WptBrowserCorpus.Cases("dom/events");
+        events.Should().Contain(HandlerCount + "?document")
+            .And.Contain(HandlerCount + "?window")
+            .And.Contain(HandlerCount + "?element");
+        events.Should().NotContain(HandlerCount, "the bare path is not a run upstream has");
+
+        // Declaration order, and adjacent to their own document, so the theory's cases stay stable.
+        WptBrowserVariants.Of(HandlerCount).Should().Equal("?document", "?window", "?element");
+        WptBrowserVariants.Of(Range).Should().Equal("?mode=closed", "?mode=open");
+    }
+
+    /// <summary>
+    /// A document that declares variants is still <i>one</i> document, which is what the census's
+    /// <c>Documents</c> column counts.
+    /// </summary>
+    [Test]
+    public void AVariantIsAnotherCaseAndNotAnotherDocument()
+    {
+        var documents = WptBrowserCorpus.Documents("dom/ranges");
+
+        documents.Should().Contain(Range).And.OnlyHaveUniqueItems();
+        documents.Count.Should().Be(WptCorpus.BrowserTestFiles("dom/ranges").Count,
+            "every vendored document of the suite is a document of it exactly once");
+        WptBrowserCorpus.Cases("dom/ranges").Count.Should().Be(documents.Count + 1, "one of them declares two variants");
+    }
+
+    /// <summary>
+    /// Every vendored document that declares a variant is reached at every one of them.
+    /// </summary>
+    /// <remarks>
+    /// The check a corpus bump runs into. It walks the whole vendored tree rather than the two documents
+    /// above, so a suite that arrives with a variant-declaring document either becomes cases or is one of the
+    /// answers the lane already has for a document it does not run — a not-vendored row, a frame body, or a
+    /// helper below a suite rather than in it.
+    /// </remarks>
+    [Test]
+    public void EveryVariantDeclaredByTheCorpusIsACase()
+    {
+        var problems = new List<string>();
+        var cases = new HashSet<string>(StringComparer.Ordinal);
+        var declaring = 0;
+
+        foreach (var suite in WptCorpus.BrowserSuites)
+        {
+            foreach (var name in WptBrowserCorpus.Cases(suite))
+            {
+                cases.Add(name);
+            }
+        }
+
+        foreach (var path in WptCorpus.Paths)
+        {
+            if (!WptCorpus.IsBrowserTestFile(path)
+                || !Array.Exists(WptCorpus.BrowserSuites, suite => string.Equals(WptCorpus.DirectoryOf(path), suite, StringComparison.Ordinal))
+                || WptBrowserCorpus.IsFrameBody(path))
+            {
+                continue;
+            }
+
+            var variants = WptBrowserVariants.Of(path);
+            if (variants.Count == 1 && variants[0].Length == 0)
+            {
+                continue;
+            }
+
+            declaring++;
+
+            foreach (var variant in variants)
+            {
+                if (!cases.Contains(path + variant))
+                {
+                    problems.Add($"{path} declares the variant \"{variant}\" and {path + variant} is not a case");
+                }
+            }
+        }
+
+        string.Join(Environment.NewLine, problems).Should().BeEmpty();
+        declaring.Should().Be(2, "handler-count.html and Range-in-shadow-after-the-shadow-removed.html declare variants at this pin");
+    }
+
+    /// <summary>
+    /// No vendored <c>.any.js</c> under a browser-lane suite declares a variant at this pin, which is why the
+    /// wrapper half of the rule reads nothing today.
+    /// </summary>
+    /// <remarks>
+    /// Recorded rather than assumed: the engine lane deliberately ignores <c>// META: variant=</c> because
+    /// one unsharded run of a <c>.any.js</c> file is the union of its shards, and this lane deliberately does
+    /// not, because it is upstream's manifest it follows. The two lanes disagreeing about a file is allowed;
+    /// nobody having noticed that they do is not.
+    /// </remarks>
+    [Test]
+    public void NoWrappedScriptDeclaresAVariantAtThisPin()
+    {
+        foreach (var suite in WptCorpus.BrowserSuites)
+        {
+            foreach (var wrapper in WptBrowserCorpus.SynthesizedCases(suite))
+            {
+                WptBrowserVariants.Of(wrapper).Should().Equal([""], $"{wrapper} wraps a script that declares no variant");
+            }
+        }
+    }
+
+    [Test]
+    public void ADocumentWithNoDeclarationRunsOnceAtTheBarePath()
+    {
+        WptBrowserVariants.InDocument("a.html", "<!doctype html><title>x</title>").Should().Equal([""]);
+        WptBrowserVariants.InScript("a.any.html", "// META: global=window\n").Should().Equal([""]);
+    }
+
+    /// <summary>Every shape of the declaration upstream's <c>variant_nodes</c> finds, and two it does not.</summary>
+    [TestCase("<meta name=variant content=?a><meta name=variant content=?b>", "?a|?b", TestName = "unquoted attributes, in tree order")]
+    [TestCase("<meta name=\"variant\" content=\"?a\">", "?a", TestName = "quoted attributes")]
+    [TestCase("<meta name=variant content=#frag>", "#frag", TestName = "a fragment variant")]
+    [TestCase("<meta name=variant>", "", TestName = "no content attribute is not a declaration")]
+    [TestCase("<meta name=Variant content=?a>", "", TestName = "the name is matched exactly")]
+    [TestCase("<script>const s = '<meta name=variant content=?a>';</script>", "", TestName = "markup spelled inside a script is not one")]
+    [TestCase("<body><meta name=variant content=?a>", "?a", TestName = "a declaration the parser moves is still one")]
+    public void TheDeclarationIsWhatAParseSaysItIs(string body, string expected)
+    {
+        var declared = WptBrowserVariants.InDocument("a.html", "<!doctype html><title>x</title>" + body);
+        var wanted = expected.Length == 0 ? [""] : expected.Split('|');
+
+        declared.Should().Equal(wanted);
+    }
+
+    [Test]
+    public void AWrappedScriptDeclaresItsVariantsInMetadata()
+    {
+        const string source = """
+            // META: global=window
+            // META: variant=?1-1000
+            // META: variant=?1001-last
+            test(() => {}, "x");
+            """;
+
+        WptBrowserVariants.InScript("a.any.html", source).Should().Equal("?1-1000", "?1001-last");
+    }
+
+    // Upstream's own two rules, from SourceFile.test_variants: a non-empty variant starts with ? or #, and
+    // neither part may be present and empty. A corpus that grew one would fail wpt's manifest build, so it
+    // has to fail here rather than make a case name nothing can serve.
+    [TestCase("mode=open", "must start with a ? or a #")]
+    [TestCase("?", "empty query or fragment")]
+    [TestCase("#", "empty query or fragment")]
+    [TestCase("?#", "empty query or fragment")]
+    public void AVariantUpstreamWouldRefuseIsRefusedHere(string variant, string expected)
+    {
+        var declaring = $"<!doctype html><meta name=variant content=\"{variant}\">";
+
+        var thrown = Caught(() => WptBrowserVariants.InDocument("a.html", declaring));
+
+        thrown.Should().BeOfType<InvalidOperationException>();
+        thrown!.Message.Should().Contain(expected).And.Contain("a.html");
+    }
+
+    /// <summary>
+    /// A variant declared twice is refused, which is this lane's rule rather than upstream's.
+    /// </summary>
+    /// <remarks>
+    /// A case name is the key its minimum-test entry, its exclusion and its cause row are all found by, so
+    /// two identical declarations would be one row standing for two runs — and the duplicate would surface
+    /// far away, as a case NUnit reaches twice.
+    /// </remarks>
+    [Test]
+    public void AVariantDeclaredTwiceIsRefused()
+    {
+        var thrown = Caught(() => WptBrowserVariants.InDocument(
+            "a.html", "<!doctype html><meta name=variant content=?a><meta name=variant content=?a>"));
+
+        thrown.Should().BeOfType<InvalidOperationException>();
+        thrown!.Message.Should().Contain("twice");
+    }
+
+    [TestCase("a/b.html", "a/b.html", "")]
+    [TestCase("a/b.html?mode=open", "a/b.html", "?mode=open")]
+    [TestCase("a/b.html#frag", "a/b.html", "#frag")]
+    [TestCase("a/b.html?q=1#frag", "a/b.html", "?q=1#frag")]
+    public void ACaseNameSplitsIntoItsDocumentAndItsVariant(string name, string document, string variant)
+    {
+        WptBrowserVariants.DocumentOf(name).Should().Be(document);
+        WptBrowserVariants.VariantOf(name).Should().Be(variant);
+        (WptBrowserVariants.DocumentOf(name) + WptBrowserVariants.VariantOf(name)).Should().Be(name);
+    }
+
+    /// <summary>
+    /// A table row that names a variant-declaring document rather than one of its cases is told which case
+    /// names exist, because "not a case of any suite" otherwise reads as "delete this row".
+    /// </summary>
+    [Test]
+    public void ARowThatNamesADocumentRatherThanACaseIsToldItsCases()
+    {
+        WptBrowserVariants.HintFor(HandlerCount).Should()
+            .Contain(HandlerCount + "?document")
+            .And.Contain(HandlerCount + "?window")
+            .And.Contain(HandlerCount + "?element");
+
+        WptBrowserVariants.HintFor("dom/ranges/Range-attributes.html").Should().BeEmpty(
+            "a document with no variant needs no help");
+        WptBrowserVariants.HintFor("dom/ranges/gone.html").Should().BeEmpty(
+            "a row naming a file the corpus does not hold is a different failure, and asking for its variants would throw over it");
+    }
+
+    private static Exception? Caught(Action action)
+    {
+        try
+        {
+            action();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+}

--- a/Jint.Tests.Browser/Wpt/WptBrowserVariants.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserVariants.cs
@@ -1,0 +1,224 @@
+using System.Collections.Concurrent;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using Jint.Tests.Wpt;
+
+namespace Jint.Tests.Browser.Wpt;
+
+/// <summary>
+/// The variants a document declares, and the two halves of a case name that carries one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A document may ask to be run more than once.</b>
+/// <see href="https://web-platform-tests.org/writing-tests/testharness.html#variants">testharness.js's
+/// variants</see> are <c>&lt;meta name="variant" content="?query"&gt;</c> elements; upstream's manifest turns
+/// each one into a test of its own whose URL is the document's path with that string appended, and the
+/// document reads which one it is out of <c>location.search</c>. Two vendored documents declare them —
+/// <c>dom/ranges/Range-in-shadow-after-the-shadow-removed.html</c> takes its shadow-root mode that way, and
+/// <c>dom/events/handler-count.html</c> its event target — and until this existed the lane served the bare
+/// path, so the first of them called <c>attachShadow({mode: null})</c> and failed WebIDL's enum conversion
+/// before it reached its subject, while the second quietly ran one of its three.
+/// </para>
+/// <para>
+/// <b>A case is therefore a path <i>and</i> a variant, spelled exactly as upstream's manifest spells it:</b>
+/// <c>dom/ranges/Range-in-shadow-after-the-shadow-removed.html?mode=open</c>. That string is the key
+/// everything else in the lane is found by — the minimum-test table, an exclusion, a cause's file, the
+/// census's own bookkeeping — and there is deliberately <b>no spelling that means "every variant"</b>: two
+/// variants are two runs of two different documents as far as the harness is concerned, so a divergence
+/// measured in one is not evidence about the other, and a row that covered both would be a blanket of
+/// exactly the kind <see cref="WptExclusion"/>'s two-sided rule exists to refuse. Upstream's own expectation
+/// files name the full URL for the same reason.
+/// </para>
+/// <para>
+/// <b>The engine lane's answer is the opposite one, and that is not a contradiction.</b>
+/// <c>Jint.Tests/Wpt/AGENTS.md</c> records that <c>// META: variant=</c> sharding is ignored there: the shim
+/// leaves <c>location.search</c> empty, <c>subsetTest</c> then runs everything, and one run of a file is the
+/// union of all of its <c>?1-1000</c> shards. That works because a shard variant selects a <i>subset of the
+/// same tests</i>. A query the document itself branches on selects <i>different</i> tests, and no single run
+/// is their union — which is why this lane, whose whole point is that the harness and the environment are
+/// the real ones, follows upstream's manifest instead.
+/// </para>
+/// </remarks>
+internal static class WptBrowserVariants
+{
+    /// <summary>What a document that declares no variant runs at: the bare path, once.</summary>
+    private static readonly string[] _bare = [""];
+
+    private static readonly ConcurrentDictionary<string, string[]> _declared = new(StringComparer.Ordinal);
+
+    /// <summary>The document a case names — the case name with its variant removed.</summary>
+    internal static string DocumentOf(string caseName)
+    {
+        var cut = caseName.AsSpan().IndexOfAny('?', '#');
+        return cut < 0 ? caseName : caseName.Substring(0, cut);
+    }
+
+    /// <summary>
+    /// The variant a case names, including its leading <c>?</c> or <c>#</c>, or the empty string.
+    /// </summary>
+    internal static string VariantOf(string caseName)
+    {
+        var cut = caseName.AsSpan().IndexOfAny('?', '#');
+        return cut < 0 ? string.Empty : caseName.Substring(cut);
+    }
+
+    /// <summary>
+    /// The variants <paramref name="document"/> declares, in the order it declares them, or one empty string
+    /// when it declares none — which is <c>SourceFile.test_variants</c>'s own <c>if not rv: rv = [""]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Cached, because the answer is a property of an embedded file that cannot change while the process
+    /// lives and every enumeration of the lane's cases asks for it.
+    /// </remarks>
+    internal static IReadOnlyList<string> Of(string document) => _declared.GetOrAdd(document, Read);
+
+    /// <summary>
+    /// What to add to "… is not a case of any suite" when the row names a document that is only ever run at
+    /// a variant, or the empty string when it does not.
+    /// </summary>
+    /// <remarks>
+    /// That message reads as "delete this row", and for such a document the answer is the opposite: append
+    /// the variant, once per case the row is about. There is no spelling that means every variant, so the
+    /// fix is a row per case and the message has to name them.
+    /// </remarks>
+    internal static string HintFor(string named)
+    {
+        var document = DocumentOf(named);
+        var underlying = WptServerWrappers.IsWrapperPath(document)
+            ? WptServerWrappers.UnderlyingFile(document)
+            : document;
+
+        // A row can also name a file the corpus no longer holds, which is a different failure and needs no
+        // help from here: asking for its variants would throw over the top of the report.
+        if (!WptCorpus.Contains(underlying))
+        {
+            return string.Empty;
+        }
+
+        var declared = Of(document);
+        if (declared.Count == 1 && declared[0].Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var names = new List<string>(declared.Count);
+        foreach (var variant in declared)
+        {
+            names.Add(document + variant);
+        }
+
+        return $" — it declares variants, so its cases are {string.Join(", ", names)}";
+    }
+
+    private static string[] Read(string document) => WptServerWrappers.IsWrapperPath(document)
+        ? InScript(document, WptCorpus.Read(WptServerWrappers.UnderlyingFile(document)))
+        : InDocument(document, WptCorpus.Read(document));
+
+    /// <summary>
+    /// The <c>content</c> of every <c>&lt;meta name="variant"&gt;</c> in the document, in tree order.
+    /// </summary>
+    /// <remarks>
+    /// Upstream reads them off a real parse — <c>SourceFile.variant_nodes</c> is
+    /// <c>root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='variant']")</c> over an html5lib tree —
+    /// so this parses too rather than scanning the source for a substring. A <c>&lt;meta&gt;</c> the parser
+    /// puts in a foreign-content tree is not one of these, and neither is a string in a script that happens
+    /// to spell the markup; both are differences a scanner would get wrong and a parse gets right for free.
+    /// </remarks>
+    internal static string[] InDocument(string path, string source)
+    {
+        var variants = new List<string>();
+        var document = new HtmlParser().ParseDocument(source);
+
+        foreach (var element in document.All)
+        {
+            if (!string.Equals(element.LocalName, "meta", StringComparison.Ordinal)
+                || !string.Equals(element.NamespaceUri, NamespaceNames.HtmlUri, StringComparison.Ordinal)
+                || !string.Equals(element.GetAttribute("name"), "variant", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Upstream's `if "content" in element.attrib`: a declaration with no content attribute is
+            // skipped rather than read as the empty variant.
+            if (element.GetAttribute("content") is { } content)
+            {
+                variants.Add(content);
+            }
+        }
+
+        return Validate(path, variants);
+    }
+
+    /// <summary>
+    /// The <c>// META: variant=</c> values of the script a wrapper wraps, which is the other half of
+    /// <c>SourceFile.test_variants</c> — the <c>.js</c> branch of it.
+    /// </summary>
+    /// <remarks>
+    /// No vendored <c>.any.js</c> under a browser-lane suite declares one today, so this reads nothing at
+    /// this pin. It is here because upstream's manifest multiplies a <c>.any.html</c> URL by its variants
+    /// exactly as it multiplies a document's, and a corpus bump that brought one in would otherwise have the
+    /// lane run one shard of it and call that the file.
+    /// </remarks>
+    internal static string[] InScript(string path, string source)
+    {
+        var variants = new List<string>();
+
+        foreach (var (key, value) in WptServerWrappers.ReadScriptMetadata(source))
+        {
+            if (string.Equals(key, "variant", StringComparison.Ordinal))
+            {
+                variants.Add(value);
+            }
+        }
+
+        return Validate(path, variants);
+    }
+
+    /// <summary>
+    /// Upstream's two rules on a declared variant, plus the one this lane needs on top of them.
+    /// </summary>
+    /// <remarks>
+    /// <c>SourceFile.test_variants</c> raises for a non-empty variant that does not start with <c>?</c> or
+    /// <c>#</c> and for one whose query or fragment is empty, so a corpus that grew either would fail
+    /// upstream's own manifest build and has to fail here rather than produce a case name nothing can serve.
+    /// The third rule is this lane's: a case name is a dictionary key in four tables, so two identical
+    /// declarations would be one row silently standing for two runs.
+    /// </remarks>
+    private static string[] Validate(string document, List<string> declared)
+    {
+        // The one case upstream spells `if not rv: rv = [""]`: no declaration is one run at the bare path.
+        if (declared.Count == 0)
+        {
+            return _bare;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var variant in declared)
+        {
+            if (variant.Length != 0)
+            {
+                if (variant[0] != '?' && variant[0] != '#')
+                {
+                    throw new InvalidOperationException(
+                        $"{document} declares the variant \"{variant}\", and a non-empty variant must start with a ? or a #.");
+                }
+
+                if (variant.Length == 1 || (variant[0] == '?' && variant[1] == '#'))
+                {
+                    throw new InvalidOperationException(
+                        $"{document} declares the variant \"{variant}\", which has an empty query or fragment; omit the empty part instead.");
+                }
+            }
+
+            if (!seen.Add(variant))
+            {
+                throw new InvalidOperationException(
+                    $"{document} declares the variant \"{variant}\" twice, and a case name is the key its exclusion, its minimum-test entry and its census row are all found by.");
+            }
+        }
+
+        return declared.ToArray();
+    }
+}

--- a/Jint.Tests/Wpt/AGENTS.md
+++ b/Jint.Tests/Wpt/AGENTS.md
@@ -43,7 +43,10 @@ enable and shims one onto the event loop, this driver enables
 `WebApiFeatures.Timers` and pumps with `Tasks.ProcessTasks()` bounded by `Tasks.TimeUntilNextScheduledWork`,
 so a suite that schedules a timer exercises the shipped `TimerQueue`. **`// META: variant=` sharding is
 ignored**: the shim leaves `location.search` empty, so `subsetTest`/`subsetTestByKey` run everything and one
-run of a file is the union of all of its variants. And **every engine carries the fetch object model**:
+run of a file is the union of all of its variants. **The browser lane's answer is the other one and both
+are right**: a shard variant selects a subset of the same tests, while a `<meta name=variant>` query a
+*document* branches on selects different ones — so that lane runs a case per declared variant, and its
+case names carry the query. And **every engine carries the fetch object model**:
 `WptHarness.BuildEngine` installs `Headers`, `Request` and `Response` on top of `Default` — and, for all but
 the files `WptHarness.IsServerBacked` names, pointedly not `fetch`, which no feature flag names the model
 without. `url/urlencoded-parser.any.js` reaches the urlencoded parser through `Request.formData()` and


### PR DESCRIPTION
## What and why

A web-platform-tests document may declare
[`<meta name="variant" content="?query">`](https://web-platform-tests.org/writing-tests/testharness.html#variants).
Upstream's manifest then makes **one test per declaration**, at the document's path with that string
appended, and the document reads which one it is out of `location.search`. The browser lane served the bare
path, so a document that declares variants ran once, with no query.

Two vendored documents declare them, and the bare-path run got both wrong, in the two ways it can:

* `dom/ranges/Range-in-shadow-after-the-shadow-removed.html` reads its shadow-root mode out of the query, so
  `mode` was `null` and `attachShadow({mode: null})` raised the `TypeError` WebIDL's enum conversion owes a
  browser. Both of its tests failed **before either reached a `Range`** — which is what half of the
  `Range's own algorithms` cause row was really counting.
* `dom/events/handler-count.html` falls back to `window`, so it passed — while two of its three variants had
  never run at all. That is the quieter failure: a green row standing for a third of a document.

## Mechanism

`WptBrowserVariants` is a port of upstream's `SourceFile.test_variants`
(`tools/manifest/sourcefile.py` at the pinned commit `6c7127bdd9f2cc6a3668fd9791757843e09d5a9e`):

* a document's `<meta name=variant>` elements, in tree order, read off a real **AngleSharp parse** — upstream
  reads them off an html5lib tree with `root.findall(".//{xhtml}meta[@name='variant']")`, and a source scanner
  would count markup spelled inside a `<script>` string, miss the `content`-less declaration rule, and have an
  opinion about quoting;
* a wrapped `.any.js` file's `// META: variant=` lines, which is the `.js` branch of the same property;
* upstream's two validity rules (a non-empty variant starts with `?` or `#`; neither part may be present and
  empty), raised rather than shrugged at, because a corpus that grew one would fail wpt's own manifest build;
* `[""]` for a file that declares none, which is upstream's `if not rv: rv = [""]`.

`WptBrowserCorpus.Cases` yields one case per declared variant, named exactly as the manifest names it
(`dom/events/handler-count.html?element`), and that name is threaded through everything a case is a key in:
the minimum-test table, the exclusion table, a cause's `File`, the census, `WptBrowserCorpus.IsVendored` /
`IsFrameBody`, the driver's per-file `timeout=long` lookup, and the `[Explicit]` `JINT_WPT_DOCUMENT` triage
runner (whose example now names a query, and whose ignore message says so). The server needed **no** change:
`WptServerRequest.Path` already drops the query and finds the file by path alone, exactly as wptserve's
`filesystem_path` does, so the query reaches the page's `location.search` and nothing else.

### The rule for an exclusion, and where it is written down

**An exclusion, a minimum-test entry and a cause row all key on the _case_, and there is deliberately no
spelling that means "every variant".** Two variants are two runs of what the harness sees as two different
documents, so a divergence measured in one is not evidence about the other, and a row covering both would be
the blanket `WptExclusion`'s two-sided rule (match a failing test, match no passing one) exists to refuse.
Upstream's own expectation files name the full URL for the same reason. The rule enforces itself:
`EveryVendoredDocumentIsAccountedFor` already fails for a row that is not a case, and it now adds which case
names *do* exist, because "not a case of any suite" otherwise reads as "delete this row" when the answer is
"append the variant". It is written down in `Wpt/AGENTS.md`, in `Wpt/README.md`, and on `WptBrowserVariants`.

### The engine lane already had a variant notion, and it is the opposite one

`Jint.Tests/Wpt` deliberately **ignores** `// META: variant=`: its shim leaves `location.search` empty, so
`subsetTest` runs everything and one run of a file is the union of its `?1-1000` shards. Both answers are
right and the difference is the kind of variant — a shard selects a subset of the *same* tests, while a query
a document branches on selects *different* ones, of which no single run is the union. There was no shape to
reuse (that lane has one theory case per file on purpose), so the two files now say why they disagree:
`Jint.Tests/Wpt/AGENTS.md` gained a sentence beside its sharding paragraph, and
`Jint.Tests.Browser/Wpt/AGENTS.md` carries the browser-lane rule.

### The census

`Documents` and `Synthesized` count **files** — the README says of itself that they do — so they are
unchanged and a variant moves only the two counted columns. `WptBrowserCorpus.Documents(suite)` is what those
two now read, and the cause table's `Documents` column counts documents rather than cases for the same reason.

**`update-raising-the-ceiling` was not needed and was not used.** The ceiling bounds `Not passing` only, and
that column *falls*: `dom/ranges` 4 → 2. `Tests` is an equality in both directions, and plain `update` writes
a rising one without complaint — `dom/events` 544 → 548, `dom/ranges` 82 → 84, total 66,646 → 66,652. So the
tables here were regenerated with `JINT_WPT_BROWSER_CENSUS=update`, never by hand.

## Failing-first evidence

**1. The new tests fail without the enumeration change.** With everything else in place and only
`WptBrowserCorpus.AddVariants` reverted to `cases.Add(document)`:

```
Failed ADocumentThatDeclaresVariantsIsOneCasePerVariant
  Expected collection {...} to contain "…Range-in-shadow-after-the-shadow-removed.html?mode=closed".
Failed AVariantIsAnotherCaseAndNotAnotherDocument
  Expected WptBrowserCorpus.Cases("dom/ranges").Count to be 18 …, but found 17.
Failed EveryVariantDeclaredByTheCorpusIsACase
  …declares the variant "?mode=closed" and …?mode=closed is not a case
Failed! - Failed: 3, Passed: 20, Total: 23
```

**2. The bare path is what the lane used to run**, shown through the triage runner on this branch
(`JINT_WPT_DOCUMENT=<bare paths>`):

```
dom/ranges/Range-in-shadow-after-the-shadow-removed.html
  [FAIL] Range in shadow should stay in the shadow after the host is removed
      Failed to execute 'Element.attachShadow': the provided value 'null' is not a valid enum value.
  [FAIL] Range in shadow should stay in the shadow after the host parent is removed
      …same…
dom/events/handler-count.html
  [PASS] Test addEventListener/removeEventListener on the window.
  [PASS] Test setting onanimationstart handler on the window.       <- one variant of three
```

**3. With the change, the five cases report ten results, all passing**, with variant-specific names that only
a populated `location.search` can produce:

```
…Range-in-shadow-after-the-shadow-removed.html?mode=closed  2 PASS
…Range-in-shadow-after-the-shadow-removed.html?mode=open    2 PASS
dom/events/handler-count.html?document  [PASS] …on the document.
dom/events/handler-count.html?window    [PASS] …on the window.
dom/events/handler-count.html?element   [PASS] …on the element.
```

The `Range-in-shadow-after-the-shadow-removed.html` exclusion row is deleted; the two-sided rule is what
proves it was live before (an exclusion that matched no failing test fails the run), and the runner is green
with it gone.

## What was verified

All in Release, no `--no-build`.

| Command | Result |
| --- | --- |
| `JINT_WPT_BROWSER_CENSUS=1 dotnet test Jint.Tests.Browser --filter FullyQualifiedName~Jint.Tests.Browser.Wpt` (net8.0 **and** net10.0) | 428 passed, 0 failed, on each — the whole lane plus the measured census and cause tables |
| `dotnet test Jint.Tests.Browser --filter FullyQualifiedName~WptBrowserVariantTests` | 23 passed (3 fail on the reverted enumeration, above) |
| `JINT_WPT_DOCUMENT=…` triage of the five variant cases, net8.0 | 10 results, 10 PASS |
| `JINT_WPT_CENSUS=1 dotnet test Jint.Tests --filter …WptCensusTests\|…WptCorpusTests` (net8.0) | 52 passed — the engine lane is untouched and says so |
| `dotnet test Jint.Tests --filter FullyQualifiedName~AgentInstructionFileTests` | 5 passed on net8.0, net10.0 and net472; `Jint.Tests.Browser/Wpt/AGENTS.md` is 24,216 CRLF bytes against the 32 KiB cap |
| `dotnet build -c Release` (solution) | Build succeeded, 0 errors |

The exclusion-discipline tests are part of the lane run above: `EveryVendoredDocumentIsAccountedFor`,
`EveryCaseIsReachedByExactlyOneSource`, `EverySynthesizedCaseIsAWrapperTheServerGenerates` and the per-case
two-sided check in `RunCaseAsync`.

## Every other document in the corpus that declares a variant

Searched the whole vendored tree for `name=variant` / `name="variant"` / `name='variant'` and for
`// META: variant=`:

* **Documents: exactly two**, both handled above and both under browser-lane suites. (`common/subset-tests.js`
  and `common/subset-tests-by-key.js` also match the search — they are the helpers that *read* a variant, not
  documents that declare one.)
* **`.any.js` files: ten** — `encoding/api-invalid-label`, `encoding/single-byte-decoder`,
  `encoding/textdecoder-fatal-single-byte`, `url/url-constructor`, `url/url-setters`,
  `WebCryptoAPI/derive_bits_keys/{hkdf,pbkdf2}.https` and
  `WebCryptoAPI/generateKey/successes_RSA-OAEP`, `successes_RSA-PSS`, `successes_RSASSA-PKCS1-v1_5`.
  **None is under a browser-lane suite**, so no synthesized `.any.html` wrapper in this lane declares a
  variant today, and the wrapper half of the rule reads nothing at this pin.
  `NoWrappedScriptDeclaresAVariantAtThisPin` pins that from the browser lane's side, so a corpus bump that
  moves one of those suites in has to notice. Those ten stay engine-lane shards, where they are deliberately
  unsharded.

## Deliberately left out

* **No change to the engine lane's behaviour.** `// META: variant=` sharding stays ignored there; only a
  sentence of its `AGENTS.md` moved, to say why the other lane answers differently.
* **No `#fragment` variant is exercised**, because none is declared. `DocumentOf`/`VariantOf` split on `?`
  *and* `#` and the validity rules cover both, so the model is upstream's, but a fragment variant's
  navigation is untested and I would want a real case before claiming it.
* **The `Range's own algorithms` cause is not deleted.** #3990 gave it the `Range-adopt-test.html` pair,
  which is real bookkeeping this change does not touch; its row is 2/1 now rather than 4/2 and its prose is
  about that pair alone.
* **The triage runner still splits on `;` and `,`.** A variant carrying a comma would need `;`, which the
  docs now say rather than my changing a documented separator.

## Incidental

`Wpt/README.md` on `main` carries **two contradictory copies** of the "Across the six of them there are …"
sentence (858 and 1,368 not passing), from two pull requests that each edited the line. `StatedTotals` reads
only the first match, so the second has been stale and invisible to the check that exists to stop exactly
that. Since this change edits that sentence anyway, there is one of it now.

## Base

Rebased onto `upstream/main` at **08d97a40a** ("An XML document's metadata is DOM's, and the wpt category that
stood for it is gone (#3990)"); every number above was measured after that rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
