### PR TITLE
DOM.setFileInputFiles, and the file selection an <input type=file> needs

### DIFF
--- a/Jint.Browser.Mcp/AGENTS.md
+++ b/Jint.Browser.Mcp/AGENTS.md
@@ -29,6 +29,16 @@ descriptions only through its source generator and only on `partial` methods, an
 The one thing every description must keep saying is that there are no screenshots. A model that believes it
 can see the page will keep asking for a picture instead of a snapshot.
 
+### One tool can move data outwards, and it is off until a deployment says otherwise
+
+`upload` is the only tool that sends this machine's own bytes to a page. Everything else gives a page what
+that page already had; an upload gives a site the model chose a file from the host, and a model reading a
+page is a model that page can try to instruct. So it is gated on `BrowserAgentOptions.UploadDirectory`
+(`null` by default, which refuses every upload), the containment check runs **before** the existence check —
+otherwise the refusal wording is a way of asking whether a file outside the directory exists — and a
+symbolic link is resolved to its final target and checked again. Do not relax any of the three, and do not
+give the tool a default directory.
+
 ### Errors are answers, not exceptions
 
 **Every tool returns a `CallToolResult` and none of them throws.** `ToolJson.Ok` fills both `content` (the

--- a/Jint.Browser.Mcp/BrowserAgent.cs
+++ b/Jint.Browser.Mcp/BrowserAgent.cs
@@ -186,6 +186,33 @@ public sealed class BrowserAgent : IAsyncDisposable
     public Task<ActionOutcome> SelectAsync(string target, string value)
         => ActAsync(target, (page, t) => page.SelectAsync(t, value), "Selected an option in");
 
+    /// <summary>Chooses host files for the <c>&lt;input type=file&gt;</c> <paramref name="target"/> names.</summary>
+    /// <param name="target">A <c>ref=</c> from an <c>ax</c> snapshot, or a CSS selector.</param>
+    /// <param name="paths">Paths of the files to choose, inside <see cref="BrowserAgentOptions.UploadDirectory"/>.</param>
+    /// <returns>Whether a file input matched, and where the page is now.</returns>
+    /// <remarks>
+    /// <b>Refused unless a deployment named a directory to upload from</b>, and refused for anything
+    /// outside it — see <see cref="BrowserAgentOptions.UploadDirectory"/> for why this one tool is off by
+    /// default. What it then does is the page's own file-selection algorithm: the events fire and a
+    /// submission carries the bytes.
+    /// </remarks>
+    /// <exception cref="BrowserToolException">
+    /// Uploads are not enabled, a path is outside the allowed directory, or a path names no file.
+    /// </exception>
+    public Task<ActionOutcome> UploadAsync(string target, IReadOnlyList<string> paths)
+        => RunAsync(async page =>
+        {
+            var allowed = Uploadable(paths);
+            var done = await page.SetInputFilesAsync(target, allowed).ConfigureAwait(false);
+
+            return new ActionOutcome(
+                done,
+                page.Url,
+                done
+                    ? $"Chose {allowed.Count} file(s) for {target}."
+                    : $"Nothing matched {target}, or it is not a file input. Take an ax snapshot and use one of its ref= values.");
+        });
+
     /// <summary>Presses one key at whatever the page has focused.</summary>
     /// <param name="key">A <c>KeyboardEvent.key</c> value: a character, or <c>Enter</c>, <c>Tab</c>, <c>Escape</c>…</param>
     /// <returns>Where the page is now, which <c>Enter</c> in a form will have moved.</returns>
@@ -381,6 +408,81 @@ public sealed class BrowserAgent : IAsyncDisposable
                     ? $"{verb} {target}."
                     : $"Nothing matched {target}. Take an ax snapshot and use one of its ref= values.");
         });
+
+    /// <summary>The paths an upload may actually read, or the sentence saying why it may read none.</summary>
+    private List<string> Uploadable(IReadOnlyList<string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+
+        if (string.IsNullOrEmpty(_options.UploadDirectory))
+        {
+            throw new BrowserToolException(
+                "This server uploads no files. A deployment enables it by naming the one directory files may "
+                + "be read from, as BrowserAgentOptions.UploadDirectory.");
+        }
+
+        if (paths.Count == 0)
+        {
+            throw new BrowserToolException("Name at least one file to upload.");
+        }
+
+        var root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(_options.UploadDirectory))
+            + Path.DirectorySeparatorChar;
+        var comparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        var allowed = new List<string>(paths.Count);
+
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new BrowserToolException("A file to upload was named as an empty path.");
+            }
+
+            var resolved = Path.GetFullPath(path);
+
+            // Containment is decided before existence, and that order is the point: answering "there is no
+            // file there" for a path outside the directory would turn this tool into a way of asking
+            // whether one exists, which is a thing the caller is not allowed to know.
+            Contain(path, resolved);
+
+            if (!File.Exists(resolved))
+            {
+                throw new BrowserToolException($"There is no file at '{path}'.");
+            }
+
+            // Then the link is followed to its final target and the check is made again, because a link
+            // inside the directory pointing outside it is the shape that survives the first one. A link
+            // that cannot be walked is refused rather than accepted as itself.
+            try
+            {
+                if (new FileInfo(resolved).ResolveLinkTarget(returnFinalTarget: true) is { } target)
+                {
+                    resolved = target.FullName;
+                    Contain(path, resolved);
+                }
+            }
+            catch (IOException failure)
+            {
+                throw new BrowserToolException($"'{path}' could not be resolved: {failure.Message}", failure);
+            }
+
+            allowed.Add(resolved);
+        }
+
+        return allowed;
+
+        void Contain(string named, string full)
+        {
+            if (!full.StartsWith(root, comparison))
+            {
+                throw new BrowserToolException(
+                    $"'{named}' is outside the one directory this server uploads from.");
+            }
+        }
+    }
 
     private async Task<Page> PageAsync()
     {

--- a/Jint.Browser.Mcp/BrowserAgentOptions.cs
+++ b/Jint.Browser.Mcp/BrowserAgentOptions.cs
@@ -63,6 +63,26 @@ public sealed class BrowserAgentOptions
     /// </remarks>
     public Func<Uri, bool>? UrlFilter { get; set; }
 
+    /// <summary>
+    /// The one directory the <c>upload</c> tool may read files from, or <see langword="null"/> — the
+    /// default — for none, which refuses every upload.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Off by default because it is the one tool that can move data outwards.</b> Everything else here
+    /// sends the page only what the page already had; an upload sends a file from the machine the server is
+    /// running on to a site a model chose, and a model reading a page is a model that can be told what to
+    /// do by one. So a deployment names the directory out loud, the way it turns
+    /// <see cref="Trusted"/> on out loud, and everything outside it is refused.
+    /// </para>
+    /// <para>
+    /// The check is on the resolved path, with a symbolic link followed to its final target first — a link
+    /// inside the directory pointing outside it is exactly the shape it exists to refuse — and it is
+    /// case-sensitive wherever the file system is.
+    /// </para>
+    /// </remarks>
+    public string? UploadDirectory { get; set; }
+
     /// <summary>Builds what every page of the server's browser is made from.</summary>
     internal BrowserOptions ToBrowserOptions()
     {

--- a/Jint.Browser.Mcp/BrowserTools.cs
+++ b/Jint.Browser.Mcp/BrowserTools.cs
@@ -126,6 +126,22 @@ public sealed class BrowserTools
         [Description("The option's value, or the text shown for it.")] string value)
         => AnswerAsync(() => _agent.SelectAsync(target, value), ToolJson.Default.ActionOutcome);
 
+    /// <summary>Chooses files for a file input.</summary>
+    [McpServerTool(Name = "upload", Title = "Choose files for a file input")]
+    [Description("""
+        Chooses files from this machine for a file upload field — an <input type=file> — exactly as picking
+        them in the file dialog would: the page sees a FileList, its input and change handlers run, and
+        submitting the form sends the bytes. Clicking a file input does nothing, so this is the only way to
+        fill one; use fill for a text field.
+        Files can only be read from the one directory this server was started with, and the tool answers an
+        error naming that restriction when the deployment allowed none — that is a configuration decision,
+        not something to work around by another route.
+        """)]
+    public Task<CallToolResult> UploadAsync(
+        [Description("A ref= value from an ax snapshot, or a CSS selector naming the <input type=file>.")] string target,
+        [Description("Paths of the files to choose, in order, inside the directory this server uploads from.")] string[] paths)
+        => AnswerAsync(() => _agent.UploadAsync(target, paths), ToolJson.Default.ActionOutcome);
+
     /// <summary>Moves the pointer over an element.</summary>
     [McpServerTool(Name = "hover", Title = "Hover over an element")]
     [Description("Moves the mouse pointer over an element. Only pages that listen for mousemove react; a menu that opens on mouseenter will not, because this browser tracks no pointer position between calls.")]

--- a/Jint.Browser.Mcp/README.md
+++ b/Jint.Browser.Mcp/README.md
@@ -73,6 +73,7 @@ is what a deployment decides: the security posture, the budgets, the ceiling on 
 | `navigate(url, waitUntil?)` | Loads a URL; answers its final URL, title and status. |
 | `snapshot(mode?, mainContentOnly?, maxLength?)` | Reads the page. `ax` (the default) is the accessibility tree with a `ref=` on every element; `markdown` is the page as prose; `text` is the same without formatting. |
 | `click`, `fill`, `type`, `press`, `select`, `hover`, `scroll` | Drive the page. Each takes a `ref=` from an `ax` snapshot or a CSS selector. |
+| `upload(target, paths)` | Chooses files for an `<input type=file>`, as a file dialog would. **Refused unless a deployment set `BrowserAgentOptions.UploadDirectory`**, and refused for anything outside it. |
 | `back`, `forward`, `reload` | The three buttons above the page. |
 | `evaluate(expression)` | Runs one JavaScript expression and answers its JSON, serialized by the page. |
 | `wait_for(selector?, text?, timeoutSeconds?)` | Waits for the page to catch up with what an action started. |
@@ -101,6 +102,13 @@ cloud-metadata addresses are refused.
 `BrowserAgentOptions.Trusted` turns the profile off and `BlockPrivateNetwork` decides the network rule on its
 own, so a deployment pointing an agent at its own staging server says so once, out loud. `UrlFilter` is the
 narrower tool and the one to reach for: it is checked on the first hop and on every redirect.
+
+**`upload` is off until a directory is named, and it is the one tool that can move data outwards.** Every
+other tool sends a page only what that page already had; an upload sends a file from this machine to a site
+the model chose, and a model reading a page is a model that page can try to instruct. So
+`BrowserAgentOptions.UploadDirectory` names the one directory files may be read from — nothing outside it,
+and a symbolic link is followed before that is decided — and with no directory named the tool answers an
+error rather than a file.
 
 ## Sessions and HTTP
 

--- a/Jint.Browser.Playwright/AGENTS.md
+++ b/Jint.Browser.Playwright/AGENTS.md
@@ -47,6 +47,12 @@ is not. **Never return `null`, an empty result, or a completed task for somethin
 A silent no-op turns a missing feature into a wrong answer, and an automation script cannot tell the
 difference between "the button was not there" and "clicking is not implemented".
 
+The same reasoning decides an edge the model underneath answers differently. `SetInputFilesAsync` given more
+than one file for an input without `multiple` throws in Playwright's own wording, while
+`Page.SetInputFilesAsync` keeps the first and drops the rest — which is what HTML says a user agent must do.
+Both are right for their own caller: a client of *this* interface is written against one that throws, and
+reporting success with one of its two files selected is the silent wrong answer above.
+
 ## An option that is not honoured throws; it is never ignored
 
 Every entry point taking an options object calls `OptionSupport.EnsureOnly(options, operation, …supported)`,

--- a/Jint.Browser.Playwright/PageAdapters.cs
+++ b/Jint.Browser.Playwright/PageAdapters.cs
@@ -76,6 +76,15 @@ internal sealed class PageTarget(BrowserContextTarget context, JintPage inner) :
                     (string) arguments[0]!,
                     arguments[1],
                     (PageWaitForFunctionOptions?) arguments[2]);
+            case nameof(IPage.SetInputFilesAsync):
+                OptionSupport.EnsureOnly(
+                    arguments[2],
+                    "IPage.SetInputFilesAsync",
+                    nameof(PageSetInputFilesOptions.Timeout));
+                return SetInputFilesAsync(
+                    (string) arguments[0]!,
+                    arguments[1],
+                    ((PageSetInputFilesOptions?) arguments[2])?.Timeout);
             case nameof(IPage.CloseAsync):
                 OptionSupport.EnsureOnly(arguments[0], "IPage.CloseAsync");
                 return CloseAsync();
@@ -95,6 +104,14 @@ internal sealed class PageTarget(BrowserContextTarget context, JintPage inner) :
     }
 
     internal IFrame MainFrame => _mainFrame ??= ProxyFactory.Create<IFrame>(new FrameTarget(this));
+
+    /// <summary>
+    /// The selector forms of <c>setInputFiles</c> on <see cref="IPage"/> and <see cref="IFrame"/>, which
+    /// Playwright itself deprecates in favour of the locator's — so they route to exactly the locator's
+    /// path rather than to a second implementation of it.
+    /// </summary>
+    internal Task SetInputFilesAsync(string selector, object? files, float? timeout)
+        => new LocatorTarget(this, LocatorDescriptor.Css(selector)).SetInputFilesAsync(files, timeout);
 
     private ILocator Locator(string selector)
         => ProxyFactory.Create<ILocator>(new LocatorTarget(this, LocatorDescriptor.Css(selector)));
@@ -397,8 +414,18 @@ internal sealed class FrameTarget(PageTarget page) : ProxyTarget
                 (FrameLocatorOptions?) arguments[1]),
             nameof(IFrame.ContentAsync) => page.Inner.ContentAsync(),
             nameof(IFrame.TitleAsync) => page.Inner.TitleAsync(),
+            nameof(IFrame.SetInputFilesAsync) => SetInputFilesAsync(
+                (string) arguments[0]!,
+                arguments[1],
+                (FrameSetInputFilesOptions?) arguments[2]),
             _ => Unsupported(method),
         };
+    }
+
+    private Task SetInputFilesAsync(string selector, object? files, FrameSetInputFilesOptions? options)
+    {
+        OptionSupport.EnsureOnly(options, "IFrame.SetInputFilesAsync", nameof(FrameSetInputFilesOptions.Timeout));
+        return page.SetInputFilesAsync(selector, files, options?.Timeout);
     }
 
     private ILocator Locator(string selector, FrameLocatorOptions? options)
@@ -428,6 +455,9 @@ internal sealed class LocatorTarget(PageTarget page, LocatorDescriptor descripto
             nameof(ILocator.ClickAsync) => ClickAsync((LocatorClickOptions?) arguments[0]),
             nameof(ILocator.FillAsync) => FillAsync((string) arguments[0]!, (LocatorFillOptions?) arguments[1]),
             nameof(ILocator.PressAsync) => PressAsync((string) arguments[0]!, (LocatorPressOptions?) arguments[1]),
+            nameof(ILocator.SetInputFilesAsync) => SetInputFilesAsync(
+                arguments[0],
+                (LocatorSetInputFilesOptions?) arguments[1]),
             _ => Unsupported(method),
         };
     }
@@ -559,6 +589,92 @@ internal sealed class LocatorTarget(PageTarget page, LocatorDescriptor descripto
                 timeout)
             .ConfigureAwait(false);
     }
+
+    private Task SetInputFilesAsync(object? files, LocatorSetInputFilesOptions? options)
+    {
+        OptionSupport.EnsureOnly(
+            options,
+            "ILocator.SetInputFilesAsync",
+            nameof(LocatorSetInputFilesOptions.Timeout));
+        return SetInputFilesAsync(files, options?.Timeout);
+    }
+
+    /// <summary>
+    /// Playwright's four <c>setInputFiles</c> overloads — a path, paths, a payload, payloads — over
+    /// <c>Page.SetInputFilesAsync</c>, which is the same file-selection algorithm
+    /// <c>DOM.setFileInputFiles</c> runs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Attached rather than visible.</b> A file input is usually <c>display: none</c> behind a styled
+    /// <c>&lt;label&gt;</c>, so waiting for a box would time out on the commonest markup there is; this is
+    /// the one action here whose wait deliberately stops at attached.
+    /// </para>
+    /// <para>
+    /// <b>An input without <c>multiple</c> given more than one file is refused, in Playwright's own
+    /// words.</b> HTML makes the extra files the user agent's to drop, and <c>Page.SetInputFilesAsync</c>
+    /// drops them — but a caller of <i>this</i> interface is written against a client that throws, and
+    /// answering success with one of its two files selected is exactly the silent wrong answer this adapter
+    /// exists to avoid.
+    /// </para>
+    /// </remarks>
+    internal async Task SetInputFilesAsync(object? files, float? timeoutMilliseconds)
+    {
+        // Materialized once, before anything is awaited: an argument may be any IEnumerable, and one that
+        // can be walked only once would answer a count and then select nothing.
+        var (paths, payloads) = Chosen(files);
+        var count = paths?.Count ?? payloads!.Count;
+
+        var timeout = PageTarget.Timeout(timeoutMilliseconds, page.DefaultTimeout);
+        var started = Stopwatch.GetTimestamp();
+        await WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Attached,
+            Timeout = timeoutMilliseconds,
+        }).ConfigureAwait(false);
+
+        var index = await descriptor.ResolveIndexAsync(page.Inner).ConfigureAwait(false);
+        var remaining = RequireRemaining(timeout, started);
+
+        if (count > 1
+            && await page.EvaluateValueAsync<bool?>(descriptor.PropertyScript("multiple")).ConfigureAwait(false) != true)
+        {
+            throw new PlaywrightException("Non-multiple file input can only accept single file");
+        }
+
+        if (index is null)
+        {
+            throw new PlaywrightException("The locator did not resolve to a file input element.");
+        }
+
+        // Started inside the branch rather than before it: a task created for an index that turned out to
+        // be nothing would go on making the selection with nobody awaiting it.
+        var selected = await (paths is not null
+                ? page.Inner.SetInputFilesAsync(descriptor.Selector, index.Value, paths)
+                : page.Inner.SetInputFilesAsync(descriptor.Selector, index.Value, payloads!))
+            .WaitAsync(remaining).ConfigureAwait(false);
+
+        if (!selected)
+        {
+            throw new PlaywrightException("The locator did not resolve to a file input element.");
+        }
+    }
+
+    /// <summary>The argument of one of the four overloads, read once into the shape the page member takes.</summary>
+    private static (List<string>? Paths, List<PageFile>? Payloads) Chosen(object? files)
+        => files switch
+        {
+            string path => ([path], null),
+            FilePayload payload => (null, [Convert(payload)]),
+            IEnumerable<string> paths => ([.. paths], null),
+            IEnumerable<FilePayload> payloads => (null, [.. payloads.Select(Convert)]),
+            _ => throw new NotSupportedException(
+                "Jint.Browser.Playwright does not support ILocator.SetInputFilesAsync for "
+                + (files?.GetType().Name ?? "null") + "."),
+        };
+
+    private static PageFile Convert(FilePayload payload)
+        => new(payload.Name, payload.MimeType, payload.Buffer);
 
     private static TimeSpan RequireRemaining(TimeSpan timeout, long started)
     {

--- a/Jint.Browser.Playwright/README.md
+++ b/Jint.Browser.Playwright/README.md
@@ -26,6 +26,12 @@ Locator support currently covers CSS selectors and a first set of role locators,
 waiting and trusted input dispatch. It does not yet reproduce Playwright's complete actionability,
 accessibility-name or atomic locator-resolution semantics.
 
+`SetInputFilesAsync` is supported on the locator, the page and the frame, in all four of its forms — a path,
+paths, a `FilePayload`, payloads — and runs the same file-selection algorithm the page API and the DevTools
+Protocol run. It waits for the element to be attached rather than visible, because a file input is usually
+hidden behind a styled label, and it refuses more than one file for an input without `multiple` in
+Playwright's own words rather than silently keeping the first.
+
 The package is built and tested against Microsoft.Playwright 1.62. Applications can use Playwright's public
 browser, context, page, frame and locator interfaces, but Playwright features that downcast those interfaces
 to its internal implementation, including its built-in assertions, cannot use a third-party implementation.

--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -55,7 +55,11 @@ target/runtime split and the manifest are there and none of it is repeated here.
   one character at a time. `Input` is `dispatchMouseEvent`, `dispatchKeyEvent`, `insertText` and an
   `imeSetComposition` that is accepted and changes nothing; touch, drag and the synthesized gestures are
   honestly `-32601`, and the public `Page.ClickAsync`/`TypeAsync`/`PressAsync` reach the same dispatcher
-  rather than a second one. The keyboard's own rules are
+  rather than a second one. **`DOM.setFileInputFiles` is the file chooser there is none of**: clicking an
+  `<input type=file>` only records that a page asked for a picker, so this command, `Page.SetInputFilesAsync`
+  and the Playwright adapter all run one algorithm, `Dom/Files/FileSelection`. It reads the host paths on the
+  loop before it changes anything — a `File` here is memory the engine owns, not a handle, so a failed read
+  leaves the previous selection standing and is `-32000` naming the path rather than an empty selection. The keyboard's own rules are
   [above](../Events/AGENTS.md#the-keyboard-and-the-editor-under-it).
 - **A named isolated world is made again over every document.** Chrome does that, and Puppeteer and
   Playwright each create one utility world when they attach and then use it for the life of the page — so a

--- a/Jint.Browser/DevTools/DomDomain.cs
+++ b/Jint.Browser/DevTools/DomDomain.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Jint.Browser.Dom.Files;
 using Jint.Browser.Events;
 using Jint.Browser.Layout;
 using Jint.Browser.Runtime;
@@ -304,6 +306,64 @@ internal sealed partial class DomDomain : DOMDomainBase, IDetachableDomain, ITar
     {
         var node = RequireNodeId(parameters.NodeId);
         node.NodeValue = parameters.Value;
+        return new ValueTask<EmptyResult>(EmptyResult.Instance);
+    }
+
+    /// <summary>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-setFileInputFiles — the command
+    /// behind Playwright's <c>setInputFiles</c> and Puppeteer's <c>uploadFile</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The paths are the browser machine's, and the bytes are read here.</b> There is no renderer
+    /// process to hand a file handle to, so a selected file is a <c>File</c> over memory the page's engine
+    /// owns — which is also why a path naming nothing is refused rather than accepted and discovered when
+    /// the page reads it. Chrome has no wording for that failure because Chrome never opens the file at
+    /// this point; the message names the path, which is the only thing a client can act on.
+    /// </para>
+    /// <para>
+    /// <b>The read runs on the page loop, before anything is changed.</b> Every command here does, and this
+    /// one is bounded by the page's own turn budget like any other; reading first is what makes a failed
+    /// read leave the previous selection standing.
+    /// </para>
+    /// <para>
+    /// <b>Nothing filters the paths.</b> A client that reaches this server can already run script in the
+    /// page, so a path is no more privilege than it already had — but the endpoint is unauthenticated,
+    /// which is what the package documentation says to bind to loopback about.
+    /// </para>
+    /// </remarks>
+    protected override ValueTask<EmptyResult> SetFileInputFilesAsync(SetFileInputFilesRequest parameters, CommandContext context)
+    {
+        var node = Resolve(parameters.NodeId, parameters.BackendNodeId, parameters.ObjectId);
+
+        // Chrome's own wording, which is what tells a client it addressed the wrong node rather than sent
+        // the wrong command: third_party/blink/renderer/core/inspector/inspector_dom_agent.cc.
+        if (node is not IHtmlInputElement input || !FileSelection.IsFileInput(input))
+        {
+            return Throw.ServerError<ValueTask<EmptyResult>>("Node is not a file input element");
+        }
+
+        var runtime = Runtime(node);
+
+        // Trimmed before the read rather than after it, so a file this input could never hold is not opened
+        // at all; FileSelection.Update applies the same rule for every other caller.
+        var paths = FileSelection.Allowed(input, parameters.Files);
+        var files = new List<SelectedFile>(paths.Count);
+
+        foreach (var path in paths)
+        {
+            try
+            {
+                files.Add(FileSelection.Read(path));
+            }
+            catch (Exception failure)
+                when (failure is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+            {
+                return Throw.ServerError<ValueTask<EmptyResult>>("Cannot read file " + path, failure.Message);
+            }
+        }
+
+        FileSelection.Update(runtime, input, files);
         return new ValueTask<EmptyResult>(EmptyResult.Instance);
     }
 

--- a/Jint.Browser/Dom/Files/FileSelection.cs
+++ b/Jint.Browser/Dom/Files/FileSelection.cs
@@ -1,0 +1,182 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using Jint.Browser.Events;
+using Jint.Browser.Runtime;
+using Jint.WebApi.Files;
+
+namespace Jint.Browser.Dom.Files;
+
+/// <summary>
+/// One file on its way into an <c>&lt;input type=file&gt;</c>: the bytes, and the three things a
+/// <c>File</c> is built from.
+/// </summary>
+/// <param name="Name">The file's name, which is what a submission and <c>file.name</c> report.</param>
+/// <param name="Type">The MIME type, or <see cref="FileSelection.DefaultType"/> when nothing named one.</param>
+/// <param name="Content">The bytes, already read: a selection holds a file rather than a path to one.</param>
+/// <param name="LastModified">Milliseconds since the Unix epoch.</param>
+internal readonly record struct SelectedFile(
+    string Name,
+    string Type,
+    ReadOnlyMemory<byte> Content,
+    long LastModified);
+
+/// <summary>
+/// HTML's File Upload state: what a host, a protocol client or an adapter selects into a file input, and
+/// the two events the page hears when the selection moves.
+/// <para>
+/// https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>There is no picker, and this is the seam that stands in for one.</b> Clicking a file input runs
+/// <c>BrowserActivationHost.OpenFileChooser</c>, which a headless host answers by recording that a page
+/// asked for something nobody could give it. Everything that <i>can</i> answer —
+/// <c>DOM.setFileInputFiles</c>, <c>Page.SetInputFilesAsync</c>, the Playwright adapter's
+/// <c>SetInputFilesAsync</c> — comes through here, so one selection algorithm serves all three rather than
+/// three that drift.
+/// </para>
+/// <para>
+/// <b>The selection is the same state a script sets through <c>input.files</c>.</b>
+/// <see cref="FileTransferRealm"/> owns it, mirrors it into AngleSharp's own input model so
+/// <c>input.value</c> and constraint validation agree with the <c>FileList</c>, and
+/// <c>Runtime/FormSubmitter</c> reads it when it builds an entry list. Nothing here keeps a second copy.
+/// </para>
+/// </remarks>
+internal static class FileSelection
+{
+    /// <summary>
+    /// The type a file gets when nothing named one — the value HTML's own "empty file" entry carries, and
+    /// what a <c>multipart/form-data</c> part is labelled with when no type could be worked out.
+    /// </summary>
+    internal const string DefaultType = "application/octet-stream";
+
+    /// <summary>Whether <paramref name="node"/> is an <c>input</c> element in the File Upload state.</summary>
+    internal static bool IsFileInput(INode? node)
+        => node is IHtmlInputElement input && ActivationBehaviors.IsType(input, "file");
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/input.html#update-the-file-selection — replace the element's
+    /// selected files and let the page hear it.
+    /// </summary>
+    /// <param name="runtime">The page the input belongs to. The caller is already on its loop.</param>
+    /// <param name="input">The file input whose selection is being made.</param>
+    /// <param name="files">The files chosen, in the order they were chosen.</param>
+    /// <remarks>
+    /// <para>
+    /// <b>The events are fired rather than queued, and the reason is the thread.</b> HTML queues an element
+    /// task because a picker is asynchronous user interface that finishes on some later turn; here the
+    /// caller <i>is</i> a turn of the page loop — a protocol command, a mailbox request — so this call is
+    /// that task. Queueing a second one would only mean a client could be told the command succeeded before
+    /// the page had heard about it, which is not what any of them expects.
+    /// </para>
+    /// <para>
+    /// <b>Both events fire whenever a selection is made</b>, even one that leaves the same files in place:
+    /// the algorithm has no "did it change" step, and a caller that reached here made a selection. An empty
+    /// selection is a selection too, and clears the input — Blink returns early instead, which is the bug
+    /// Puppeteer's <c>uploadFile</c> works around by not sending the command at all for an empty list.
+    /// </para>
+    /// </remarks>
+    internal static void Update(PageRuntime runtime, IHtmlInputElement input, IReadOnlyList<SelectedFile> files)
+    {
+        var realm = FileTransferRealm.Of(runtime.Engine);
+        var list = realm.NewFileList();
+
+        foreach (var file in Allowed(input, files))
+        {
+            list.Add(ToFile(runtime.Engine, file));
+        }
+
+        realm.SetInputFiles(input, list);
+
+        if (runtime.Dom.WrapNode(input) is { } target)
+        {
+            ActivationBehaviors.FireInputAndChange(target);
+        }
+    }
+
+    /// <summary>
+    /// The files a selection may actually contain: all of them for a <c>multiple</c> input, the first
+    /// otherwise.
+    /// </summary>
+    /// <remarks>
+    /// https://html.spec.whatwg.org/multipage/input.html#attr-input-multiple — "if the attribute is not
+    /// specified, the user agent must not allow the user to select more than one file". A selection made by
+    /// a client rather than by a user is still the user agent's to bound, so the extra files are dropped
+    /// rather than the call refused: Blink's <c>FileInputType::SetFilesFromPaths</c> keeps the first path
+    /// the same way, and Playwright refuses the call in its own client before one is ever sent.
+    /// </remarks>
+    internal static IReadOnlyList<T> Allowed<T>(IHtmlInputElement input, IReadOnlyList<T> files)
+        => input.IsMultiple || files.Count <= 1 ? files : [files[0]];
+
+    /// <summary>Reads one host file into a selection, in the shape the File API gives it.</summary>
+    /// <param name="path">A path on the machine the browser is running on.</param>
+    /// <exception cref="FileNotFoundException">There is no such file.</exception>
+    /// <exception cref="IOException">The file could not be read.</exception>
+    /// <remarks>
+    /// <b>The bytes are read now, not when the page asks for them.</b> A <c>File</c> here is a <c>Blob</c>
+    /// over memory the engine owns — there is no lazily opened host handle behind it, and there must not be
+    /// one, because the page may read it long after the file has changed or gone. The type comes from the
+    /// extension, which is the only source a headless browser has; the timestamp is the file system's,
+    /// clamped at the epoch the way <see cref="AngleSharpFileAdapter"/> clamps the other end.
+    /// </remarks>
+    internal static SelectedFile Read(string path)
+    {
+        var info = new FileInfo(path);
+        if (!info.Exists)
+        {
+            throw new FileNotFoundException("Could not find file '" + path + "'.", path);
+        }
+
+        var content = File.ReadAllBytes(path);
+
+        return new SelectedFile(info.Name, TypeOf(info.Name), content, Milliseconds(info.LastWriteTimeUtc));
+    }
+
+    /// <summary>Milliseconds since the Unix epoch, which is what <c>File.lastModified</c> is.</summary>
+    internal static long Milliseconds(DateTime utc)
+        => utc <= DateTime.UnixEpoch ? 0 : (long) (utc - DateTime.UnixEpoch).TotalMilliseconds;
+
+    /// <summary>The MIME type an extension names, or <see cref="DefaultType"/> when it names none.</summary>
+    /// <remarks>
+    /// <b>AngleSharp's table, plus three registrations it predates.</b> There is no standard mapping from an
+    /// extension to a type — a browser asks the platform, which answers differently on each of them — so a
+    /// fixed table is what makes this answer the same everywhere, and <c>AngleSharp.Io.MimeTypeNames</c> is
+    /// the one already in the dependency set. It answers <see cref="DefaultType"/> for
+    /// <c>.json</c>, <c>.csv</c> and <c>.md</c>, which are three of the commonest things a form uploads, so
+    /// their IANA registrations are supplied here: RFC 8259, RFC 4180 and RFC 7763. This is a gap in a
+    /// convenience table rather than a divergence from a specification, which is why it is filled here
+    /// instead of being recorded in <c>Dom/divergences.md</c>.
+    /// </remarks>
+    internal static string TypeOf(string name)
+    {
+        var extension = Path.GetExtension(name);
+        if (extension.Length == 0)
+        {
+            return DefaultType;
+        }
+
+        var supplement = extension.ToLowerInvariant() switch
+        {
+            ".json" => "application/json",
+            ".csv" => "text/csv",
+            ".md" => "text/markdown",
+            _ => null,
+        };
+
+        if (supplement is not null)
+        {
+            return supplement;
+        }
+
+        var mime = AngleSharp.Io.MimeTypeNames.FromExtension(extension);
+        return string.IsNullOrEmpty(mime) ? DefaultType : mime;
+    }
+
+    /// <summary>The engine's <c>File</c> for one selected file — the same one <c>new File()</c> builds.</summary>
+    private static JsFile ToFile(Engine engine, SelectedFile file)
+        => new(engine, file.Content, file.Type, file.Name, file.LastModified)
+        {
+            _prototype = engine._mainRealm.Intrinsics.File.PrototypeObject,
+        };
+}

--- a/Jint.Browser/Page.Input.cs
+++ b/Jint.Browser/Page.Input.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Html.Dom;
+using Jint.Browser.Dom.Files;
 using Jint.Browser.Events;
 using Jint.Browser.Extraction;
 using Jint.Browser.Runtime;
@@ -344,6 +345,120 @@ public sealed partial class Page
             return true;
         });
     }
+
+    /// <summary>Selects host files into the file input <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="paths">Paths on this machine, in the order they were chosen.</param>
+    /// <returns><see langword="true"/> when an <c>&lt;input type=file&gt;</c> matched.</returns>
+    /// <remarks>
+    /// <para>
+    /// This is the file chooser a headless browser does not have: clicking a file input records that a page
+    /// asked for a picker nobody could open, and this is what answers instead — the same algorithm the
+    /// protocol's <c>DOM.setFileInputFiles</c> and the Playwright adapter's <c>SetInputFilesAsync</c> run,
+    /// so neither can make a page do something the other cannot.
+    /// </para>
+    /// <para>
+    /// The page then sees a <c>FileList</c> on <c>input.files</c>, a fake Windows path plus the first file's name
+    /// on <c>input.value</c> — HTML's own answer, not a Windows detail — and one <c>input</c> event followed
+    /// by one <c>change</c> event, both trusted and both bubbling. A submission of the form carries the
+    /// bytes as <c>multipart/form-data</c> parts.
+    /// </para>
+    /// <para>
+    /// <b>The files are read here, before the page is touched.</b> The bytes become a <c>Blob</c> the page
+    /// owns, so a file that changes or is deleted afterwards changes nothing; and the read happens off the
+    /// page loop, so a slow disk does not spend the page's own turn budget. An input without the
+    /// <c>multiple</c> attribute takes the first file and no more, which is what HTML says a user agent must
+    /// allow. Passing no paths clears the selection, and still fires both events.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="target"/> or <paramref name="paths"/> is null.</exception>
+    /// <exception cref="FileNotFoundException">One of the paths names no file.</exception>
+    /// <exception cref="IOException">One of the files could not be read.</exception>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> SetInputFilesAsync(string target, IReadOnlyList<string> paths)
+        => SetInputFilesAsync(target, 0, paths);
+
+    /// <summary>Selects host files into the indexed file input that <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="index">The zero-based match, or a negative offset from the last match.</param>
+    /// <param name="paths">Paths on this machine, in the order they were chosen.</param>
+    /// <returns><see langword="true"/> when the indexed match was an <c>&lt;input type=file&gt;</c>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="target"/> or <paramref name="paths"/> is null.</exception>
+    /// <exception cref="FileNotFoundException">One of the paths names no file.</exception>
+    /// <exception cref="IOException">One of the files could not be read.</exception>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> SetInputFilesAsync(string target, int index, IReadOnlyList<string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(paths);
+        ObjectDisposedException.ThrowIf(_closed, this);
+
+        var selected = new List<SelectedFile>(paths.Count);
+
+        foreach (var path in paths)
+        {
+            ArgumentNullException.ThrowIfNull(path, nameof(paths));
+            selected.Add(FileSelection.Read(path));
+        }
+
+        return SelectFilesAsync(target, index, selected);
+    }
+
+    /// <summary>Selects files held in memory into the file input <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="files">The files, in the order they were chosen.</param>
+    /// <returns><see langword="true"/> when an <c>&lt;input type=file&gt;</c> matched.</returns>
+    /// <remarks>
+    /// The overload for content with no path — a generated document, a fixture in a resource. Everything
+    /// else is as <see cref="SetInputFilesAsync(string, IReadOnlyList{string})"/> describes it.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="target"/> or <paramref name="files"/> is null.</exception>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> SetInputFilesAsync(string target, IReadOnlyList<PageFile> files)
+        => SetInputFilesAsync(target, 0, files);
+
+    /// <summary>Selects files held in memory into the indexed file input that <paramref name="target"/> names.</summary>
+    /// <param name="target">A CSS selector, or a <c>ref=</c> from an accessibility snapshot.</param>
+    /// <param name="index">The zero-based match, or a negative offset from the last match.</param>
+    /// <param name="files">The files, in the order they were chosen.</param>
+    /// <returns><see langword="true"/> when the indexed match was an <c>&lt;input type=file&gt;</c>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="target"/> or <paramref name="files"/> is null.</exception>
+    /// <exception cref="ObjectDisposedException">The page has been closed.</exception>
+    public Task<bool> SetInputFilesAsync(string target, int index, IReadOnlyList<PageFile> files)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(files);
+        ObjectDisposedException.ThrowIf(_closed, this);
+
+        var selected = new List<SelectedFile>(files.Count);
+
+        foreach (var file in files)
+        {
+            ArgumentNullException.ThrowIfNull(file, nameof(files));
+            selected.Add(new SelectedFile(
+                file.Name,
+                file.MimeType,
+                file.Content,
+                file.LastModified.ToUnixTimeMilliseconds()));
+        }
+
+        return SelectFilesAsync(target, index, selected);
+    }
+
+    /// <summary>The one place a selection is made, whatever the files came from.</summary>
+    private Task<bool> SelectFilesAsync(string target, int index, List<SelectedFile> files)
+        => _loop.PostAsync(engine =>
+        {
+            if (PageRuntime.Find(engine) is not { } runtime
+                || ElementLocator.Find(runtime.Document, target, index) is not IHtmlInputElement input
+                || !FileSelection.IsFileInput(input))
+            {
+                return false;
+            }
+
+            FileSelection.Update(runtime, input, files);
+            return true;
+        });
 
     /// <summary>Scrolls the page to <paramref name="y"/>, clamped to the document.</summary>
     /// <param name="y">The offset from the top of the document, in CSS pixels.</param>

--- a/Jint.Browser/PageFile.cs
+++ b/Jint.Browser/PageFile.cs
@@ -1,0 +1,55 @@
+namespace Jint.Browser;
+
+/// <summary>
+/// A file selected into an <c>&lt;input type=file&gt;</c> from memory rather than from a path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It is what the page sees as a <c>File</c>: <see cref="Name"/> is <c>file.name</c> and the file name a
+/// submission writes, <see cref="MimeType"/> is <c>file.type</c> and the part's <c>Content-Type</c>, and
+/// <see cref="Content"/> is the body. Nothing about it is a handle — the bytes are the file, so a caller
+/// that builds one from a stream has already read it, and the page can read it back long afterwards.
+/// </para>
+/// <para>
+/// <see cref="Page.SetInputFilesAsync(string, IReadOnlyList{string})"/> takes host paths instead and reads
+/// them, which is the same thing with the reading done for you. Use this overload for content that has no
+/// path: a generated CSV, a fixture in a resource, bytes that came off a network.
+/// </para>
+/// </remarks>
+public sealed class PageFile
+{
+    /// <summary>Creates a file from bytes already in memory.</summary>
+    /// <param name="name">The file's name, which the page reads as <c>file.name</c>.</param>
+    /// <param name="mimeType">
+    /// The type, which the page reads as <c>file.type</c>. The empty string is what the File API gives a
+    /// file whose type nothing could determine, and is passed through unchanged.
+    /// </param>
+    /// <param name="content">The bytes. They are not copied; do not write to the buffer afterwards.</param>
+    /// <param name="lastModified">
+    /// What the page reads as <c>file.lastModified</c>, or <see langword="null"/> for the host clock's
+    /// current time, which is what the <c>File</c> constructor's own default is.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="mimeType"/> is null.</exception>
+    public PageFile(string name, string mimeType, ReadOnlyMemory<byte> content, DateTimeOffset? lastModified = null)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(mimeType);
+
+        Name = name;
+        MimeType = mimeType;
+        Content = content;
+        LastModified = lastModified ?? DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>Gets the file's name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the file's MIME type.</summary>
+    public string MimeType { get; }
+
+    /// <summary>Gets the file's bytes.</summary>
+    public ReadOnlyMemory<byte> Content { get; }
+
+    /// <summary>Gets what the page reads as <c>file.lastModified</c>.</summary>
+    public DateTimeOffset LastModified { get; }
+}

--- a/Jint.DevTools/Protocol/Generated/DOM.g.cs
+++ b/Jint.DevTools/Protocol/Generated/DOM.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/browser_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, DOM entries, sha256:c126f42f390d
+//     manifest: tools/devtools-protocol/manifest.json, DOM entries, sha256:a146c1dc0d57
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -2210,6 +2210,12 @@ namespace Jint.DevTools.Domains
                 case "setAttributesAsText":
                 {
                     var result = await SetAttributesAsTextAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.DOMSetAttributesAsTextRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "setFileInputFiles":
+                {
+                    var result = await SetFileInputFilesAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.DOMSetFileInputFilesRequest), context).ConfigureAwait(false);
                     return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
                 }
 

--- a/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:5a814e01293c
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:190c8fa59465
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and

--- a/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:5a814e01293c
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:190c8fa59465
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -127,6 +127,7 @@ namespace Jint.DevTools.Protocol
             "DOM.scrollIntoViewIfNeeded",
             "DOM.setAttributeValue",
             "DOM.setAttributesAsText",
+            "DOM.setFileInputFiles",
             "DOM.setNodeValue",
             "DOM.setOuterHTML",
             "Emulation.clearDeviceMetricsOverride",

--- a/Jint.Tests.Browser/DevTools/DomFileInputTests.cs
+++ b/Jint.Tests.Browser/DevTools/DomFileInputTests.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+
+namespace Jint.Tests.Browser.DevTools;
+
+/// <summary>
+/// <c>DOM.setFileInputFiles</c> over the real protocol — the command Playwright's <c>setInputFiles</c> and
+/// Puppeteer's <c>uploadFile</c> send.
+/// </summary>
+/// <remarks>
+/// These assert the envelope as text for the reason <c>DomDomainTests</c> gives, and they address the node
+/// by all three of the identifiers the command takes, because a client library picks a different one from
+/// the next: Puppeteer sends <c>objectId</c> and <c>backendNodeId</c> together, Playwright sends
+/// <c>objectId</c>, and a front end sends a <c>nodeId</c>.
+/// </remarks>
+[NonParallelizable]
+public sealed class DomFileInputTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "jint-dom-file-input-" + Guid.NewGuid().ToString("N"));
+
+    public DomFileInputTests() => Directory.CreateDirectory(_directory);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A temporary directory that outlives one test run is not a test failure.
+        }
+    }
+
+    [Test]
+    public async Task FilesReachThePageAsAFileListAndTheEventsAUserWouldCause()
+    {
+        var first = Write("greeting.txt", "hello from the protocol");
+        var second = Write("data.json", "{\"answer\":42}");
+
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await session.OpenPageAsync();
+        await Content(session, attachment, Markup);
+
+        var objectId = await ObjectIdAsync(session, attachment, "document.getElementById('upload')");
+
+        await session.ResultAsync(
+            "DOM.setFileInputFiles",
+            JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["objectId"] = objectId,
+                ["files"] = new[] { first, second },
+            }),
+            attachment);
+
+        var report = await session.EvaluateAsync(
+            """
+            (() => {
+              const input = document.getElementById('upload');
+              return [
+                input.files instanceof FileList,
+                input.files.length,
+                Array.from(input.files, f => f.name + '|' + f.type + '|' + f.size).join(';'),
+                input.value,
+                window.fileEvents.join(',')
+              ].join('#');
+            })()
+            """,
+            attachment);
+
+        report.GetProperty("value").GetString().Should().Be(
+            "true#2#greeting.txt|text/plain|23;data.json|application/json|13#"
+            + @"C:\fakepath\greeting.txt#input:upload:true,change:upload:true");
+    }
+
+    [Test]
+    public async Task ANodeIdAndABackendNodeIdAddressTheSameInput()
+    {
+        var path = Write("by-id.txt", "one");
+
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await session.OpenPageAsync();
+        await Content(session, attachment, Markup);
+        await session.ResultAsync("DOM.enable", "{}", attachment);
+
+        var objectId = await ObjectIdAsync(session, attachment, "document.getElementById('upload')");
+        var described = (await session.ResultAsync(
+            "DOM.describeNode", $$"""{"objectId":"{{objectId}}"}""", attachment)).GetProperty("node");
+        var backendNodeId = described.GetProperty("backendNodeId").GetInt32();
+
+        await session.ResultAsync(
+            "DOM.setFileInputFiles",
+            JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["backendNodeId"] = backendNodeId,
+                ["files"] = new[] { path },
+            }),
+            attachment);
+
+        (await NamesAsync(session, attachment)).Should().Be("by-id.txt");
+
+        var nodeId = (await session.ResultAsync(
+            "DOM.requestNode", $$"""{"objectId":"{{objectId}}"}""", attachment)).GetProperty("nodeId").GetInt32();
+
+        await session.ResultAsync(
+            "DOM.setFileInputFiles",
+            JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["nodeId"] = nodeId,
+                ["files"] = Array.Empty<string>(),
+            }),
+            attachment);
+
+        (await NamesAsync(session, attachment)).Should().BeEmpty("an empty list is a selection, and it clears the input");
+    }
+
+    [Test]
+    public async Task AnInputWithoutMultipleKeepsTheFirstFileOnly()
+    {
+        var first = Write("first.txt", "one");
+        var second = Write("second.txt", "two");
+
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await session.OpenPageAsync();
+        await Content(session, attachment, Markup);
+
+        await session.ResultAsync(
+            "DOM.setFileInputFiles",
+            JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["objectId"] = await ObjectIdAsync(session, attachment, "document.getElementById('single')"),
+                ["files"] = new[] { first, second },
+            }),
+            attachment);
+
+        (await session.EvaluateAsync(
+                "Array.from(document.getElementById('single').files, f => f.name).join(',')",
+                attachment))
+            .GetProperty("value").GetString().Should().Be("first.txt");
+    }
+
+    [Test]
+    public async Task ANodeThatIsNotAFileInputIsRefusedInChromesWording()
+    {
+        var path = Write("ignored.txt", "x");
+
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await session.OpenPageAsync();
+        await Content(session, attachment, Markup);
+
+        foreach (var expression in new[] { "document.getElementById('text')", "document.body" })
+        {
+            var error = await session.ErrorAsync(
+                "DOM.setFileInputFiles",
+                JsonSerializer.Serialize(new Dictionary<string, object>
+                {
+                    ["objectId"] = await ObjectIdAsync(session, attachment, expression),
+                    ["files"] = new[] { path },
+                }),
+                attachment);
+
+            error.GetProperty("message").GetString().Should().Be("Node is not a file input element");
+        }
+    }
+
+    [Test]
+    public async Task APathThatNamesNoFileIsRefusedAndTheSelectionStands()
+    {
+        var kept = Write("kept.txt", "kept");
+
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await session.OpenPageAsync();
+        await Content(session, attachment, Markup);
+
+        var objectId = await ObjectIdAsync(session, attachment, "document.getElementById('upload')");
+
+        await session.ResultAsync(
+            "DOM.setFileInputFiles",
+            JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["objectId"] = objectId,
+                ["files"] = new[] { kept },
+            }),
+            attachment);
+
+        var missing = Path.Combine(_directory, "absent.txt");
+        var error = await session.ErrorAsync(
+            "DOM.setFileInputFiles",
+            JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["objectId"] = objectId,
+                ["files"] = new[] { missing },
+            }),
+            attachment);
+
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+        error.GetProperty("message").GetString().Should().Be("Cannot read file " + missing);
+
+        (await NamesAsync(session, attachment)).Should().Be("kept.txt", "a failed read changes nothing");
+    }
+
+    [Test]
+    public async Task NoIdentifierAtAllIsRefusedTheWayEveryOtherDomCommandRefusesIt()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await session.OpenPageAsync();
+        await Content(session, attachment, Markup);
+
+        var error = await session.ErrorAsync("DOM.setFileInputFiles", """{"files":[]}""", attachment);
+
+        error.GetProperty("message").GetString()
+            .Should().Be("Either nodeId, backendNodeId or objectId must be specified");
+    }
+
+    /// <summary>A file input that takes many, one that takes one, and a control that is not one at all.</summary>
+    private const string Markup =
+        """
+        <input id='upload' type='file' multiple>
+        <input id='single' type='file'>
+        <input id='text'>
+        <script>
+          window.fileEvents = [];
+          for (const type of ['input', 'change']) {
+            document.body.addEventListener(type, event => {
+              window.fileEvents.push(type + ':' + event.target.id + ':' + event.bubbles);
+            });
+          }
+        </script>
+        """;
+
+    private static async Task Content(PageSession session, string attachment, string body)
+        => await session.ResultAsync(
+            "Page.setDocumentContent",
+            JsonSerializer.Serialize(new Dictionary<string, object> { ["frameId"] = "", ["html"] = body }),
+            attachment);
+
+    private static async Task<string> ObjectIdAsync(PageSession session, string attachment, string expression)
+    {
+        var result = await session.EvaluateAsync(expression, attachment, returnByValue: false);
+        return result.GetProperty("objectId").GetString()!;
+    }
+
+    private static async Task<string> NamesAsync(PageSession session, string attachment)
+        => (await session.EvaluateAsync(
+                "Array.from(document.getElementById('upload').files, f => f.name).join(',')",
+                attachment))
+            .GetProperty("value").GetString()!;
+
+    private string Write(string name, string content)
+    {
+        var path = Path.Combine(_directory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/Jint.Tests.Browser/Files/FileInputSelectionTests.cs
+++ b/Jint.Tests.Browser/Files/FileInputSelectionTests.cs
@@ -1,0 +1,268 @@
+using System.Text;
+using Jint.Browser;
+using Jint.Tests.Browser.Navigation;
+
+namespace Jint.Tests.Browser.Files;
+
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// HTML's File Upload state, driven from the host: <c>Page.SetInputFilesAsync</c>, the two events it fires,
+/// and what a submission builds out of the selection.
+/// </summary>
+/// <remarks>
+/// The page half of the same state is <see cref="FileTransferTests"/>, which sets <c>input.files</c> from a
+/// <c>DataTransfer</c>. Both end in one selection owned by one place, which is why these assert the same
+/// three observables: the <c>FileList</c>, <c>input.value</c>, and the entries a form is built from.
+/// </remarks>
+public sealed class FileInputSelectionTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "jint-file-input-" + Guid.NewGuid().ToString("N"));
+
+    public FileInputSelectionTests() => Directory.CreateDirectory(_directory);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A temporary directory that outlives one test run is not a test failure.
+        }
+    }
+
+    [Test]
+    public async Task SelectingHostFilesFillsTheFileListAndFiresInputThenChange()
+    {
+        var first = Write("greeting.txt", "hello from the host");
+        var second = Write("data.json", "{\"answer\":42}");
+
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Markup);
+
+        (await page.SetInputFilesAsync("#upload", new[] { first, second })).Should().BeTrue();
+
+        (await Report(page)).Should().Be(
+            "true#2#true#true#greeting.txt|text/plain|hello from the host;"
+            + "data.json|application/json|{\"answer\":42}#input:upload:true,change:upload:true");
+
+        // HTML's own answer for the value of a file input: a fake path, and only the first file's name.
+        (await page.EvaluateAsync<string>("document.getElementById('upload').value"))
+            .Should().Be(@"C:\fakepath\greeting.txt");
+    }
+
+    [Test]
+    public async Task TheTimestampIsTheFileSystemsAndTheTypeComesFromTheExtension()
+    {
+        var path = Write("notes.md", "# heading");
+        var modified = new DateTime(2021, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(path, modified);
+
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Markup);
+
+        await page.SetInputFilesAsync("#upload", new[] { path });
+
+        (await page.EvaluateAsync<string>(
+                "(() => { const f = document.getElementById('upload').files[0]; return [f.type, f.lastModified].join('|'); })()"))
+            .Should().Be(
+                "text/markdown|"
+                + new DateTimeOffset(modified).ToUnixTimeMilliseconds().ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Test]
+    public async Task AnInputWithoutMultipleTakesTheFirstFileAndNoMore()
+    {
+        var first = Write("first.txt", "one");
+        var second = Write("second.txt", "two");
+
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Markup);
+
+        (await page.SetInputFilesAsync("#single", new[] { first, second })).Should().BeTrue();
+
+        (await page.EvaluateAsync<string>(
+                "(() => { const files = document.getElementById('single').files; "
+                + "return [files.length, ...Array.from(files, f => f.name)].join(','); })()"))
+            .Should().Be("1,first.txt");
+    }
+
+    [Test]
+    public async Task SelectingNoFilesClearsTheSelectionAndStillFiresBothEvents()
+    {
+        var path = Write("gone.txt", "here");
+
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Markup);
+
+        await page.SetInputFilesAsync("#upload", new[] { path });
+        await page.EvaluateAsync("window.fileEvents = []");
+
+        (await page.SetInputFilesAsync("#upload", Array.Empty<string>())).Should().BeTrue();
+
+        (await page.EvaluateAsync<string>(
+                "(() => { const input = document.getElementById('upload'); "
+                + "return [input.files.length, input.value, window.fileEvents.join(',')].join('#'); })()"))
+            .Should().Be("0##input:upload:true,change:upload:true");
+    }
+
+    [Test]
+    public async Task FilesHeldInMemoryCarryTheirOwnNameTypeAndTimestamp()
+    {
+        var modified = new DateTimeOffset(2019, 7, 8, 9, 10, 11, TimeSpan.Zero);
+
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Markup);
+
+        (await page.SetInputFilesAsync(
+                "#upload",
+                new[]
+                {
+                    new PageFile("report.csv", "text/csv", Encoding.UTF8.GetBytes("a,b\n1,2"), modified),
+                })).Should().BeTrue();
+
+        (await page.EvaluateAndAwaitAsync<string>(
+                "(async () => { const f = document.getElementById('upload').files[0]; "
+                + "return [f.name, f.type, f.lastModified, await f.text()].join('|'); })()"))
+            .Should().Be(
+                "report.csv|text/csv|"
+                + modified.ToUnixTimeMilliseconds().ToString(System.Globalization.CultureInfo.InvariantCulture)
+                + "|a,b\n1,2");
+    }
+
+    [Test]
+    public async Task SomethingThatIsNotAFileInputIsAnAnswerRatherThanAFault()
+    {
+        var path = Write("ignored.txt", "x");
+
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Markup);
+
+        (await page.SetInputFilesAsync("#text", new[] { path })).Should().BeFalse("a text input is not a file input");
+        (await page.SetInputFilesAsync("#nothing-matches-this", new[] { path })).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task APathThatNamesNoFileThrowsAndLeavesTheSelectionAlone()
+    {
+        var path = Write("kept.txt", "kept");
+
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Markup);
+
+        await page.SetInputFilesAsync("#upload", new[] { path });
+
+        var act = () => page.SetInputFilesAsync("#upload", new[] { Path.Combine(_directory, "absent.txt") });
+
+        await act.Should().ThrowAsync<FileNotFoundException>();
+        (await page.EvaluateAsync<string>("document.getElementById('upload').files[0].name")).Should().Be("kept.txt");
+    }
+
+    [Test]
+    public async Task AFormDataCarriesOneEntryPerSelectedFileAndAnEmptyOneForNone()
+    {
+        var first = Write("one.txt", "one");
+        var second = Write("two.txt", "two");
+
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            """
+            <form id='f'>
+              <input id='upload' name='attachment' type='file' multiple>
+              <input id='empty' name='nothing' type='file'>
+            </form>
+            """);
+
+        await page.SetInputFilesAsync("#upload", new[] { first, second });
+
+        (await page.EvaluateAsync<string>(
+                "(() => { const data = new FormData(document.getElementById('f')); "
+                + "return data.getAll('attachment').map(f => f.name + ':' + f.size).join(',') + '#' "
+                + "+ data.getAll('nothing').map(f => [f.constructor.name, f.name, f.size, f.type].join('|')).join(','); })()"))
+            .Should().Be("one.txt:3,two.txt:3#File||0|application/octet-stream");
+    }
+
+    [Test]
+    public async Task AMultipartSubmissionCarriesTheFileNameTypeAndBytes()
+    {
+        var path = Write("upload.txt", "the bytes that were chosen");
+
+        await using var fixture = await LoopbackPage.CreateAsync(server => server
+            .Map("/echo", request => LoopbackResponse.Html(
+                "<title>echo</title><pre id='type'>" + (request.Header("Content-Type") ?? "") + "</pre>"
+                + "<pre id='body'>" + System.Net.WebUtility.HtmlEncode(request.Body) + "</pre>"))
+            .MapHtml(
+                "/form.html",
+                """
+                <form id='f' action='/echo' method='post' enctype='multipart/form-data'>
+                  <input id='upload' name='attachment' type='file'>
+                </form>
+                """));
+
+        await fixture.Page.NavigateAsync(fixture.Url("/form.html"));
+        await fixture.Page.SetInputFilesAsync("#upload", new[] { path });
+        (await fixture.Page.SubmitFormAsync("#f")).Should().NotBeNull();
+
+        (await fixture.Page.EvaluateAsync<string>("document.getElementById('type').textContent"))
+            .Should().StartWith("multipart/form-data; boundary=");
+
+        var body = await fixture.Page.EvaluateAsync<string>("document.getElementById('body').textContent");
+        body.Should().Contain("Content-Disposition: form-data; name=\"attachment\"; filename=\"upload.txt\"");
+        body.Should().Contain("Content-Type: text/plain");
+        body.Should().Contain("the bytes that were chosen");
+    }
+
+    /// <summary>One file input that takes many, one that takes one, one that is not a file input at all.</summary>
+    private const string Markup =
+        """
+        <input id='upload' type='file' multiple>
+        <input id='single' type='file'>
+        <input id='text'>
+        <script>
+          window.fileEvents = [];
+          for (const type of ['input', 'change']) {
+            document.body.addEventListener(type, event => {
+              window.fileEvents.push(type + ':' + event.target.id + ':' + event.bubbles);
+            });
+          }
+        </script>
+        """;
+
+    /// <summary>The same report the Playwright course asks for, so the two lanes assert one shape.</summary>
+    private static async Task<string?> Report(Page page)
+        => await page.EvaluateAndAwaitAsync<string>(
+            """
+            (async () => {
+              const files = document.getElementById('upload').files;
+              const details = await Promise.all(Array.from(files, async file =>
+                [file.name, file.type, await file.text()].join('|')));
+              return [
+                files instanceof FileList,
+                files.length,
+                files.item(0) === files[0],
+                files.item(files.length) === null,
+                details.join(';'),
+                window.fileEvents.join(',')
+              ].join('#');
+            })()
+            """);
+
+    private string Write(string name, string content)
+    {
+        var path = Path.Combine(_directory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/Jint.Tests.Browser/Mcp/BrowserToolsTests.cs
+++ b/Jint.Tests.Browser/Mcp/BrowserToolsTests.cs
@@ -37,7 +37,7 @@ public sealed class BrowserToolsTests
         names.Should().Contain([
             "navigate", "back", "forward", "reload",
             "snapshot",
-            "click", "fill", "type", "press", "select", "hover", "scroll",
+            "click", "fill", "type", "press", "select", "hover", "scroll", "upload",
             "evaluate", "wait_for", "network_requests", "cookies", "set_cookie", "close",
         ]);
 
@@ -313,10 +313,63 @@ public sealed class BrowserToolsTests
             .Single().Text.Should().Contain("# Welcome");
     }
 
+    [Test]
+    public async Task UploadIsRefusedUntilADeploymentNamesADirectoryToUploadFrom()
+    {
+        var directory = Directory.CreateTempSubdirectory("jint-mcp-upload-");
+
+        try
+        {
+            var inside = Path.Combine(directory.FullName, "receipt.txt");
+            await File.WriteAllTextAsync(inside, "the receipt");
+
+            // Off by default, and the refusal says what would turn it on rather than what went wrong.
+            await using (var closed = await McpFixture.CreateAsync(UploadRoutes))
+            {
+                await closed.CallAsync("navigate", ("url", closed.Url("/upload")));
+                var refused = await closed.CallAsync("upload", ("target", "#f"), ("paths", new[] { inside }));
+
+                refused.IsError.Should().BeTrue();
+                McpFixture.TextOf(refused).Should().Contain("BrowserAgentOptions.UploadDirectory");
+            }
+
+            await using var fixture = await McpFixture.CreateAsync(
+                UploadRoutes,
+                agent => agent.UploadDirectory = directory.FullName);
+
+            await fixture.CallAsync("navigate", ("url", fixture.Url("/upload")));
+
+            var chosen = JsonDocument.Parse(McpFixture.TextOf(
+                await fixture.CallAsync("upload", ("target", "#f"), ("paths", new[] { inside })))).RootElement;
+            chosen.GetProperty("done").GetBoolean().Should().BeTrue();
+
+            var files = await fixture.CallAsync(
+                "evaluate",
+                ("expression", "Array.from(document.getElementById('f').files, f => f.name + ':' + f.size).join(',')"));
+            McpFixture.TextOf(files).Should().Contain("receipt.txt:11");
+
+            // And a path outside the directory is refused even though the directory is now named.
+            var outside = await fixture.CallAsync(
+                "upload",
+                ("target", "#f"),
+                ("paths", new[] { Path.Combine(directory.FullName, "..", "elsewhere.txt") }));
+
+            outside.IsError.Should().BeTrue();
+            McpFixture.TextOf(outside).Should().Contain("outside");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
     private static void Routes(LoopbackServer server)
     {
         server.MapHtml("/", Home);
         server.MapHtml("/about", "<!doctype html><title>About</title><h1>About us</h1>");
         server.MapHtml("/search", "<!doctype html><title>Results</title><h1>Results</h1>");
     }
+
+    private static void UploadRoutes(LoopbackServer server)
+        => server.MapHtml("/upload", "<!doctype html><title>Upload</title><input id='f' type='file'>");
 }

--- a/Jint.Tests.Browser/Playwright/DirectPlaywrightTests.cs
+++ b/Jint.Tests.Browser/Playwright/DirectPlaywrightTests.cs
@@ -427,6 +427,92 @@ public sealed class DirectPlaywrightTests
     }
 
     [Test]
+    public async Task SetInputFilesTakesPathsPayloadsAndBothSelectorForms()
+    {
+        var directory = Directory.CreateTempSubdirectory("jint-playwright-files-");
+
+        try
+        {
+            var path = Path.Combine(directory.FullName, "from-disk.txt");
+            await File.WriteAllTextAsync(path, "read from a path");
+
+            await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+            var page = await browser.NewPageAsync();
+            await page.SetContentAsync(
+                "<input id='upload' type='file' multiple><input id='single' type='file'>");
+
+            // A path, through the locator.
+            await page.Locator("#upload").SetInputFilesAsync(path);
+            (await Names(page, "#upload")).Should().Be("from-disk.txt");
+
+            // Payloads, through the locator — the form Playwright's own client uses for in-memory content.
+            await page.Locator("#upload").SetInputFilesAsync(
+            [
+                new FilePayload { Name = "a.txt", MimeType = "text/plain", Buffer = "one"u8.ToArray() },
+                new FilePayload { Name = "b.json", MimeType = "application/json", Buffer = "{}"u8.ToArray() },
+            ]);
+            (await Names(page, "#upload")).Should().Be("a.txt,b.json");
+
+            // And the selector forms on the page and the frame, which route to the same place.
+            await page.SetInputFilesAsync("#upload", new[] { path });
+            (await Names(page, "#upload")).Should().Be("from-disk.txt");
+
+            await page.MainFrame.SetInputFilesAsync(
+                "#upload",
+                new FilePayload { Name = "c.csv", MimeType = "text/csv", Buffer = "x"u8.ToArray() });
+            (await Names(page, "#upload")).Should().Be("c.csv");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task SetInputFilesRefusesMoreThanOneFileForAnInputWithoutMultiple()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<input id='single' type='file'>");
+
+        var act = async () => await page.Locator("#single").SetInputFilesAsync(
+        [
+            new FilePayload { Name = "a.txt", MimeType = "text/plain", Buffer = "one"u8.ToArray() },
+            new FilePayload { Name = "b.txt", MimeType = "text/plain", Buffer = "two"u8.ToArray() },
+        ]);
+
+        // Playwright's own client wording. The model underneath would drop the second file, which is what
+        // HTML says a user agent must do — and is exactly the silently wrong answer this adapter refuses.
+        await act.Should().ThrowAsync<PlaywrightException>().WithMessage("*Non-multiple file input*");
+        (await Names(page, "#single")).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task SetInputFilesFailsLoudlyForSomethingThatIsNotAFileInput()
+    {
+        await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync("<input id='text'>");
+
+        var wrongKind = async () => await page.Locator("#text").SetInputFilesAsync(
+            new FilePayload { Name = "a.txt", MimeType = "text/plain", Buffer = "one"u8.ToArray() });
+        await wrongKind.Should().ThrowAsync<PlaywrightException>().WithMessage("*file input*");
+
+        // The only option either overload honours is Timeout, and anything else is refused rather than
+        // dropped: a Strict that did nothing would make a strictness test pass without strictness.
+        var unsupportedOption = async () => await page.SetInputFilesAsync(
+            "#text",
+            "a.txt",
+            new PageSetInputFilesOptions { Strict = true });
+        await unsupportedOption.Should().ThrowAsync<NotSupportedException>()
+            .WithMessage("*PageSetInputFilesOptions.Strict*");
+    }
+
+    private static async Task<string> Names(IPage page, string selector)
+        => await page.EvaluateAsync<string>(
+            $"() => Array.from(document.querySelector('{selector}').files, f => f.name).join(',')");
+
+    [Test]
     public async Task UnsupportedOperationsNameThePlaywrightMember()
     {
         await using var browser = await global::Jint.Browser.Playwright.JintPlaywright.BrowserType.LaunchAsync();

--- a/Jint.Tests.Browser/Verify/McpPublicApiTest.verified.txt
+++ b/Jint.Tests.Browser/Verify/McpPublicApiTest.verified.txt
@@ -29,6 +29,7 @@ namespace Jint.Browser.Mcp
         public System.Threading.Tasks.Task<Jint.Browser.Mcp.ActionOutcome> SetCookieAsync(string name, string value, string? url = null) { }
         public System.Threading.Tasks.Task<Jint.Browser.Mcp.PageSnapshot> SnapshotAsync(string? mode = null, bool mainContentOnly = false, int? maxLength = default) { }
         public System.Threading.Tasks.Task<Jint.Browser.Mcp.ActionOutcome> TypeAsync(string target, string text) { }
+        public System.Threading.Tasks.Task<Jint.Browser.Mcp.ActionOutcome> UploadAsync(string target, System.Collections.Generic.IReadOnlyList<string> paths) { }
         public System.Threading.Tasks.Task<Jint.Browser.Mcp.ActionOutcome> WaitForAsync(string? selector = null, string? text = null, double? timeoutSeconds = default) { }
     }
     public sealed class BrowserAgentOptions
@@ -40,6 +41,7 @@ namespace Jint.Browser.Mcp
         public long? MemoryLimit { get; set; }
         public System.TimeSpan Timeout { get; set; }
         public bool Trusted { get; set; }
+        public string? UploadDirectory { get; set; }
         public System.Func<System.Uri, bool>? UrlFilter { get; set; }
         public string? UserAgent { get; set; }
     }
@@ -152,6 +154,16 @@ renders nothing.")]
             " there. The page sees every keystroke, which is what a search box with live sugg" +
             "estions is waiting for.")]
         public System.Threading.Tasks.Task<ModelContextProtocol.Protocol.CallToolResult> TypeAsync([System.ComponentModel.Description("A ref= value from an ax snapshot, or a CSS selector.")] string target, [System.ComponentModel.Description("The characters to type.")] string text) { }
+        [ModelContextProtocol.Server.McpServerTool(Name="upload", Title="Choose files for a file input")]
+        [System.ComponentModel.Description(@"Chooses files from this machine for a file upload field — an <input type=file> — exactly as picking
+them in the file dialog would: the page sees a FileList, its input and change handlers run, and
+submitting the form sends the bytes. Clicking a file input does nothing, so this is the only way to
+fill one; use fill for a text field.
+Files can only be read from the one directory this server was started with, and the tool answers an
+error naming that restriction when the deployment allowed none — that is a configuration decision,
+not something to work around by another route.")]
+        public System.Threading.Tasks.Task<ModelContextProtocol.Protocol.CallToolResult> UploadAsync([System.ComponentModel.Description("A ref= value from an ax snapshot, or a CSS selector naming the <input type=file>.")] string target, [System.ComponentModel.Description("Paths of the files to choose, in order, inside the directory this server uploads " +
+            "from.")] string[] paths) { }
         [ModelContextProtocol.Server.McpServerTool(Name="wait_for", ReadOnly=true, Title="Wait for the page to change")]
         [System.ComponentModel.Description("Waits until an element matching a CSS selector is in the page, or until some text" +
             " appears in it. Use it after an action that starts something the page finishes l" +

--- a/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
+++ b/Jint.Tests.Browser/Verify/PublicApiTest.verified.txt
@@ -144,6 +144,10 @@ namespace Jint.Browser
         public System.Threading.Tasks.Task<bool> SelectAsync(string target, string value) { }
         public System.Threading.Tasks.Task<bool> SelectAsync(string target, int index, string value) { }
         public System.Threading.Tasks.Task SetContentAsync(string html, string? baseUrl = null) { }
+        public System.Threading.Tasks.Task<bool> SetInputFilesAsync(string target, System.Collections.Generic.IReadOnlyList<Jint.Browser.PageFile> files) { }
+        public System.Threading.Tasks.Task<bool> SetInputFilesAsync(string target, System.Collections.Generic.IReadOnlyList<string> paths) { }
+        public System.Threading.Tasks.Task<bool> SetInputFilesAsync(string target, int index, System.Collections.Generic.IReadOnlyList<Jint.Browser.PageFile> files) { }
+        public System.Threading.Tasks.Task<bool> SetInputFilesAsync(string target, int index, System.Collections.Generic.IReadOnlyList<string> paths) { }
         public System.Threading.Tasks.Task<Jint.Browser.PageResponse?> SubmitFormAsync(string selector, Jint.Browser.NavigationOptions? options = null) { }
         public System.Threading.Tasks.Task<string> TextAsync(bool mainContentOnly = false, int maxLength = 0) { }
         public System.Threading.Tasks.Task<string> TitleAsync() { }
@@ -174,6 +178,14 @@ namespace Jint.Browser
         WorkerError = 3,
         ScriptError = 4,
         BudgetExceeded = 5,
+    }
+    public sealed class PageFile
+    {
+        public PageFile(string name, string mimeType, System.ReadOnlyMemory<byte> content, System.DateTimeOffset? lastModified = default) { }
+        public System.ReadOnlyMemory<byte> Content { get; }
+        public System.DateTimeOffset LastModified { get; }
+        public string MimeType { get; }
+        public string Name { get; }
     }
     public readonly struct PageHeader : System.IEquatable<Jint.Browser.PageHeader>
     {

--- a/docs/packages/jint-browser/devtools.md
+++ b/docs/packages/jint-browser/devtools.md
@@ -18,6 +18,8 @@ Puppeteer and Playwright attach with their **connect** APIs, not launch APIs. Ex
 
 The implementation covers the page, DOM, input, network, fetch interception, storage, accessibility, and selected emulation paths needed by supported clients. Unsupported protocol commands report protocol errors rather than silently succeeding.
 
+`DOM.setFileInputFiles` — the command behind Playwright's `setInputFiles` and Puppeteer's `uploadFile` — selects files by path on the machine the server is running on. The bytes are read when the command runs, so the page keeps them whatever happens to the file afterwards, and a path that names no readable file is a protocol error rather than an empty selection.
+
 With `Fetch.enable`'s `handleAuthRequests`, a `401` pauses as `Fetch.authRequired`, and
 `Fetch.continueWithAuth` answers it. Basic credentials are supported; other schemes are reported and
 credentials offered for them are refused with an error naming the scheme.

--- a/docs/packages/jint-browser/input-and-forms.md
+++ b/docs/packages/jint-browser/input-and-forms.md
@@ -8,6 +8,7 @@ await page.TypeAsync("#search", "jint");
 await page.PressAsync("Enter");
 await page.ClickAsync("#save");
 await page.SelectAsync("#country", "FR");
+await page.SetInputFilesAsync("#avatar", ["/tmp/portrait.png"]);
 await page.HoverAsync("#menu");
 await page.ScrollToAsync(800);
 ```
@@ -26,6 +27,7 @@ References belong to one document and stop resolving after navigation.
 - `PressAsync` targets the focused element, or the body when nothing is focused.
 - `ClickAsync` scrolls the target into view and runs link, button, checkbox, radio, label, summary, and option activation.
 - `SelectAsync` matches an option by value, then by visible text, and fires `input` followed by `change`.
+- `SetInputFilesAsync` selects files into an `<input type=file>`, which is what a file picker would do and what clicking one cannot: the files are read into memory, `input.files` becomes a `FileList`, `input.value` becomes a fake Windows path plus the first name, and `input` then `change` fire. An overload takes `PageFile` values for content that has no path. An input without `multiple` keeps only the first file, and passing no files clears the selection.
 
 Methods that name an element return `false` when no suitable target exists.
 

--- a/docs/packages/jint-browser/limitations.md
+++ b/docs/packages/jint-browser/limitations.md
@@ -9,6 +9,7 @@
 - Child-frame documents can be fetched and parsed, but do not have a script realm. `contentWindow` is `null`.
 - No IndexedDB, Cache Storage integration for page origins, WebAssembly, CSP enforcement, SharedWorker, or ServiceWorker.
 - No drag and drop, clipboard API, touch event dispatch, or native input.
+- No file picker: clicking an `<input type=file>` records that a page asked for one. `Page.SetInputFilesAsync` and `DOM.setFileInputFiles` make the selection instead.
 - Hover dispatches movement but not mouse boundary events such as `mouseenter`.
 - `contenteditable` support is intentionally limited; structural editing such as Enter-created blocks is absent.
 - Isolated CDP worlds are aliases, not isolated realms.

--- a/tools/devtools-protocol/manifest.json
+++ b/tools/devtools-protocol/manifest.json
@@ -278,6 +278,7 @@
     "DOM.scrollIntoViewIfNeeded",
     "DOM.setAttributeValue",
     "DOM.setAttributesAsText",
+    "DOM.setFileInputFiles",
     "DOM.setNodeValue",
     "DOM.setOuterHTML",
     "Emulation.clearDeviceMetricsOverride",


### PR DESCRIPTION
## What and why

Clicking an `<input type=file>` opened a picker nobody could answer: the activation behaviour recorded that a page had asked for one and the selection never moved. The `FileList`, the drag data store and the entry-list rules were already here — a page script could reach them through `input.files = transfer.files` — but a **host**, a **protocol client** and the **Playwright adapter** had no way in at all, so `DOM.setFileInputFiles`, `Page.SetInputFilesAsync` and `setInputFiles` were all missing.

This adds the file-selection model behind them and the three entry points onto it.

## Mechanism

**`Jint.Browser/Dom/Files/FileSelection` is the one algorithm all three run.** It is HTML's [update the file selection](https://html.spec.whatwg.org/multipage/input.html#update-the-file-selection): build the engine's own `File` values, hand them to `FileTransferRealm` — the single owner of a selection, which mirrors it into AngleSharp so `input.value` and constraint validation agree with the `FileList` — then fire `input` and `change`, both trusted and bubbling.

Four decisions in it are arguments rather than accidents, and each is stated in the code:

- **The events are fired, not queued.** HTML queues an element task because a picker is asynchronous UI finishing on some later turn. Here the caller *is* a turn of the page loop — a protocol command, a mailbox request — so this call is that task. Queueing a second one would only mean a client could be told a command succeeded before the page had heard about it.
- **An input without `multiple` keeps the first file and drops the rest.** [HTML](https://html.spec.whatwg.org/multipage/input.html#attr-input-multiple): "if the attribute is not specified, the user agent must not allow the user to select more than one file". Blink's `FileInputType::SetFilesFromPaths` takes the first path the same way, and Playwright refuses the call in its own client before one is ever sent.
- **An empty selection clears the input and still fires both events.** The algorithm has no "did it change" step. Blink returns early instead, which is the behaviour Puppeteer's `uploadFile` works around by *not sending the command at all* for an empty list — so this is a divergence in the direction no client can be broken by.
- **A file is bytes, not a handle.** There is no renderer process to pass a file descriptor to, so a selected file is a `Blob` over memory the engine owns and the read happens at selection time. A page may read it long after the file has changed or gone.

**The command.** [`DOM.setFileInputFiles`](https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-setFileInputFiles) resolves `nodeId` / `backendNodeId` / `objectId` exactly as its neighbours in `DomDomain` do, and answers Chrome's own `Node is not a file input element` for anything else (`inspector_dom_agent.cc`). It reads every path **before** it changes anything, so a path that names no readable file is `-32000` naming that path and the previous selection stands. Chrome has no wording for that failure because Chrome never opens the file at this point. Added through the manifest and regenerated, per `Jint.DevTools/AGENTS.md`.

**The page API.** `Page.SetInputFilesAsync(target, paths)` reads the files **off** the loop, so a slow disk does not spend the page's own turn budget, and `Page.SetInputFilesAsync(target, IReadOnlyList<PageFile>)` takes content that has no path. Both answer `false` — rather than throwing — when the target matches nothing or is not a file input, which is the rule every other `Page` input member follows.

**The Playwright adapter.** `SetInputFilesAsync` on `ILocator`, `IPage` and `IFrame`, in all four argument forms (a path, paths, a `FilePayload`, payloads), routed through the model rather than through CDP. The page and frame forms build a locator instead of duplicating it. Two behaviours are deliberate: the wait stops at **attached** rather than visible, because a file input is usually `display: none` behind a styled `<label>`; and more than one file for a non-multiple input **throws** in Playwright's own words, because a caller of that interface is written against a client that throws and reporting success with one of its two files selected is the silent wrong answer `Jint.Browser.Playwright/AGENTS.md` exists to forbid. `IElementHandle` has no target class in this adapter at all, so there was nothing to add there.

**MCP.** `upload(target, paths)` is added, and it is the **one tool that can move data outwards** — every other tool gives a page only what that page already had, while an upload gives a site the model chose a file from the host, and a model reading a page is a model that page can try to instruct. So it is gated on a new `BrowserAgentOptions.UploadDirectory`, `null` by default, which refuses every upload with a sentence naming what would enable it. The containment check runs **before** the existence check — otherwise the refusal wording is a way of asking whether a file outside the directory exists — and a symbolic link is resolved to its final target and checked again.

## Failing-first evidence

`Jint.Tests.Browser/DevTools/DomFileInputTests` (6 cases, driven over the real protocol) was copied into a detached worktree at `upstream/main` and run there:

```
Failed AnInputWithoutMultipleKeepsTheFirstFileOnly
  Expected ... to be False because 'DOM.setFileInputFiles' was expected to succeed, and it answered
  {"code":-32601,"message":"'DOM.setFileInputFiles' wasn't found"}
...
Failed!  - Failed: 6, Passed: 0, Skipped: 0, Total: 6
```

All six pass on this branch. The model, adapter and MCP tests exercise API that does not exist on `main`, so their failing-first form is that they do not compile there — the protocol suite is what pins the behaviour from outside the package.

## What was verified

Release only, never `--no-build`, `TreatWarningsAsErrors` on.

| Command | Result |
| --- | --- |
| `dotnet build -c Release` (whole solution) | succeeded, 0 errors |
| `dotnet test Jint.Tests.Browser -c Release` | net8.0 **2406** passed / 38 skipped, net10.0 **2410** passed / 38 skipped, 0 failed |
| `dotnet test Jint.Tests.DevTools -c Release` | net8.0 **413** passed, net10.0 **415** passed, 0 failed |
| `dotnet test Jint.Tests -c Release` filtered to `AgentInstructionFileTests`, `MigrationGuideTests`, `SpecCitationTests` | 11 passed |

New and changed tests: `Jint.Tests.Browser/DevTools/DomFileInputTests` (6), `Jint.Tests.Browser/Files/FileInputSelectionTests` (9 — the `FileList`, the value, the event order, the extension-derived type and the file-system timestamp, the non-multiple rule, clearing, the missing-path fault, `new FormData(form)` entries including HTML's empty `File` for a control with no selection, and a real `multipart/form-data` submission read back off a loopback server), three cases in `DirectPlaywrightTests`, one in `Mcp/BrowserToolsTests`. The two public-API baselines (`PublicApiTest.verified.txt`, `McpPublicApiTest.verified.txt`) were regenerated and their diff is exactly the four `SetInputFilesAsync` overloads, `PageFile`, `UploadAsync` and `UploadDirectory`.

`GeneratedProtocolIsCurrentTests` and both manifest suites pass with the regenerated protocol; only `DOM.g.cs` (one dispatch `case`), `ProtocolManifest.g.cs` and the two digest headers moved.

## What was deliberately left out

- **No web-platform-tests were vendored.** `grep` over `Jint.Tests/Wpt/Vendor` for `type=file` and `setFileInputFiles` finds no document, so there was nothing in the corpus to un-exclude. Vendoring new documents needs an upstream checkout and a census regeneration, which is its own change. **`WptBrowserExclusions.cs`, `Wpt/README.md` and `Dom/divergences.md` are untouched**, so this cannot conflict with the other branches editing them.
- **No entry in `docs/guide/migrating-to-v5.md`.** Section 5.26 of that document states the rule for these packages: they are additive, outside the engine's compatibility contract, and the one member it records is there because it changed *after* the package's first release. The package documentation is the reference instead, and `docs/packages/jint-browser/{input-and-forms,devtools,limitations}.md` and both package READMEs are updated. Say the word if you would rather have a 5.35 as well.
- **No budget on the bytes a selection holds.** A file becomes memory the page owns, and there is no `BrowserOptions` figure for it. The DevTools client and the host both choose the paths themselves, and the MCP surface — the only one an untrusted party can steer — is behind the directory gate above. Worth revisiting if a page-level allowance is ever wanted.
- **No `Page.setInterceptFileChooserDialog` / `Page.fileChooserOpened`.** `BrowserActivationHost.OpenFileChooser` is still the seam it names, and this change does not move it; that command pair is a separate protocol surface.
- **`input.files = …` still fires no events**, because the `files` setter in HTML has no event steps — only "update the file selection" does. Playwright's own payload path dispatches them from its injected script, which is why `PlaywrightCanSetMultipleInputFiles` already observed them.

## Upstream findings

- `AngleSharp.Io.MimeTypeNames.FromExtension` answers `application/octet-stream` for `.json`, `.csv` and `.md` — three of the commonest things a form uploads. It is a convenience table rather than a specification algorithm (there is no standard extension-to-type mapping; a browser asks the platform), so the three IANA registrations are supplied in `FileSelection.TypeOf` and this is **not** recorded in `Dom/divergences.md`. Noted here rather than worked around silently, per the package's principle.
- Nothing else: no AngleSharp DOM behaviour was worked around in this change.

## Base

Rebased onto `upstream/main` at `8ea3bd236978b75f90d2543a21b4bcf84a774fea`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
