### PR TITLE
CSS rule-usage coverage, which is what page.coverage.startCSSCoverage() is

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -64,6 +64,12 @@ exist. That register's `getComputedStyle` row points back at this table.
 | a longhand nothing declared, through `getComputedStyle` | CSSOM's *resolved value*: every supported longhand answers, and a property nothing declared answers its initial value | the empty string, which read every element of every page as hidden to an automation client (`style.visibility !== "visible"` is where Playwright's actionability check ends). `Dom/Views/ResolvedStyle` is the exception this bought — **ten** properties, and it argues which ten. Everything else is still the declared cascade, a declaration always wins, and `length`/`item(i)` stay the declared set |
 | a relative length through `getComputedStyle` | the used value in `px` for `width`/`height`, resolved against the containing block; the percentage *kept* in the computed value of `min-width`, a margin and a padding | `px` against the **viewport** for every one of them, and against its *width* whichever axis the property is on — so `height: 50%` is half the window's width. `Runtime/PageRenderDevice` is the device that makes any of it computable: with none registered AngleSharp.Css raises `ArgumentException` rather than skipping the declaration, and one `width: 100%` rule took `getComputedStyle` **and every box query** down with it ([#3730](https://github.com/sebastienros/jint/issues/3730)). `ch` and `ex` have no conversion at all and still raise, which is why `Dom/Views/CssCascade` is the one guarded door all four callers come through |
 
+**That door is also where rule-usage coverage is recorded.** `Dom/Views/CssRuleUsage` is a static arming
+switch every cascade computation reads — a volatile array read and a length test with nothing armed — and
+the `CSS` domain's `startRuleUsageTracking` is what arms it
+([`DevTools/AGENTS.md`](DevTools/AGENTS.md)). Adding a fifth caller of the cascade adds a fifth place a
+client's coverage hears from; removing one silently narrows what "used" means.
+
 ### DOM §7's XPath, and CSSOM's `CSS`
 
 Two surfaces neither pinned assembly declares, so neither could be generated: there is no

--- a/Jint.Browser/DevTools/AGENTS.md
+++ b/Jint.Browser/DevTools/AGENTS.md
@@ -142,10 +142,40 @@ target/runtime split and the manifest are there and none of it is repeated here.
   domain's `backendNodeId` on every node — which is what makes a node a client found by role one it can then
   measure and click. It is computed per request and never maintained, which is why `loadComplete` and
   `nodesUpdated` are not emitted: an event stream would promise that the answer is being watched.
-- **`Security`, `Overlay` and `CSS` answer what a front end sends while attaching and nothing more.** `CSS`
-  has the two reads AngleSharp.Css can stand behind and every editing command is `-32601`; `Overlay` would
-  draw on a surface that does not exist; `Security` has no certificate decision to report, the transport
-  being the host's own `HttpClient`.
+- **`Security` and `Overlay` answer what a front end sends while attaching and nothing more.** `Overlay`
+  would draw on a surface that does not exist; `Security` has no certificate decision to report, the
+  transport being the host's own `HttpClient`.
+- **`CSS` is two reads and a coverage run, and every editing command is still `-32601`.**
+  `getComputedStyleForNode` and `getInlineStylesForNode` are what AngleSharp.Css can stand behind;
+  `startRuleUsageTracking`, `takeCoverageDelta` and `stopRuleUsageTracking` — with `styleSheetAdded` and
+  `getStyleSheetText`, which are the rest of what a coverage client sends — are
+  `page.coverage.startCSSCoverage()`. Four things about them are decisions:
+  - **A rule is used when it matched an element in a cascade computation.** `Dom/Views/CssRuleUsage` is the
+    seam and `Dom/Views/CssCascade` is where it sits, so every `getComputedStyle`, every box the flat model
+    measures and this domain's own computed style feed it. It is armed only while a window is open — a
+    process-wide array, a volatile read and a length test — so a page nobody is tracking pays what a page
+    with no `Network` client pays. **The matching is done again rather than read off the cascade**: nothing
+    in AngleSharp.Css reports which rules produced a computed declaration, which is the upstream finding
+    behind this whole shape. The window matches only the rules it has not already recorded, over
+    `IWindow.GetStyleCollection`'s own flattened, condition-filtered list — so a rule inside an `@media` or
+    `@supports` that holds counts on its own, one inside a group that does not is never a candidate, and a
+    rule that matched once is not recorded twice.
+  - **Starting a window walks the document once, and so does a commit.** Blink's `startRuleUsageTracking`
+    marks every element for style recalculation and runs it before returning; nothing renders here, so a
+    document nobody queries would otherwise yield an empty report. That sweep is selector matching and no
+    value computation.
+  - **The offsets index the text this domain hands out and no other string.** AngleSharp keeps a sheet's
+    authored text (`IStyleSheet.Source`) but no source position on any rule, so a range into the authored
+    bytes cannot be computed at all. `CssStyleSheetText` serializes the sheet and measures that same
+    serialization, which is what `getStyleSheetText` answers with — one rule per line, two spaces of
+    nesting, an LF line break everywhere — so two platforms report the same offsets, and a client
+    slicing the text it was given gets the rule it was told about.
+  - **Sheets are reconciled when a client asks, not watched.** AngleSharp raises no notification when a
+    sheet joins or leaves a document, so `CssStyleSheetTracker` mints identifiers — a document's, shared by
+    every attachment, exactly as `DomNodeTracker` mints a `nodeId` — and `styleSheetAdded` is emitted at
+    `enable`, at each commit, and before any command that hands out an offset. `styleSheetChanged` and
+    `styleSheetRemoved` are absent for the same reason, and their absence is what a client cannot notice:
+    it can cache a text that a page has since edited.
 
 `Jint.Tests.Browser/DevTools/` holds two handshake replays — every *method* four recorded clients sent, and
 every parameter **shape** they sent it with, the second built out of each call's own `paramsKeys` and typed

--- a/Jint.Browser/DevTools/CssDomain.Coverage.cs
+++ b/Jint.Browser/DevTools/CssDomain.Coverage.cs
@@ -1,0 +1,331 @@
+using AngleSharp.Css.Dom;
+using AngleSharp.Dom;
+using Jint.Browser.Dom.Views;
+using Jint.Browser.Runtime;
+using Jint.DevTools;
+using Jint.DevTools.Domains;
+using Jint.DevTools.Protocol;
+using Jint.DevTools.Session;
+using ProtocolCss = Jint.DevTools.Protocol.CSS;
+
+namespace Jint.Browser.DevTools;
+
+/// <summary>
+/// Rule-usage coverage: which of a page's style rules matched something while a client was watching.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This is what <c>page.coverage.startCSSCoverage()</c> is.</b> Puppeteer and Playwright both build it
+/// out of exactly five calls — <c>DOM.enable</c>, <c>CSS.enable</c>, <c>CSS.startRuleUsageTracking</c>, the
+/// <c>CSS.styleSheetAdded</c> stream with a <c>CSS.getStyleSheetText</c> per sheet, and finally
+/// <c>CSS.stopRuleUsageTracking</c> — and then slice each sheet's text with the offsets the last one
+/// carries. All five are here; nothing else of the domain's thirty-odd editing commands is.
+/// </para>
+/// <para>
+/// <b>Used means matched during a cascade computation.</b> <see cref="CssRuleUsage"/> is the seam, armed
+/// only while a window is open, and every caller of <c>Dom/Views/CssCascade</c> feeds it: the page's own
+/// <c>getComputedStyle</c>, every box the flat model measures, the accessibility tree's hidden verdict and
+/// this domain's own <c>getComputedStyleForNode</c>. There is no rendering here to recalculate style for,
+/// so a document nobody queries computes no cascade — which is why
+/// <see cref="StartRuleUsageTrackingAsync"/> and a commit each walk the document once, the way Blink's own
+/// <c>startRuleUsageTracking</c> marks every element for style recalculation and runs it before returning.
+/// </para>
+/// <para>
+/// <b>The offsets index the text this domain hands out and no other string.</b>
+/// <see cref="CssStyleSheetText"/> serializes a sheet and measures the same serialization, because
+/// AngleSharp keeps no source position on a rule; what that costs a client is stated on that type.
+/// </para>
+/// <para>
+/// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-startRuleUsageTracking"/>,
+/// <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-takeCoverageDelta"/> and
+/// <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-stopRuleUsageTracking"/>.
+/// </para>
+/// </remarks>
+internal sealed partial class CssDomain : IDetachableDomain, ITargetObserver
+{
+    private readonly HashSet<string> _announced = new(StringComparer.Ordinal);
+
+    private CssRuleUsageTracker? _coverage;
+
+    private CssStyleSheetTracker Sheets => _target.Sheets;
+
+    /// <inheritdoc/>
+    void IDetachableDomain.Detach()
+    {
+        Sheets.Remove(this);
+        StopTracking();
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A navigation throws every <c>styleSheetId</c> away with the document that minted them — the target
+    /// clears the table once, for every attachment — so this forgets what it has announced. The window
+    /// itself survives, unbound, because coverage is the client's rather than the document's; the commit
+    /// that follows rebinds and sweeps it.
+    /// </remarks>
+    void ITargetObserver.RuntimeReplaced(TargetRuntime runtime)
+    {
+        _announced.Clear();
+        _coverage?.Rebind(null);
+    }
+
+    /// <summary>Announces the new document's sheets, and gives an open window its first look at it.</summary>
+    /// <remarks>
+    /// Called from <see cref="PageTarget"/> at <c>DocumentParsed</c>, which is the first moment there is a
+    /// tree to read sheets off — <c>RuntimeReplaced</c> runs before the parse, where the document has none.
+    /// </remarks>
+    internal void DocumentCommitted(PageRuntime runtime)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        foreach (var header in Unannounced(runtime))
+        {
+            EmitDetached(CSSEvents.StyleSheetAdded(new ProtocolCss.StyleSheetAddedEvent { Header = header }));
+        }
+
+        if (_coverage is { } coverage && runtime.Document is { } document)
+        {
+            coverage.Rebind(document);
+            coverage.Sweep();
+        }
+    }
+
+    /// <summary>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-getStyleSheetText — one sheet's
+    /// text, which is the string a coverage offset indexes.
+    /// </summary>
+    protected override async ValueTask<ProtocolCss.GetStyleSheetTextResponse> GetStyleSheetTextAsync(
+        ProtocolCss.GetStyleSheetTextRequest parameters,
+        CommandContext context)
+    {
+        await AnnounceAsync(context).ConfigureAwait(false);
+
+        var sheet = Sheets.ById(parameters.StyleSheetId)
+            ?? Throw.ServerError<ICssStyleSheet>("No style sheet with given id found");
+
+        return new ProtocolCss.GetStyleSheetTextResponse { Text = CssStyleSheetText.Of(sheet).Text };
+    }
+
+    /// <summary>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-startRuleUsageTracking — opens a
+    /// window, and walks the document once so that it describes the page as it stands.
+    /// </summary>
+    /// <remarks>
+    /// The protocol gives this command no return values, so the reply is empty: the timestamp a client
+    /// reads a window's start from is the one <c>takeCoverageDelta</c> answers with. Starting a second time
+    /// replaces the window rather than failing, which is what re-arming a coverage run means.
+    /// </remarks>
+    protected override async ValueTask<EmptyResult> StartRuleUsageTrackingAsync(
+        EmptyParameters parameters,
+        CommandContext context)
+    {
+        await AnnounceAsync(context).ConfigureAwait(false);
+
+        StopTracking();
+
+        var coverage = new CssRuleUsageTracker();
+        coverage.Rebind(Document());
+        _coverage = coverage;
+        CssRuleUsage.Arm(coverage);
+        coverage.Sweep();
+
+        return EmptyResult.Instance;
+    }
+
+    /// <summary>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-takeCoverageDelta — the rules
+    /// that became used since the last one.
+    /// </summary>
+    protected override async ValueTask<ProtocolCss.TakeCoverageDeltaResponse> TakeCoverageDeltaAsync(
+        EmptyParameters parameters,
+        CommandContext context)
+    {
+        var coverage = Tracking();
+        await AnnounceAsync(context).ConfigureAwait(false);
+
+        return new ProtocolCss.TakeCoverageDeltaResponse
+        {
+            Coverage = Report(coverage.TakeDelta()),
+            Timestamp = DevToolsTarget.UnixMilliseconds() / 1000d,
+        };
+    }
+
+    /// <summary>
+    /// https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-stopRuleUsageTracking — the rest
+    /// of the window, and the seam disarmed.
+    /// </summary>
+    /// <remarks>
+    /// Chrome's own implementation is a <c>takeCoverageDelta</c> followed by turning the tracker off, so a
+    /// client that took a delta and then stopped is told about the rules used in between and about nothing
+    /// twice.
+    /// </remarks>
+    protected override async ValueTask<ProtocolCss.StopRuleUsageTrackingResponse> StopRuleUsageTrackingAsync(
+        EmptyParameters parameters,
+        CommandContext context)
+    {
+        var coverage = Tracking();
+        await AnnounceAsync(context).ConfigureAwait(false);
+
+        var usage = Report(coverage.TakeDelta());
+        StopTracking();
+
+        return new ProtocolCss.StopRuleUsageTrackingResponse { RuleUsage = usage };
+    }
+
+    /// <summary>The open window, or the refusal a client that never opened one gets.</summary>
+    private CssRuleUsageTracker Tracking()
+        => _coverage ?? Throw.ServerError<CssRuleUsageTracker>(
+            "CSS rule usage tracking is not enabled",
+            "no window is open on this attachment: send CSS.startRuleUsageTracking before asking for coverage");
+
+    private void StopTracking()
+    {
+        if (_coverage is { } coverage)
+        {
+            CssRuleUsage.Disarm(coverage);
+            _coverage = null;
+        }
+    }
+
+    /// <summary>Turns recorded rules into the protocol's usage entries, dropping what cannot be placed.</summary>
+    /// <remarks>
+    /// A rule is dropped when its sheet has no identifier — which is how a user-agent rule is left out,
+    /// the protocol having no way to name that sheet — and when the sheet's serialization gives it no range
+    /// of its own. Everything reported is reported <c>used: true</c>: the protocol's own description of
+    /// both commands is "the rules that were used", and a window only ever records a rule when it matched.
+    /// </remarks>
+    private ProtocolCss.RuleUsage[] Report(ICssStyleRule[] rules)
+    {
+        if (rules.Length == 0)
+        {
+            return [];
+        }
+
+        var texts = new Dictionary<ICssStyleSheet, CssStyleSheetText>(ReferenceEqualityComparer.Instance);
+        var usage = new List<ProtocolCss.RuleUsage>(rules.Length);
+
+        foreach (var rule in rules)
+        {
+            if (rule.Owner is not { } sheet || Sheets.KnownIdOf(sheet) is not { } id)
+            {
+                continue;
+            }
+
+            if (!texts.TryGetValue(sheet, out var text))
+            {
+                text = CssStyleSheetText.Of(sheet);
+                texts[sheet] = text;
+            }
+
+            if (!text.TryRangeOf(rule, out var range))
+            {
+                continue;
+            }
+
+            usage.Add(new ProtocolCss.RuleUsage
+            {
+                StyleSheetId = id,
+                StartOffset = range.Start,
+                EndOffset = range.End,
+                Used = true,
+            });
+        }
+
+        return [.. usage];
+    }
+
+    /// <summary>Announces the sheets this attachment has not been told about, before the reply it precedes.</summary>
+    private async ValueTask AnnounceAsync(CommandContext context)
+    {
+        if (!IsEnabled || PageRuntime.Find(_target.Runtime.Engine) is not { } runtime)
+        {
+            return;
+        }
+
+        foreach (var header in Unannounced(runtime))
+        {
+            await EmitAsync(
+                CSSEvents.StyleSheetAdded(new ProtocolCss.StyleSheetAddedEvent { Header = header }),
+                context.CancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>The headers for every sheet of the current document this attachment has not heard about.</summary>
+    private List<ProtocolCss.CSSStyleSheetHeader> Unannounced(PageRuntime runtime)
+    {
+        var headers = new List<ProtocolCss.CSSStyleSheetHeader>();
+        if (runtime.Document is not { } document)
+        {
+            return headers;
+        }
+
+        foreach (var sheet in CssStyleSheetTracker.SheetsOf(document))
+        {
+            var id = Sheets.IdOf(sheet);
+            if (_announced.Add(id))
+            {
+                headers.Add(Header(sheet, id, runtime.DocumentUrl));
+            }
+        }
+
+        return headers;
+    }
+
+    /// <summary>What a client is told about one sheet.</summary>
+    /// <remarks>
+    /// <para>
+    /// <b>An inline sheet's <c>sourceURL</c> is the document's</b>, which is Chrome's answer and not a
+    /// convenience: Puppeteer's and Playwright's CSS coverage both drop a header whose <c>sourceURL</c> is
+    /// empty, so a <c>&lt;style&gt;</c> block reported with none would be invisible to the very clients
+    /// this is for.
+    /// </para>
+    /// <para>
+    /// <b>The position fields describe this domain's text rather than the document's.</b> A sheet's text
+    /// here is its own serialization, so it starts at line zero, column zero; Chrome reports where a
+    /// <c>&lt;style&gt;</c> element's content sits inside the page's markup, which is a source position
+    /// nothing in AngleSharp records. <c>isMutable</c> and <c>isConstructed</c> are false because there is
+    /// no editing command and no <c>new CSSStyleSheet()</c> in this binding.
+    /// </para>
+    /// </remarks>
+    private ProtocolCss.CSSStyleSheetHeader Header(ICssStyleSheet sheet, string id, string documentUrl)
+    {
+        var text = CssStyleSheetText.Of(sheet).Text;
+        var lines = 0;
+        var lastBreak = -1;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '\n')
+            {
+                lines++;
+                lastBreak = i;
+            }
+        }
+
+        return new ProtocolCss.CSSStyleSheetHeader
+        {
+            StyleSheetId = id,
+            FrameId = _target.FrameId,
+            SourceURL = string.IsNullOrEmpty(sheet.Href) ? documentUrl : sheet.Href,
+            Origin = ProtocolCss.StyleSheetOriginValues.Regular,
+            Title = sheet.Title ?? "",
+            OwnerNode = sheet.OwnerNode is { } owner ? _target.Nodes.BackendIdOf(owner) : null,
+            Disabled = sheet.IsDisabled,
+            IsInline = string.IsNullOrEmpty(sheet.Href),
+            IsMutable = false,
+            IsConstructed = false,
+            StartLine = 0,
+            StartColumn = 0,
+            Length = text.Length,
+            EndLine = lines,
+            EndColumn = text.Length - lastBreak - 1,
+        };
+    }
+
+    /// <summary>The document a window is about, or Chrome's own refusal when there is none yet.</summary>
+    private IDocument Document()
+        => PageRuntime.Find(_target.Runtime.Engine)?.Document
+        ?? Throw.ServerError<IDocument>("Document is not available");
+}

--- a/Jint.Browser/DevTools/CssDomain.cs
+++ b/Jint.Browser/DevTools/CssDomain.cs
@@ -10,19 +10,21 @@ using ProtocolCss = Jint.DevTools.Protocol.CSS;
 namespace Jint.Browser.DevTools;
 
 /// <summary>
-/// The <c>CSS</c> domain: the two questions AngleSharp.Css can answer about a node, and nothing else.
+/// The <c>CSS</c> domain: what AngleSharp.Css can answer about a node, and which of a page's rules were
+/// used.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Two read commands, and every editing command is honestly <c>-32601</c>.</b>
+/// <b>Reads only, and every editing command is honestly <c>-32601</c>.</b>
 /// <c>getComputedStyleForNode</c> is the cascade AngleSharp.Css resolves — the same one
 /// <c>window.getComputedStyle</c> answers from, so a front end and a page are told one story — and
-/// <c>getInlineStylesForNode</c> is the element's own <c>style</c> attribute. What is <i>not</i> here is
-/// everything that names a style sheet: <c>getMatchedStylesForNode</c>, <c>setStyleTexts</c>,
-/// <c>addRule</c>, the rule-usage tracking and the <c>styleSheetAdded</c> stream. Each of them needs a
-/// stable identifier for a sheet and a range inside its source text, which means owning the CSSOM's
-/// serialization end to end; that is AngleSharp's half of this package and re-implementing it is the one
-/// thing <c>Jint.Browser</c> is not for.
+/// <c>getInlineStylesForNode</c> is the element's own <c>style</c> attribute. Rule-usage coverage, the
+/// <c>styleSheetAdded</c> stream and <c>getStyleSheetText</c> are in
+/// the other half of this class, <c>CssDomain.Coverage.cs</c>, and they need a sheet identifier
+/// and a range inside a sheet's text, which <c>CssStyleSheetTracker</c> and <c>CssStyleSheetText</c> are.
+/// What is still <i>not</i> here is everything that <i>edits</i> — <c>setStyleTexts</c>, <c>addRule</c>,
+/// <c>createStyleSheet</c> — and <c>getMatchedStylesForNode</c>, which would have to name the rule every
+/// declaration came from and AngleSharp.Css exposes no such thing.
 /// </para>
 /// <para>
 /// <b>A computed value here has no layout behind it.</b> A property the style sheets, the inline style or
@@ -42,7 +44,7 @@ namespace Jint.Browser.DevTools;
 /// See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/"/>.
 /// </para>
 /// </remarks>
-internal sealed class CssDomain : CSSDomainBase
+internal sealed partial class CssDomain : CSSDomainBase
 {
     private readonly PageTarget _target;
 
@@ -53,19 +55,26 @@ internal sealed class CssDomain : CSSDomainBase
 
     /// <inheritdoc/>
     /// <remarks>
-    /// No <c>styleSheetAdded</c> follows, because no style sheet is published: a client is told about the
-    /// sheets it can then read and edit, and there are none it can.
+    /// A <c>styleSheetAdded</c> follows for every sheet of the document that is showing, which is what
+    /// Chrome does and what a coverage client waits for before it asks for any text.
     /// </remarks>
     protected override async ValueTask<EmptyResult> EnableAsync(EmptyParameters parameters, CommandContext context)
     {
         await MarkEnabledAsync(context).ConfigureAwait(false);
+        await AnnounceAsync(context).ConfigureAwait(false);
         return EmptyResult.Instance;
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// A disabled domain publishes nothing, so an open coverage window is closed with it rather than left
+    /// recording into a report nobody can ask for — and the cascade seam is disarmed with it.
+    /// </remarks>
     protected override async ValueTask<EmptyResult> DisableAsync(EmptyParameters parameters, CommandContext context)
     {
         await MarkDisabledAsync(context).ConfigureAwait(false);
+        StopTracking();
+        _announced.Clear();
         return EmptyResult.Instance;
     }
 

--- a/Jint.Browser/DevTools/CssStyleSheetText.cs
+++ b/Jint.Browser/DevTools/CssStyleSheetText.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using AngleSharp.Css.Dom;
+
+namespace Jint.Browser.DevTools;
+
+/// <summary>
+/// The text a client is given for one style sheet, and where every rule in it starts and ends.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The text is the CSSOM's serialization, not the bytes the page was authored with, and the two cannot
+/// be swapped.</b> <c>CSS.getStyleSheetText</c> and a <c>RuleUsage</c>'s <c>startOffset</c> and
+/// <c>endOffset</c> are one answer: a client slices the first with the second — that is the whole of what
+/// Puppeteer's and Playwright's CSS coverage do with them — so the offsets must index the string this
+/// hands out. AngleSharp keeps the authored text (<c>IStyleSheet.Source</c>) but no <c>ICssRule</c> carries
+/// a source position, so there is no way to say where a rule sits inside it. Serializing the sheet here and
+/// measuring the same serialization is the only pairing that is internally consistent, and it is what
+/// Chrome itself does for a sheet with no source text of its own — a constructed <c>new CSSStyleSheet()</c>
+/// is reported with an empty <c>sourceURL</c> and a text built from its rules.
+/// </para>
+/// <para>
+/// <b>It is built on demand and never cached.</b> A cached snapshot would go stale the moment a page
+/// inserted a rule, and this domain publishes no <c>styleSheetChanged</c> for a client to notice with; a
+/// fresh one always describes the sheet as it is now. Only a client that asked for coverage or for a
+/// sheet's text pays for it.
+/// </para>
+/// <para>
+/// <b>The layout is deliberately its own rather than <c>ICssStyleSheet.ToCss()</c>.</b> That serializer
+/// joins rules with the platform's newline, which would put a coverage report's offsets four bytes apart on
+/// Windows and Linux for the same page; and it emits a grouping rule on one line, which would leave a
+/// nested rule with no range of its own. One rule per line, two spaces of nesting, <c>\n</c> everywhere.
+/// </para>
+/// </remarks>
+internal sealed class CssStyleSheetText
+{
+    private readonly Dictionary<ICssRule, CssRuleRange> _ranges = new(ReferenceEqualityComparer.Instance);
+
+    private CssStyleSheetText(string text)
+    {
+        Text = text;
+    }
+
+    /// <summary>The sheet's text, which is what <c>CSS.getStyleSheetText</c> answers.</summary>
+    internal string Text { get; }
+
+    /// <summary>Serializes <paramref name="sheet"/> and measures every rule in it.</summary>
+    internal static CssStyleSheetText Of(ICssStyleSheet sheet)
+    {
+        var builder = new StringBuilder();
+        var ranges = new List<(ICssRule Rule, CssRuleRange Range)>();
+        Write(sheet.Rules, builder, ranges, indent: "");
+
+        var text = new CssStyleSheetText(builder.ToString());
+        foreach (var (rule, range) in ranges)
+        {
+            text._ranges[rule] = range;
+        }
+
+        return text;
+    }
+
+    /// <summary>Where <paramref name="rule"/> sits in <see cref="Text"/>, when it sits anywhere.</summary>
+    /// <remarks>
+    /// A rule with no range is one this serialization does not write on its own line — a style rule nested
+    /// inside another style rule, which CSS nesting allows and this writes as part of its parent's text.
+    /// A client is told nothing about it rather than told the wrong offsets.
+    /// </remarks>
+    internal bool TryRangeOf(ICssRule rule, out CssRuleRange range) => _ranges.TryGetValue(rule, out range);
+
+    private static void Write(
+        ICssRuleList rules,
+        StringBuilder builder,
+        List<(ICssRule Rule, CssRuleRange Range)> ranges,
+        string indent)
+    {
+        for (var i = 0; i < rules.Length; i++)
+        {
+            var rule = rules[i];
+            builder.Append(indent);
+            var start = builder.Length;
+
+            if (rule is ICssGroupingRule group)
+            {
+                builder.Append(Prelude(rule)).Append('\n');
+                Write(group.Rules, builder, ranges, indent + "  ");
+                builder.Append(indent).Append('}');
+            }
+            else
+            {
+                builder.Append(rule.CssText);
+            }
+
+            ranges.Add((rule, new CssRuleRange(start, builder.Length)));
+            builder.Append('\n');
+        }
+    }
+
+    /// <summary>A grouping rule's own text, up to and including the brace its children sit inside.</summary>
+    /// <remarks>
+    /// Read off the rule's serialization rather than rebuilt per rule type, so <c>@media</c>,
+    /// <c>@supports</c>, <c>@container</c>, <c>@layer</c> and whatever AngleSharp.Css groups next are all
+    /// one line of code. A prelude cannot contain a brace, so the first one ends it.
+    /// </remarks>
+    private static string Prelude(ICssRule rule)
+    {
+        var text = rule.CssText;
+        var brace = text.IndexOf('{');
+        return brace < 0 ? text : text[..(brace + 1)];
+    }
+}
+
+/// <summary>Where one rule starts and ends inside its sheet's text.</summary>
+/// <param name="Start">The offset of the rule's first character, its selector or at-keyword included.</param>
+/// <param name="End">The offset just past the rule's closing brace.</param>
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+internal readonly record struct CssRuleRange(int Start, int End);

--- a/Jint.Browser/DevTools/CssStyleSheetTracker.cs
+++ b/Jint.Browser/DevTools/CssStyleSheetTracker.cs
@@ -1,0 +1,143 @@
+using System.Globalization;
+using AngleSharp.Css.Dom;
+using AngleSharp.Dom;
+using Jint.Browser.Runtime;
+
+namespace Jint.Browser.DevTools;
+
+/// <summary>
+/// The identifiers the <c>CSS</c> domain addresses a page's style sheets by, and the commit every
+/// attachment hears about.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A <c>styleSheetId</c> is a document's, and one table serves every attachment.</b> That is
+/// <see cref="DomNodeTracker"/>'s decision for a <c>nodeId</c> and the same one holds here: two clients
+/// attached to one page must be told the same identifier for the same sheet, and a sheet dies with the
+/// document that owns it, so both maps are emptied on every commit. The counter is process-wide, so an
+/// identifier from the document before last resolves to nothing rather than to a sheet of the one that
+/// replaced it.
+/// </para>
+/// <para>
+/// <b>Sheets are announced when the domain is asked, not watched.</b> AngleSharp raises no notification
+/// when a sheet is added to or removed from a document — <c>IStyleSheetList</c> is a live view over the
+/// tree with no event on it — so there is nothing to subscribe to. <see cref="CssDomain"/> reconciles the
+/// document's sheets against this table at the four moments a client can tell the difference: when it
+/// enables the domain, when a document commits, when it reads a sheet's text, and before it is handed
+/// coverage. <c>styleSheetRemoved</c> and <c>styleSheetChanged</c> are absent for the same reason and are
+/// stated in <c>DevTools/AGENTS.md</c>.
+/// </para>
+/// <para>
+/// Everything here runs on the page loop.
+/// </para>
+/// </remarks>
+internal sealed class CssStyleSheetTracker
+{
+    private static int _serial;
+
+    private readonly Dictionary<ICssStyleSheet, string> _ids = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<string, ICssStyleSheet> _byId = new(StringComparer.Ordinal);
+
+    private readonly object _domainGate = new();
+    private CssDomain[] _domains = [];
+
+    /// <summary>Registers one attachment's domain, so it hears about a document's sheets.</summary>
+    internal void Add(CssDomain domain)
+    {
+        lock (_domainGate)
+        {
+            _domains = [.. _domains, domain];
+        }
+    }
+
+    /// <summary>Stops telling one attachment's domain anything, which detaching does.</summary>
+    internal void Remove(CssDomain domain)
+    {
+        lock (_domainGate)
+        {
+            _domains = [.. _domains.Where(candidate => !ReferenceEquals(candidate, domain))];
+        }
+    }
+
+    /// <summary>Throws away a document's identifiers, which a navigation does.</summary>
+    internal void DocumentReplaced()
+    {
+        _ids.Clear();
+        _byId.Clear();
+    }
+
+    /// <summary>Tells every attachment that a document is parsed and its sheets can be read.</summary>
+    internal void DocumentCommitted(PageRuntime runtime)
+    {
+        foreach (var domain in Volatile.Read(ref _domains))
+        {
+            domain.DocumentCommitted(runtime);
+        }
+    }
+
+    /// <summary>The identifier <paramref name="sheet"/> is addressed by in this document, minting one.</summary>
+    internal string IdOf(ICssStyleSheet sheet)
+    {
+        if (_ids.TryGetValue(sheet, out var existing))
+        {
+            return existing;
+        }
+
+        var id = Interlocked.Increment(ref _serial).ToString(CultureInfo.InvariantCulture);
+        _ids[sheet] = id;
+        _byId[id] = sheet;
+        return id;
+    }
+
+    /// <summary>Whether <paramref name="sheet"/> has been given an identifier already.</summary>
+    internal bool Knows(ICssStyleSheet sheet) => _ids.ContainsKey(sheet);
+
+    /// <summary>The sheet an identifier names, or none.</summary>
+    internal ICssStyleSheet? ById(string id) => _byId.GetValueOrDefault(id);
+
+    /// <summary>The identifier <paramref name="sheet"/> already has, or none.</summary>
+    internal string? KnownIdOf(ICssStyleSheet sheet) => _ids.GetValueOrDefault(sheet);
+
+    /// <summary>
+    /// Every sheet of <paramref name="document"/> a rule can be attributed to, outermost first.
+    /// </summary>
+    /// <remarks>
+    /// The document's own sheets and everything they <c>@import</c>, which is what CSSOM calls the
+    /// document's style sheet set plus the sheets hanging off it. The user-agent sheet is not among them and
+    /// deliberately gets no identifier: the protocol says a <c>RuleUsage</c>'s style sheet identifier is
+    /// absent for user-agent rules, and a client that was handed one would ask for text this cannot give.
+    /// </remarks>
+    internal static List<ICssStyleSheet> SheetsOf(IDocument document)
+    {
+        var sheets = new List<ICssStyleSheet>();
+        var seen = new HashSet<ICssStyleSheet>(ReferenceEqualityComparer.Instance);
+
+        for (var i = 0; i < document.StyleSheets.Length; i++)
+        {
+            if (document.StyleSheets[i] is ICssStyleSheet sheet)
+            {
+                Collect(sheet, sheets, seen);
+            }
+        }
+
+        return sheets;
+    }
+
+    private static void Collect(ICssStyleSheet sheet, List<ICssStyleSheet> sheets, HashSet<ICssStyleSheet> seen)
+    {
+        if (!seen.Add(sheet))
+        {
+            return;
+        }
+
+        sheets.Add(sheet);
+
+        for (var i = 0; i < sheet.Rules.Length; i++)
+        {
+            if (sheet.Rules[i] is ICssImportRule { Sheet: { } imported })
+            {
+                Collect(imported, sheets, seen);
+            }
+        }
+    }
+}

--- a/Jint.Browser/DevTools/PageTarget.cs
+++ b/Jint.Browser/DevTools/PageTarget.cs
@@ -98,6 +98,16 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     /// </remarks>
     internal DomNodeTracker Nodes { get; } = new();
 
+    /// <summary>
+    /// The identifiers the <c>CSS</c> domain addresses this page's style sheets by.
+    /// </summary>
+    /// <remarks>
+    /// On the target for the reason <see cref="Nodes"/> is: two clients attached to one page must be told
+    /// the same <c>styleSheetId</c> for the same sheet. Unlike a <c>backendNodeId</c> none of it outlives a
+    /// document, so the table is emptied on every commit.
+    /// </remarks>
+    internal CssStyleSheetTracker Sheets { get; } = new();
+
     /// <summary>The tab this page hangs off, which is how a client reaches it. Set by the host.</summary>
     /// <remarks>
     /// A tab shows what its page shows, so everything that moves the page's title or location moves the
@@ -189,6 +199,7 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
 
         AddDomain(page);
         Nodes.Add(dom);
+        Sheets.Add(css);
 
         // Every one of these that listens -- the DOM domain hears about the engine being replaced under the
         // target the way the built-in five do -- is observed by `With` and unobserved again by `Detach`.
@@ -302,6 +313,7 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
         // Before the swap, because the swap is what tells every DOM domain to announce documentUpdated and a
         // client that acted on it must find the identifiers already gone rather than resolving one more time.
         Nodes.DocumentReplaced();
+        Sheets.DocumentReplaced();
 
         Replace(runtime.Engine);
         NewDocumentScripts.Run(runtime);
@@ -314,6 +326,11 @@ internal sealed partial class PageTarget : DevToolsTarget, IPageObserver
     void IPageObserver.DocumentParsed(PageRuntime runtime, string loaderId)
     {
         Nodes.Watch(runtime);
+
+        // The first moment there is a tree to read style sheets off: RuntimeReplaced above runs before the
+        // parse, where the document has none. A client tracking rule usage across a navigation gets the new
+        // document's sheets announced and its window pointed at the new document here.
+        Sheets.DocumentCommitted(runtime);
 
         foreach (var domain in Snapshot())
         {

--- a/Jint.Browser/Dom/Views/CssCascade.cs
+++ b/Jint.Browser/Dom/Views/CssCascade.cs
@@ -55,6 +55,8 @@ internal static class CssCascade
     /// </summary>
     internal static ICssStyleDeclaration? Of(IElement element)
     {
+        CssRuleUsage.Observe(element);
+
         try
         {
             var computed = element.ComputeCurrentStyle();
@@ -133,6 +135,8 @@ internal static class CssCascade
                 var parent = current is null ? null : _cascaded[current];
                 while (_pending.TryPop(out current))
                 {
+                    CssRuleUsage.Observe(element);
+
                     // Capture local variables before inheritance. A rule matching both parent and
                     // child shares property objects, so reference identity cannot identify inheritance.
                     var cascade = styles.ComputeExplicitStyle(current);

--- a/Jint.Browser/Dom/Views/CssRuleUsage.cs
+++ b/Jint.Browser/Dom/Views/CssRuleUsage.cs
@@ -1,0 +1,320 @@
+using System.Runtime.CompilerServices;
+using AngleSharp;
+using AngleSharp.Css;
+using AngleSharp.Css.Dom;
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Dom.Views;
+
+/// <summary>
+/// Which style rules matched something while a client was watching: the arming switch every cascade
+/// computation reads, and nothing else.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A page nobody is tracking pays one static read.</b> <see cref="Observe"/> is on the hot path of
+/// <see cref="CssCascade.Of"/> and of every step of <see cref="CssCascade.Traversal"/>, which between them
+/// answer <c>getComputedStyle</c>, every box the flat model produces and the accessibility tree's hidden
+/// verdict. With nothing armed it is a volatile array read and a length test — no allocation, no dictionary,
+/// no per-page field to find — and the recording itself is behind a non-inlined call so that the guard is
+/// the only thing a caller's code carries. That is the same shape <c>Runtime/PageNetworkRecorder</c> uses
+/// for a page with no client attached.
+/// </para>
+/// <para>
+/// <b>The list is process-wide and the tracker filters by document, rather than the other way round.</b> An
+/// <see cref="IElement"/> knows its document and nothing above it, and a page's browsing context is rebuilt
+/// for every document (<c>Runtime/Parsing/ParserDriver</c>), so there is no per-page key a static seam could
+/// look a tracker up by. Two pages tracked at once therefore cost each other one reference comparison per
+/// cascade, which is what <see cref="CssRuleUsageTracker.Observe"/> starts with.
+/// </para>
+/// <para>
+/// <b>Nothing here may throw into a cascade.</b> Every caller is running a page's own script or answering a
+/// protocol command; an escaping CLR exception would turn a client's coverage request into a broken
+/// <c>getComputedStyle</c>. The recording is guarded exactly as <see cref="CssCascade"/> guards the compute.
+/// </para>
+/// </remarks>
+internal static class CssRuleUsage
+{
+    private static readonly object Gate = new();
+
+    private static CssRuleUsageTracker[] _tracking = [];
+
+    /// <summary>Whether any client is recording rule usage anywhere in this process.</summary>
+    internal static bool IsTracking => Volatile.Read(ref _tracking).Length != 0;
+
+    /// <summary>Records the rules that match <paramref name="element"/>, for whoever is tracking.</summary>
+    /// <param name="element">The element a cascade is being computed for.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void Observe(IElement element)
+    {
+        var tracking = Volatile.Read(ref _tracking);
+        if (tracking.Length != 0)
+        {
+            Record(tracking, element);
+        }
+    }
+
+    /// <summary>Starts delivering to <paramref name="tracker"/>.</summary>
+    internal static void Arm(CssRuleUsageTracker tracker)
+    {
+        lock (Gate)
+        {
+            _tracking = [.. _tracking, tracker];
+        }
+    }
+
+    /// <summary>Stops delivering to <paramref name="tracker"/>, which is what stopping tracking does.</summary>
+    internal static void Disarm(CssRuleUsageTracker tracker)
+    {
+        lock (Gate)
+        {
+            _tracking = [.. _tracking.Where(candidate => !ReferenceEquals(candidate, tracker))];
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Record(CssRuleUsageTracker[] tracking, IElement element)
+    {
+        foreach (var tracker in tracking)
+        {
+            tracker.Observe(element);
+        }
+    }
+}
+
+/// <summary>
+/// One client's recording window: the author rules that have matched an element since it opened, and the
+/// ones it has not been told about yet.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The candidate list is AngleSharp's own, and that is the whole point.</b>
+/// <c>IWindow.GetStyleCollection(device)</c> is the flattened, ordered, condition-filtered rule list the
+/// cascade itself matches against, so a rule inside an <c>@media</c> or <c>@supports</c> whose condition
+/// holds is enumerated individually — exactly what a client expects a nested rule's coverage to mean — and
+/// one inside a group that does not hold is not enumerated at all, so it can never be reported used. The
+/// predicate is <c>ICssStyleRule.TryMatch</c>, the same public member AngleSharp.Css matches with.
+/// </para>
+/// <para>
+/// <b>Why matching rather than reading the cascade's answer.</b> AngleSharp.Css's computed-style pipeline —
+/// <c>IElement.ComputeCurrentStyle()</c>, <c>IStyleCollection.ComputeCascadedStyle</c> and their siblings —
+/// answers an <c>ICssStyleDeclaration</c>, and neither it nor the <c>ICssProperty</c> objects in it carry
+/// the rule a declaration came from. There is no public seam anywhere in the assembly that reports which
+/// rules matched an element, so rule identity cannot be recovered from a cascade that has already run: the
+/// matching has to be done again. It is done over the *unused* candidates only, so the work shrinks towards
+/// nothing as the window goes on, and it computes no values at all — no device conversion, no custom
+/// property resolution, no inheritance — which is the expensive half of a cascade.
+/// </para>
+/// <para>
+/// <b>Used means used once.</b> A rule that matched in one query and not in the next is used; the recorded
+/// set is never revisited, which is why a matched rule leaves the candidate list for good.
+/// </para>
+/// <para>
+/// Everything here runs on the page loop, because every caller does.
+/// </para>
+/// </remarks>
+internal sealed class CssRuleUsageTracker
+{
+    private readonly HashSet<ICssStyleRule> _used = new(ReferenceEqualityComparer.Instance);
+    private readonly List<ICssStyleRule> _pending = [];
+    private readonly List<ICssStyleRule> _candidates = [];
+    private readonly HashSet<ICssStyleSheet> _reportable = new(ReferenceEqualityComparer.Instance);
+
+    private readonly Predicate<ICssStyleRule> _recorded;
+
+    private IDocument? _document;
+    private IStyleSheet[] _sheets = [];
+    private int _ruleCount = -1;
+
+    internal CssRuleUsageTracker()
+    {
+        _recorded = _used.Contains;
+    }
+
+    /// <summary>The document whose cascades this window is about, or none until it is bound.</summary>
+    internal IDocument? Document => _document;
+
+    /// <summary>Points the window at <paramref name="document"/>, forgetting the candidates of the last.</summary>
+    /// <remarks>
+    /// The recorded set is deliberately kept: Chrome's coverage is the agent's rather than the document's,
+    /// and a client that navigates in the middle of a window is told about both documents' rules when it
+    /// takes its next delta. What is dropped is the candidate list, because its rules belong to sheets that
+    /// are gone.
+    /// </remarks>
+    internal void Rebind(IDocument? document)
+    {
+        _document = document;
+        _candidates.Clear();
+        _reportable.Clear();
+        _sheets = [];
+        _ruleCount = -1;
+    }
+
+    /// <summary>
+    /// Records every rule that matches something in the bound document right now.
+    /// </summary>
+    /// <remarks>
+    /// This is Blink's forced recalculation, in the one form this engine can give it. Chrome's
+    /// <c>startRuleUsageTracking</c> does not merely arm a counter: it marks every element of every document
+    /// for style recalculation and runs it, so that coverage describes the page as it stands rather than
+    /// only what happens to be restyled afterwards. Nothing renders here, so a document that is never
+    /// queried computes no cascade at all and a window opened over it would be empty; this walks the
+    /// document once instead, which costs selector matching and no value computation.
+    /// </remarks>
+    internal void Sweep()
+    {
+        if (_document is not { } document)
+        {
+            return;
+        }
+
+        foreach (var element in document.All)
+        {
+            Observe(element);
+        }
+    }
+
+    /// <summary>Records the rules matching <paramref name="element"/>, if it belongs to this window.</summary>
+    internal void Observe(IElement element)
+    {
+        if (_document is null || !ReferenceEquals(element.Owner, _document))
+        {
+            return;
+        }
+
+        try
+        {
+            Refresh();
+
+            var matched = false;
+            foreach (var rule in _candidates)
+            {
+                if (rule.TryMatch(element, null, out _))
+                {
+                    _used.Add(rule);
+                    _pending.Add(rule);
+                    matched = true;
+                }
+            }
+
+            if (matched)
+            {
+                _candidates.RemoveAll(_recorded);
+            }
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException or NullReferenceException)
+        {
+            // The same three AngleSharp.Css raises out of a cascade it cannot compute, and for the same
+            // reason they are swallowed there: a client's coverage request may not break the page's own
+            // getComputedStyle. A window that cannot match reports less, and reports nothing wrong.
+        }
+    }
+
+    /// <summary>The rules recorded since the last take, oldest first, emptying the pending list.</summary>
+    internal ICssStyleRule[] TakeDelta()
+    {
+        var delta = _pending.ToArray();
+        _pending.Clear();
+        return delta;
+    }
+
+    /// <summary>Rebuilds the candidate list when the document's sheets have moved under it.</summary>
+    /// <remarks>
+    /// The check is the sheet list's identity plus the number of top-level rules in it, which catches a
+    /// sheet appearing or disappearing and a rule inserted at the top level of one. A rule inserted into an
+    /// <c>@media</c> block of a sheet that was already there is not caught until something else moves; there
+    /// is no CSSOM mutation signal in AngleSharp to hang a precise invalidation on, and re-flattening every
+    /// sheet for every element would make each cascade quadratic in the page's rules.
+    /// </remarks>
+    private void Refresh()
+    {
+        var sheets = _document!.StyleSheets;
+        var count = 0;
+        for (var i = 0; i < sheets.Length; i++)
+        {
+            count += (sheets[i] as ICssStyleSheet)?.Rules.Length ?? 0;
+        }
+
+        if (count == _ruleCount && Same(sheets))
+        {
+            return;
+        }
+
+        _sheets = [.. sheets];
+        _ruleCount = count;
+        _candidates.Clear();
+        _reportable.Clear();
+
+        foreach (var sheet in _sheets)
+        {
+            if (sheet is ICssStyleSheet css)
+            {
+                Reportable(css);
+            }
+        }
+
+        if (Collection() is not { } styles)
+        {
+            return;
+        }
+
+        foreach (var rule in styles)
+        {
+            if (!_used.Contains(rule) && rule.Owner is { } owner && _reportable.Contains(owner))
+            {
+                _candidates.Add(rule);
+            }
+        }
+    }
+
+    /// <summary>The sheets a rule may be attributed to: the document's, and everything they import.</summary>
+    /// <remarks>
+    /// The user-agent sheet is excluded by construction — it is not among the document's — which is what the
+    /// protocol asks for: a <c>RuleUsage</c>'s style sheet identifier is "absent for user agent stylesheet
+    /// and user-specified stylesheet rules", and there is no identifier to give one.
+    /// </remarks>
+    private void Reportable(ICssStyleSheet sheet)
+    {
+        if (!_reportable.Add(sheet))
+        {
+            return;
+        }
+
+        for (var i = 0; i < sheet.Rules.Length; i++)
+        {
+            if (sheet.Rules[i] is ICssImportRule { Sheet: { } imported })
+            {
+                Reportable(imported);
+            }
+        }
+    }
+
+    private IStyleCollection? Collection()
+    {
+        if (_document?.DefaultView is not { } window)
+        {
+            return null;
+        }
+
+        var device = _document.Context.GetService<IRenderDevice>() ?? new DefaultRenderDevice();
+        return window.GetStyleCollection(device);
+    }
+
+    private bool Same(IStyleSheetList sheets)
+    {
+        if (sheets.Length != _sheets.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _sheets.Length; i++)
+        {
+            if (!ReferenceEquals(sheets[i], _sheets[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Jint.DevTools/Protocol/Generated/CSS.g.cs
+++ b/Jint.DevTools/Protocol/Generated/CSS.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/browser_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, CSS entries, sha256:350c29d3176b
+//     manifest: tools/devtools-protocol/manifest.json, CSS entries, sha256:5de351ec6787
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -14,6 +14,126 @@
 
 namespace Jint.DevTools.Protocol.CSS
 {
+    /// <summary>The strings the protocol admits for <c>CSS.StyleSheetOrigin</c>.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-StyleSheetOrigin"/>.</remarks>
+    internal static class StyleSheetOriginValues
+    {
+        /// <summary>The protocol's <c>injected</c> value.</summary>
+        internal const string Injected = "injected";
+
+        /// <summary>The protocol's <c>user-agent</c> value.</summary>
+        internal const string UserAgent = "user-agent";
+
+        /// <summary>The protocol's <c>inspector</c> value.</summary>
+        internal const string Inspector = "inspector";
+
+        /// <summary>The protocol's <c>regular</c> value.</summary>
+        internal const string Regular = "regular";
+    }
+
+    /// <summary>CSS stylesheet metainformation.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-CSSStyleSheetHeader"/>.</remarks>
+    internal sealed record CSSStyleSheetHeader
+    {
+        /// <summary>The stylesheet identifier.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("styleSheetId")]
+        public required string StyleSheetId { get; init; }
+
+        /// <summary>Owner frame identifier.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("frameId")]
+        public required string FrameId { get; init; }
+
+        /// <summary>Stylesheet resource URL.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("sourceURL")]
+        public required string SourceURL { get; init; }
+
+        /// <summary>URL of source map associated with the stylesheet (if any).</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("sourceMapURL")]
+        [global::System.Text.Json.Serialization.JsonIgnore(Condition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public string? SourceMapURL { get; init; }
+
+        /// <summary>Stylesheet origin.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("origin")]
+        public required string Origin { get; init; }
+
+        /// <summary>Stylesheet title.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("title")]
+        public required string Title { get; init; }
+
+        /// <summary>The backend id for the owner node of the stylesheet.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("ownerNode")]
+        [global::System.Text.Json.Serialization.JsonIgnore(Condition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public int? OwnerNode { get; init; }
+
+        /// <summary>Denotes whether the stylesheet is disabled.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("disabled")]
+        public required bool Disabled { get; init; }
+
+        /// <summary>Whether the sourceURL field value comes from the sourceURL comment.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("hasSourceURL")]
+        [global::System.Text.Json.Serialization.JsonIgnore(Condition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public bool? HasSourceURL { get; init; }
+
+        /// <summary>Whether this stylesheet is created for STYLE tag by parser.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("isInline")]
+        public required bool IsInline { get; init; }
+
+        /// <summary>Whether this stylesheet is mutable.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("isMutable")]
+        public required bool IsMutable { get; init; }
+
+        /// <summary>True if this stylesheet is created through new CSSStyleSheet() or imported as a CSS module script.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("isConstructed")]
+        public required bool IsConstructed { get; init; }
+
+        /// <summary>Line offset of the stylesheet within the resource (zero based).</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("startLine")]
+        public required double StartLine { get; init; }
+
+        /// <summary>Column offset of the stylesheet within the resource (zero based).</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("startColumn")]
+        public required double StartColumn { get; init; }
+
+        /// <summary>Size of the content (in characters).</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("length")]
+        public required double Length { get; init; }
+
+        /// <summary>Line offset of the end of the stylesheet within the resource (zero based).</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("endLine")]
+        public required double EndLine { get; init; }
+
+        /// <summary>Column offset of the end of the stylesheet within the resource (zero based).</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("endColumn")]
+        public required double EndColumn { get; init; }
+
+        /// <summary>The protocol's <c>loadingFailed</c> member.</summary>
+        /// <remarks>Experimental in the protocol. </remarks>
+        [global::System.Text.Json.Serialization.JsonPropertyName("loadingFailed")]
+        [global::System.Text.Json.Serialization.JsonIgnore(Condition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public bool? LoadingFailed { get; init; }
+    }
+
+    /// <summary>CSS coverage information.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-RuleUsage"/>.</remarks>
+    internal sealed record RuleUsage
+    {
+        /// <summary>The css style sheet identifier (absent for user agent stylesheet and user-specified stylesheet rules) this rule came from.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("styleSheetId")]
+        public required string StyleSheetId { get; init; }
+
+        /// <summary>Offset of the start of the rule (including selector) from the beginning of the stylesheet.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("startOffset")]
+        public required double StartOffset { get; init; }
+
+        /// <summary>Offset of the end of the rule body from the beginning of the stylesheet.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("endOffset")]
+        public required double EndOffset { get; init; }
+
+        /// <summary>Indicates whether the rule was actually used by some element in the page.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("used")]
+        public required bool Used { get; init; }
+    }
+
     /// <summary>Text range within a resource.</summary>
     /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-SourceRange"/>.</remarks>
     internal sealed record SourceRange
@@ -198,6 +318,55 @@ namespace Jint.DevTools.Protocol.CSS
         [global::System.Text.Json.Serialization.JsonIgnore(Condition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         public global::Jint.DevTools.Protocol.CSS.CSSStyle? AttributesStyle { get; init; }
     }
+
+    /// <summary>The parameters of the <c>CSS.getStyleSheetText</c> command.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-getStyleSheetText"/>.</remarks>
+    internal sealed record GetStyleSheetTextRequest
+    {
+        /// <summary>The protocol's <c>styleSheetId</c> member.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("styleSheetId")]
+        public required string StyleSheetId { get; init; }
+    }
+
+    /// <summary>The result of the <c>CSS.getStyleSheetText</c> command.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-getStyleSheetText"/>.</remarks>
+    internal sealed record GetStyleSheetTextResponse
+    {
+        /// <summary>The stylesheet text.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("text")]
+        public required string Text { get; init; }
+    }
+
+    /// <summary>The result of the <c>CSS.stopRuleUsageTracking</c> command.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-stopRuleUsageTracking"/>.</remarks>
+    internal sealed record StopRuleUsageTrackingResponse
+    {
+        /// <summary>The protocol's <c>ruleUsage</c> member.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("ruleUsage")]
+        public required global::Jint.DevTools.Protocol.CSS.RuleUsage[] RuleUsage { get; init; }
+    }
+
+    /// <summary>The result of the <c>CSS.takeCoverageDelta</c> command.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-takeCoverageDelta"/>.</remarks>
+    internal sealed record TakeCoverageDeltaResponse
+    {
+        /// <summary>The protocol's <c>coverage</c> member.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("coverage")]
+        public required global::Jint.DevTools.Protocol.CSS.RuleUsage[] Coverage { get; init; }
+
+        /// <summary>Monotonically increasing time, in seconds.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("timestamp")]
+        public required double Timestamp { get; init; }
+    }
+
+    /// <summary>The parameters of the <c>CSS.styleSheetAdded</c> event.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#event-styleSheetAdded"/>.</remarks>
+    internal sealed record StyleSheetAddedEvent
+    {
+        /// <summary>Added stylesheet metainfo.</summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("header")]
+        public required global::Jint.DevTools.Protocol.CSS.CSSStyleSheetHeader Header { get; init; }
+    }
 }
 
 namespace Jint.DevTools.Domains
@@ -229,6 +398,26 @@ namespace Jint.DevTools.Domains
         protected virtual global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.CSS.GetInlineStylesForNodeResponse> GetInlineStylesForNodeAsync(global::Jint.DevTools.Protocol.CSS.GetInlineStylesForNodeRequest parameters, global::Jint.DevTools.Session.CommandContext context)
             => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.CSS.GetInlineStylesForNodeResponse>>("CSS.getInlineStylesForNode");
 
+        /// <summary>Returns the current textual content for a stylesheet.</summary>
+        /// <remarks>Reached only while manifest.json lists it. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-getStyleSheetText"/>.</remarks>
+        protected virtual global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.CSS.GetStyleSheetTextResponse> GetStyleSheetTextAsync(global::Jint.DevTools.Protocol.CSS.GetStyleSheetTextRequest parameters, global::Jint.DevTools.Session.CommandContext context)
+            => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.CSS.GetStyleSheetTextResponse>>("CSS.getStyleSheetText");
+
+        /// <summary>Enables the selector recording.</summary>
+        /// <remarks>Reached only while manifest.json lists it. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-startRuleUsageTracking"/>.</remarks>
+        protected virtual global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.EmptyResult> StartRuleUsageTrackingAsync(global::Jint.DevTools.Protocol.EmptyParameters parameters, global::Jint.DevTools.Session.CommandContext context)
+            => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.EmptyResult>>("CSS.startRuleUsageTracking");
+
+        /// <summary>Stop tracking rule usage and return the list of rules that were used since last call to `takeCoverageDelta` (or since start of coverage instrumentation).</summary>
+        /// <remarks>Reached only while manifest.json lists it. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-stopRuleUsageTracking"/>.</remarks>
+        protected virtual global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.CSS.StopRuleUsageTrackingResponse> StopRuleUsageTrackingAsync(global::Jint.DevTools.Protocol.EmptyParameters parameters, global::Jint.DevTools.Session.CommandContext context)
+            => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.CSS.StopRuleUsageTrackingResponse>>("CSS.stopRuleUsageTracking");
+
+        /// <summary>Obtain list of rules that became used since last call to this method (or since start of coverage instrumentation).</summary>
+        /// <remarks>Reached only while manifest.json lists it. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#method-takeCoverageDelta"/>.</remarks>
+        protected virtual global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.CSS.TakeCoverageDeltaResponse> TakeCoverageDeltaAsync(global::Jint.DevTools.Protocol.EmptyParameters parameters, global::Jint.DevTools.Session.CommandContext context)
+            => global::Jint.DevTools.Throw.MethodNotFound<global::System.Threading.Tasks.ValueTask<global::Jint.DevTools.Protocol.CSS.TakeCoverageDeltaResponse>>("CSS.takeCoverageDelta");
+
         /// <inheritdoc/>
         internal sealed override async global::System.Threading.Tasks.ValueTask<string> DispatchAsync(string method, global::System.Text.Json.JsonElement? parameters, global::Jint.DevTools.Session.CommandContext context)
         {
@@ -258,6 +447,30 @@ namespace Jint.DevTools.Domains
                     return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.CSSGetInlineStylesForNodeResponse);
                 }
 
+                case "getStyleSheetText":
+                {
+                    var result = await GetStyleSheetTextAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.CSSGetStyleSheetTextRequest), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.CSSGetStyleSheetTextResponse);
+                }
+
+                case "startRuleUsageTracking":
+                {
+                    var result = await StartRuleUsageTrackingAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyResult);
+                }
+
+                case "stopRuleUsageTracking":
+                {
+                    var result = await StopRuleUsageTrackingAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.CSSStopRuleUsageTrackingResponse);
+                }
+
+                case "takeCoverageDelta":
+                {
+                    var result = await TakeCoverageDeltaAsync(global::Jint.DevTools.Protocol.ProtocolPayload.Read(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.EmptyParameters), context).ConfigureAwait(false);
+                    return global::System.Text.Json.JsonSerializer.Serialize(result, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.CSSTakeCoverageDeltaResponse);
+                }
+
                 // A command manifest.json does not list is method-not-found BEFORE its parameters
                 // are looked at, which is the order Chrome answers in: a command a backend does not
                 // implement is not in its dispatch table at all, so its payload is never read.
@@ -265,5 +478,15 @@ namespace Jint.DevTools.Domains
                     return global::Jint.DevTools.Throw.MethodNotFound<string>("CSS." + method);
             }
         }
+    }
+
+    /// <summary>Builds the <c>CSS</c> domain's events.</summary>
+    /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/"/>.</remarks>
+    internal static class CSSEvents
+    {
+        /// <summary>Builds the <c>CSS.styleSheetAdded</c> event.</summary>
+        /// <remarks>Generated from the pinned protocol; do not edit. See <see href="https://chromedevtools.github.io/devtools-protocol/tot/CSS/#event-styleSheetAdded"/>.</remarks>
+        internal static global::Jint.DevTools.Protocol.ProtocolEvent StyleSheetAdded(global::Jint.DevTools.Protocol.CSS.StyleSheetAddedEvent parameters)
+            => new("CSS.styleSheetAdded", global::System.Text.Json.JsonSerializer.Serialize(parameters, global::Jint.DevTools.Protocol.ProtocolJsonContext.Default.CSSStyleSheetAddedEvent));
     }
 }

--- a/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolJsonContext.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:190c8fa59465
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:a268bb8c038f
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -640,6 +640,8 @@ namespace Jint.DevTools.Protocol
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.Security.SetIgnoreCertificateErrorsRequest), TypeInfoPropertyName = "SecuritySetIgnoreCertificateErrorsRequest")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.Overlay.SetPausedInDebuggerMessageRequest), TypeInfoPropertyName = "OverlaySetPausedInDebuggerMessageRequest")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.Overlay.SetShowViewportSizeOnResizeRequest), TypeInfoPropertyName = "OverlaySetShowViewportSizeOnResizeRequest")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.CSSStyleSheetHeader), TypeInfoPropertyName = "CSSCSSStyleSheetHeader")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.RuleUsage), TypeInfoPropertyName = "CSSRuleUsage")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.SourceRange), TypeInfoPropertyName = "CSSSourceRange")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.ShorthandEntry), TypeInfoPropertyName = "CSSShorthandEntry")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.CSSComputedStyleProperty), TypeInfoPropertyName = "CSSCSSComputedStyleProperty")]
@@ -650,6 +652,11 @@ namespace Jint.DevTools.Protocol
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.GetComputedStyleForNodeResponse), TypeInfoPropertyName = "CSSGetComputedStyleForNodeResponse")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.GetInlineStylesForNodeRequest), TypeInfoPropertyName = "CSSGetInlineStylesForNodeRequest")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.GetInlineStylesForNodeResponse), TypeInfoPropertyName = "CSSGetInlineStylesForNodeResponse")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.GetStyleSheetTextRequest), TypeInfoPropertyName = "CSSGetStyleSheetTextRequest")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.GetStyleSheetTextResponse), TypeInfoPropertyName = "CSSGetStyleSheetTextResponse")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.StopRuleUsageTrackingResponse), TypeInfoPropertyName = "CSSStopRuleUsageTrackingResponse")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.TakeCoverageDeltaResponse), TypeInfoPropertyName = "CSSTakeCoverageDeltaResponse")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.StyleSheetAddedEvent), TypeInfoPropertyName = "CSSStyleSheetAddedEvent")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.Jint.GetMarkdownRequest), TypeInfoPropertyName = "JintGetMarkdownRequest")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.Jint.GetMarkdownResponse), TypeInfoPropertyName = "JintGetMarkdownResponse")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.Jint.GetTextRequest), TypeInfoPropertyName = "JintGetTextRequest")]
@@ -662,6 +669,7 @@ namespace Jint.DevTools.Protocol
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.Accessibility.AXValueSource[]), TypeInfoPropertyName = "AccessibilityAXValueSourceArray")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.CSSComputedStyleProperty[]), TypeInfoPropertyName = "CSSCSSComputedStylePropertyArray")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.CSSProperty[]), TypeInfoPropertyName = "CSSCSSPropertyArray")]
+    [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.RuleUsage[]), TypeInfoPropertyName = "CSSRuleUsageArray")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.CSS.ShorthandEntry[]), TypeInfoPropertyName = "CSSShorthandEntryArray")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.DOM.BackendNode[]), TypeInfoPropertyName = "DOMBackendNodeArray")]
     [global::System.Text.Json.Serialization.JsonSerializable(typeof(global::Jint.DevTools.Protocol.DOM.CSSComputedStyleProperty[]), TypeInfoPropertyName = "DOMCSSComputedStylePropertyArray")]

--- a/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
+++ b/Jint.DevTools/Protocol/Generated/ProtocolManifest.g.cs
@@ -4,7 +4,7 @@
 //
 //     source:   tools/devtools-protocol/js_protocol.json, browser_protocol.json, jint_protocol.json
 //     protocol: version 1.3, ChromeDevTools/devtools-protocol@ea39a11d80de9a08ce2af03f52125ed2e462cf84 (devtools-protocol@0.0.1687809)
-//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:190c8fa59465
+//     manifest: tools/devtools-protocol/manifest.json, whole file, sha256:a268bb8c038f
 //
 // Do not edit. Regenerate instead, and read the diff: it is the upstream change stated in the
 // vocabulary this repository compiles. tools/devtools-protocol/README.md has the command, and
@@ -79,6 +79,10 @@ namespace Jint.DevTools.Protocol
             "CSS.enable",
             "CSS.getComputedStyleForNode",
             "CSS.getInlineStylesForNode",
+            "CSS.getStyleSheetText",
+            "CSS.startRuleUsageTracking",
+            "CSS.stopRuleUsageTracking",
+            "CSS.takeCoverageDelta",
             "Debugger.continueToLocation",
             "Debugger.disable",
             "Debugger.enable",
@@ -269,6 +273,7 @@ namespace Jint.DevTools.Protocol
         /// <summary>The events this assembly emits.</summary>
         internal static global::System.Collections.Generic.IReadOnlyList<string> ImplementedEvents { get; } =
         [
+            "CSS.styleSheetAdded",
             "Console.messageAdded",
             "DOM.attributeModified",
             "DOM.attributeRemoved",

--- a/Jint.Tests.Browser/DevTools/CssCoverageTests.cs
+++ b/Jint.Tests.Browser/DevTools/CssCoverageTests.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+
+namespace Jint.Tests.Browser.DevTools;
+
+/// <summary>
+/// The <c>CSS</c> domain's rule-usage coverage over a real document, driven the way a coverage client
+/// drives it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every assertion here is made through the wire, because the whole feature is a wire contract: a client
+/// hears a <c>styleSheetAdded</c>, reads that sheet's text, is handed offsets into it, and slices. So the
+/// checks are the slices — the substring a reported range names — rather than an internal set of rules,
+/// which is what would still pass if the offsets were nonsense.
+/// </para>
+/// <para>
+/// The pages are deliberately tiny and deliberately have rules that must never be reported: one nothing
+/// matches, and one inside an <c>@media</c> block that cannot hold at any viewport.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public class CssCoverageTests
+{
+    private const string Styled =
+        """
+        <html><head><style>
+        .used { color: rgb(1, 2, 3) }
+        .unused { color: rgb(4, 5, 6) }
+        @media (min-width: 10px) { .conditional { color: rgb(7, 8, 9) } .conditionalunused { color: rgb(10, 11, 12) } }
+        @media (min-width: 99999px) { .impossible { color: rgb(13, 14, 15) } }
+        @supports (color: red) { .supported { color: rgb(16, 17, 18) } }
+        </style></head>
+        <body><p id="box" class="used conditional supported">text</p></body></html>
+        """;
+
+    [Test]
+    public async Task ARuleThatMatchedIsReportedAndOneThatNeverDidIsNot()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await OpenAsync(session, Styled);
+
+        await session.ResultAsync("CSS.enable", null, attachment);
+        await session.ResultAsync("CSS.startRuleUsageTracking", null, attachment);
+
+        var usage = (await session.ResultAsync("CSS.stopRuleUsageTracking", null, attachment))
+            .GetProperty("ruleUsage");
+
+        var covered = await SlicesAsync(session, attachment, usage);
+
+        covered.Should().Contain(slice => slice.Contains(".used", StringComparison.Ordinal));
+        covered.Should().NotContain(slice => slice.Contains(".unused", StringComparison.Ordinal),
+            "no element carries that class, so nothing ever matched the rule");
+        covered.Should().NotContain(slice => slice.Contains(".impossible", StringComparison.Ordinal),
+            "a rule inside a media block that cannot hold is never part of the cascade at all");
+
+        foreach (var entry in usage.EnumerateArray())
+        {
+            entry.GetProperty("used").GetBoolean().Should().BeTrue("every reported rule is one that matched");
+            entry.GetProperty("endOffset").GetDouble().Should()
+                .BeGreaterThan(entry.GetProperty("startOffset").GetDouble());
+        }
+    }
+
+    [Test]
+    public async Task EveryReportedRangeSlicesTheTextGetStyleSheetTextAnswers()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await OpenAsync(session, Styled);
+
+        await session.ResultAsync("CSS.enable", null, attachment);
+
+        var header = (await session.EventAsync("CSS.styleSheetAdded", 0, attachment)).GetProperty("header");
+        var styleSheetId = header.GetProperty("styleSheetId").GetString()!;
+
+        header.GetProperty("sourceURL").GetString().Should().NotBeNullOrEmpty(
+            "Puppeteer and Playwright both drop a header whose sourceURL is empty, so an inline sheet reported "
+            + "with none would be invisible to the clients this exists for");
+        header.GetProperty("isInline").GetBoolean().Should().BeTrue();
+        header.GetProperty("origin").GetString().Should().Be("regular");
+        header.GetProperty("frameId").GetString().Should().NotBeNullOrEmpty();
+
+        var text = (await session.ResultAsync(
+            "CSS.getStyleSheetText",
+            $$"""{"styleSheetId":"{{styleSheetId}}"}""",
+            attachment)).GetProperty("text").GetString()!;
+
+        header.GetProperty("length").GetInt32().Should().Be(text.Length);
+
+        await session.ResultAsync("CSS.startRuleUsageTracking", null, attachment);
+        var usage = (await session.ResultAsync("CSS.stopRuleUsageTracking", null, attachment))
+            .GetProperty("ruleUsage");
+
+        usage.GetArrayLength().Should().BeGreaterThan(0);
+
+        foreach (var entry in usage.EnumerateArray())
+        {
+            entry.GetProperty("styleSheetId").GetString().Should().Be(styleSheetId);
+
+            var start = entry.GetProperty("startOffset").GetInt32();
+            var end = entry.GetProperty("endOffset").GetInt32();
+
+            end.Should().BeLessThanOrEqualTo(text.Length, "an offset that does not index this text is unusable");
+            text[start..end].Should().EndWith("}", "a range runs from the selector to the closing brace");
+        }
+    }
+
+    [Test]
+    public async Task TwoDeltasReportEachRuleOnceAndTheSecondOnlyWhatBecameUsed()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await OpenAsync(session, Styled);
+
+        await session.ResultAsync("CSS.enable", null, attachment);
+        await session.ResultAsync("CSS.startRuleUsageTracking", null, attachment);
+
+        var first = await session.ResultAsync("CSS.takeCoverageDelta", null, attachment);
+        var firstSlices = await SlicesAsync(session, attachment, first.GetProperty("coverage"));
+
+        firstSlices.Should().Contain(slice => slice.Contains(".used", StringComparison.Ordinal));
+        firstSlices.Should().NotContain(slice => slice.Contains(".unused", StringComparison.Ordinal));
+        first.GetProperty("timestamp").GetDouble().Should().BeGreaterThan(0);
+
+        // Nothing has changed, so nothing became used: a rule that matched in one query and not in the
+        // next is used exactly once.
+        var empty = await session.ResultAsync("CSS.takeCoverageDelta", null, attachment);
+        empty.GetProperty("coverage").GetArrayLength().Should().Be(0);
+
+        // Now make the unused rule match, and compute a cascade over it the way a page does.
+        await session.EvaluateAsync(
+            "document.getElementById('box').className = 'unused'; getComputedStyle(document.getElementById('box')).color",
+            attachment);
+
+        var second = await session.ResultAsync("CSS.takeCoverageDelta", null, attachment);
+        var secondSlices = await SlicesAsync(session, attachment, second.GetProperty("coverage"));
+
+        secondSlices.Should().Contain(slice => slice.Contains(".unused", StringComparison.Ordinal),
+            "the cascade the page just computed matched it, which is what used means");
+        secondSlices.Should().NotContain(slice => slice.Contains(".used", StringComparison.Ordinal),
+            "a delta is what became used since the last one");
+    }
+
+    [Test]
+    public async Task ARuleInsideAConditionalGroupIsCountedOnItsOwn()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await OpenAsync(session, Styled);
+
+        await session.ResultAsync("CSS.enable", null, attachment);
+        await session.ResultAsync("CSS.startRuleUsageTracking", null, attachment);
+
+        var usage = (await session.ResultAsync("CSS.stopRuleUsageTracking", null, attachment))
+            .GetProperty("ruleUsage");
+
+        var text = await TextAsync(session, attachment, usage[0].GetProperty("styleSheetId").GetString()!);
+        var covered = Slices(text, usage);
+
+        covered.Should().Contain(slice => slice.StartsWith(".conditional ", StringComparison.Ordinal),
+            "a rule inside a media block whose condition holds is matched individually and reported on its own");
+        covered.Should().NotContain(slice => slice.StartsWith("@media", StringComparison.Ordinal),
+            "the group itself is not a style rule and matches nothing");
+        covered.Should().Contain(slice => slice.StartsWith(".supported ", StringComparison.Ordinal),
+            "and so is one inside an @supports whose condition holds");
+        covered.Should().NotContain(slice => slice.Contains(".conditionalunused", StringComparison.Ordinal),
+            "its sibling in the same block matches nothing");
+
+        // The nested rule's range sits inside its group's, which is what makes a client's slice legible.
+        var conditional = covered.Single(slice => slice.StartsWith(".conditional ", StringComparison.Ordinal));
+        var group = text.IndexOf("@media (min-width: 10px)", StringComparison.Ordinal);
+        text.IndexOf(conditional, StringComparison.Ordinal).Should().BeGreaterThan(group);
+    }
+
+    [Test]
+    public async Task ASheetAddedDuringTheWindowIsAnnouncedAndItsRulesAreCounted()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await OpenAsync(session, Styled);
+
+        await session.ResultAsync("CSS.enable", null, attachment);
+        await session.ResultAsync("CSS.startRuleUsageTracking", null, attachment);
+        await session.ResultAsync("CSS.takeCoverageDelta", null, attachment);
+
+        var announced = session.EventsOf("CSS.styleSheetAdded", attachment).Count;
+
+        await session.EvaluateAsync(
+            """
+            var sheet = document.createElement('style');
+            sheet.textContent = '#box { padding: 1px } .neverthere { padding: 2px }';
+            document.head.appendChild(sheet);
+            getComputedStyle(document.getElementById('box')).padding;
+            """,
+            attachment);
+
+        var delta = await session.ResultAsync("CSS.takeCoverageDelta", null, attachment);
+        var coverage = delta.GetProperty("coverage");
+
+        session.EventsOf("CSS.styleSheetAdded", attachment).Count.Should().BeGreaterThan(announced,
+            "the sheet the page just inserted has to be announced before a client is handed an offset into it");
+
+        var slices = await SlicesAsync(session, attachment, coverage);
+        slices.Should().Contain(slice => slice.StartsWith("#box ", StringComparison.Ordinal));
+        slices.Should().NotContain(slice => slice.Contains(".neverthere", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public async Task CoverageIsRefusedUntilAWindowIsOpen()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await OpenAsync(session, Styled);
+
+        await session.ResultAsync("CSS.enable", null, attachment);
+
+        foreach (var method in (string[]) ["CSS.takeCoverageDelta", "CSS.stopRuleUsageTracking"])
+        {
+            var error = await session.ErrorAsync(method, null, attachment);
+            error.GetProperty("code").GetInt32().Should().Be(-32000);
+            error.GetProperty("message").GetString().Should().Contain("not enabled");
+        }
+
+        var unknown = await session.ErrorAsync("CSS.getStyleSheetText", """{"styleSheetId":"nope"}""", attachment);
+        unknown.GetProperty("code").GetInt32().Should().Be(-32000);
+    }
+
+    [Test]
+    public async Task StoppingTwiceIsRefusedBecauseTheWindowIsClosed()
+    {
+        await using var session = await PageSession.CreateAsync();
+        var attachment = await OpenAsync(session, Styled);
+
+        await session.ResultAsync("CSS.enable", null, attachment);
+        await session.ResultAsync("CSS.startRuleUsageTracking", null, attachment);
+        await session.ResultAsync("CSS.stopRuleUsageTracking", null, attachment);
+
+        var error = await session.ErrorAsync("CSS.stopRuleUsageTracking", null, attachment);
+        error.GetProperty("code").GetInt32().Should().Be(-32000);
+    }
+
+    /// <summary>The substrings a coverage report names, read out of the sheet's own text.</summary>
+    private static async Task<string[]> SlicesAsync(PageSession session, string attachment, JsonElement usage)
+    {
+        var texts = new Dictionary<string, string>(StringComparer.Ordinal);
+        var slices = new List<string>();
+
+        foreach (var entry in usage.EnumerateArray())
+        {
+            var id = entry.GetProperty("styleSheetId").GetString()!;
+            if (!texts.TryGetValue(id, out var text))
+            {
+                text = await TextAsync(session, attachment, id).ConfigureAwait(false);
+                texts[id] = text;
+            }
+
+            slices.Add(text[entry.GetProperty("startOffset").GetInt32()..entry.GetProperty("endOffset").GetInt32()]);
+        }
+
+        return [.. slices];
+    }
+
+    private static string[] Slices(string text, JsonElement usage)
+    {
+        var slices = new List<string>();
+        foreach (var entry in usage.EnumerateArray())
+        {
+            slices.Add(text[entry.GetProperty("startOffset").GetInt32()..entry.GetProperty("endOffset").GetInt32()]);
+        }
+
+        return [.. slices];
+    }
+
+    private static async Task<string> TextAsync(PageSession session, string attachment, string styleSheetId)
+        => (await session.ResultAsync(
+            "CSS.getStyleSheetText",
+            $$"""{"styleSheetId":"{{styleSheetId}}"}""",
+            attachment).ConfigureAwait(false)).GetProperty("text").GetString()!;
+
+    private static async Task<string> OpenAsync(PageSession session, string html)
+    {
+        var attachment = await session.OpenPageAsync().ConfigureAwait(false);
+        await session.EnablePageAsync(attachment).ConfigureAwait(false);
+
+        var tree = await session.ResultAsync("Page.getFrameTree", null, attachment).ConfigureAwait(false);
+        var frameId = tree.GetProperty("frameTree").GetProperty("frame").GetProperty("id").GetString()!;
+
+        var payload = JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["frameId"] = frameId,
+            ["html"] = html,
+        });
+
+        await session.ResultAsync("Page.setDocumentContent", payload, attachment).ConfigureAwait(false);
+        return attachment;
+    }
+}

--- a/Jint.Tests.Browser/DevTools/CssRuleUsageSeamTests.cs
+++ b/Jint.Tests.Browser/DevTools/CssRuleUsageSeamTests.cs
@@ -1,0 +1,127 @@
+#nullable enable
+
+using Jint.Browser.Dom.Views;
+using Jint.Browser.Runtime;
+
+namespace Jint.Tests.Browser.DevTools;
+
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// The cascade seam rule-usage coverage records through, and what it costs a page nobody is tracking.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The protocol suite next door asserts what a client is told; this asserts the one thing a client cannot
+/// see and an edit can silently undo — that <b>nothing is recorded, and no tracker is even consulted, while
+/// no window is open</b>. It is written as a record count rather than as a memory measurement on purpose: a
+/// cascade allocates plenty on its own, so a byte counter around one would be measuring AngleSharp, while a
+/// window that was armed only afterwards and still holds nothing is a direct statement that the disarmed
+/// path recorded nothing at all.
+/// </para>
+/// <para>
+/// It is <c>[NonParallelizable]</c> because the seam's arming list is process-wide, and a coverage window
+/// opened by another fixture's page would be armed while this one asserts that nothing is.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class CssRuleUsageSeamTests
+{
+    private const string Styled =
+        "<style>.used { color: rgb(1, 2, 3) } .unused { color: rgb(4, 5, 6) }</style>"
+        + "<p id='box' class='used'>text</p>";
+
+    [Test]
+    public async Task ACascadeRecordsNothingWhileNoWindowIsOpen()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Styled);
+
+        var recorded = await page.RunOnLoopAsync(engine =>
+        {
+            var document = PageRuntime.Find(engine)!.Document!;
+            var box = document.GetElementById("box")!;
+
+            CssRuleUsage.IsTracking.Should().BeFalse("no client has asked for coverage");
+
+            // Exactly the computation getComputedStyle, every box the flat model measures and the
+            // accessibility tree's hidden verdict all come through.
+            for (var i = 0; i < 8; i++)
+            {
+                CssCascade.Of(box).Should().NotBeNull();
+            }
+
+            var tracker = new CssRuleUsageTracker();
+            tracker.Rebind(document);
+
+            // Armed only now, and asked what the eight cascades above left in it.
+            return tracker.TakeDelta().Length;
+        });
+
+        recorded.Should().Be(0, "a page nobody is tracking records nothing, and the seam is one static read");
+    }
+
+    [Test]
+    public async Task AnArmedWindowRecordsTheRulesACascadeMatchedAndStopsWhenDisarmed()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Styled);
+
+        var (whileArmed, afterDisarm) = await page.RunOnLoopAsync(engine =>
+        {
+            var document = PageRuntime.Find(engine)!.Document!;
+            var box = document.GetElementById("box")!;
+
+            var tracker = new CssRuleUsageTracker();
+            tracker.Rebind(document);
+            CssRuleUsage.Arm(tracker);
+
+            try
+            {
+                CssRuleUsage.IsTracking.Should().BeTrue();
+                CssCascade.Of(box).Should().NotBeNull();
+
+                // A second cascade over the same element adds nothing: a rule is used once.
+                CssCascade.Of(box).Should().NotBeNull();
+                var armed = tracker.TakeDelta();
+
+                CssRuleUsage.Disarm(tracker);
+                CssRuleUsage.IsTracking.Should().BeFalse();
+
+                CssCascade.Of(document.GetElementById("box")!).Should().NotBeNull();
+                return (armed.Length, tracker.TakeDelta().Length);
+            }
+            finally
+            {
+                CssRuleUsage.Disarm(tracker);
+            }
+        });
+
+        whileArmed.Should().BeGreaterThan(0, "the cascade matched the page's own .used rule");
+        afterDisarm.Should().Be(0, "a disarmed window hears nothing more");
+    }
+
+    [Test]
+    public async Task ASweepRecordsWhatMatchesTheDocumentWithoutAnyoneComputingACascade()
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(Styled);
+
+        var swept = await page.RunOnLoopAsync(engine =>
+        {
+            var document = PageRuntime.Find(engine)!.Document!;
+
+            var tracker = new CssRuleUsageTracker();
+            tracker.Rebind(document);
+            tracker.Sweep();
+
+            return tracker.TakeDelta().Length;
+        });
+
+        swept.Should().BeGreaterThan(0,
+            "this is Blink's forced style recalculation on start, and nothing renders here to do it for us");
+    }
+}

--- a/Jint.Tests.Browser/DevTools/PuppeteerSharpPageTests.cs
+++ b/Jint.Tests.Browser/DevTools/PuppeteerSharpPageTests.cs
@@ -642,6 +642,65 @@ public class PuppeteerSharpPageTests
         await context.CloseAsync();
     }
 
+    /// <summary>
+    /// <c>page.coverage.startCSSCoverage()</c>, which is the whole reason the <c>CSS</c> domain's
+    /// rule-usage half exists.
+    /// </summary>
+    /// <remarks>
+    /// Puppeteer builds this out of five calls and this test asserts none of them: what it asserts is the
+    /// thing only a client can, which is that the five fit together. The library enables <c>DOM</c> and
+    /// <c>CSS</c>, starts rule-usage tracking, collects a <c>styleSheetAdded</c> and reads that sheet's text,
+    /// stops tracking and then <b>slices that text with the offsets it was handed</b>. A header with an empty
+    /// <c>sourceURL</c>, a text that did not come from the same serialization as the offsets, or a range past
+    /// the end of it, and what comes back is empty or garbage rather than the rules the page used.
+    /// </remarks>
+    [Test]
+    public async Task PuppeteerReadsCssCoverageOffThePage()
+    {
+        using var origin = new LoopbackServer();
+        origin.MapHtml(
+            "/styled",
+            """
+            <html><head><title>Styled</title><style>
+            .used { color: rgb(1, 2, 3) }
+            .never { color: rgb(4, 5, 6) }
+            </style></head>
+            <body><p id="box" class="used">text</p></body></html>
+            """);
+
+        await using var pages = new global::Jint.Browser.Browser();
+        var context = await pages.NewContextAsync(new PageContextOptions { UrlFilter = origin.Owns });
+
+        await using var server = new DevToolsServer();
+        await server.AddBrowser(pages);
+        await server.StartAsync();
+
+        await using var browser = await Puppeteer.ConnectAsync(new ConnectOptions
+        {
+            BrowserWSEndpoint = server.BrowserWebSocketUrl,
+        }).WaitAsync(Bound);
+
+        var page = await browser.NewPageAsync().WaitAsync(Bound);
+        await page.GoToAsync(origin.Url("/styled")).WaitAsync(Bound);
+
+        await page.Coverage.StartCSSCoverageAsync().WaitAsync(Bound);
+        var entries = await page.Coverage.StopCSSCoverageAsync().WaitAsync(Bound);
+
+        entries.Should().NotBeEmpty("the page has a style sheet and one of its rules matched an element");
+
+        var entry = entries.Single(candidate => candidate.Text.Contains(".used", StringComparison.Ordinal));
+        entry.Url.Should().Be(origin.Url("/styled"), "an inline sheet is reported under the document's URL");
+        entry.Ranges.Should().NotBeEmpty();
+
+        var covered = string.Concat(entry.Ranges.Select(range => entry.Text[range.Start..range.End]));
+        covered.Should().Contain(".used");
+        covered.Should().NotContain(".never", "no element carries that class");
+
+        await page.CloseAsync().WaitAsync(Bound);
+        browser.Disconnect();
+        await context.CloseAsync();
+    }
+
     /// <summary>Runs <paramref name="work"/> and answers what it threw, or <see langword="null"/>.</summary>
     private static async Task<Exception?> CatchAsync(Func<Task> work)
     {

--- a/tools/devtools-protocol/manifest.json
+++ b/tools/devtools-protocol/manifest.json
@@ -100,11 +100,20 @@
       "commands": ["disable", "enable", "hideHighlight", "setPausedInDebuggerMessage", "setShowViewportSizeOnResize"]
     },
 
-    // Computed and inline styles are what the flat box model can answer for. Style sheet editing, rule
-    // matching, coverage, font and animation tracking are the other thirty-five commands.
+    // Computed and inline styles are what the flat box model can answer for, and rule-usage coverage is
+    // what Puppeteer's and Playwright's CSS coverage is built out of: startRuleUsageTracking,
+    // takeCoverageDelta and stopRuleUsageTracking, with the styleSheetAdded stream and getStyleSheetText a
+    // client needs to make sense of an offset. Style sheet editing, rule matching, font and animation
+    // tracking are the rest of the domain. styleSheetChanged and styleSheetRemoved are left out because
+    // AngleSharp raises no notification a sheet's arrival or departure could be published from; the sheets
+    // are reconciled when a client asks, which DevTools/AGENTS.md states.
     {
       "domain": "CSS",
-      "commands": ["disable", "enable", "getComputedStyleForNode", "getInlineStylesForNode"]
+      "commands": [
+        "disable", "enable", "getComputedStyleForNode", "getInlineStylesForNode", "getStyleSheetText",
+        "startRuleUsageTracking", "stopRuleUsageTracking", "takeCoverageDelta"
+      ],
+      "events": ["styleSheetAdded"]
     },
 
     "Jint"
@@ -230,6 +239,10 @@
     "CSS.enable",
     "CSS.getComputedStyleForNode",
     "CSS.getInlineStylesForNode",
+    "CSS.getStyleSheetText",
+    "CSS.startRuleUsageTracking",
+    "CSS.stopRuleUsageTracking",
+    "CSS.takeCoverageDelta",
     "Debugger.continueToLocation",
     "Debugger.disable",
     "Debugger.enable",
@@ -423,6 +436,7 @@
   // of a target while others live. Debugger.scriptFailedToParse is absent because the engine raises
   // BeforeEvaluate only for a program it did parse; a parse failure never reaches this package.
   "implementedEvents": [
+    "CSS.styleSheetAdded",
     "Console.messageAdded",
     "DOM.attributeModified",
     "DOM.attributeRemoved",


### PR DESCRIPTION
## What and why

`CSS.startRuleUsageTracking`, `CSS.takeCoverageDelta` and `CSS.stopRuleUsageTracking`, plus the
`CSS.styleSheetAdded` stream and `CSS.getStyleSheetText` that go with them.

Those five calls **are** `page.coverage.startCSSCoverage()`: Puppeteer's and Playwright's Chromium CSS
coverage each enable `DOM` and `CSS`, start rule-usage tracking, collect a `styleSheetAdded` and read that
sheet's text, stop tracking, and then slice the text with the offsets they were handed. Before this, the
first of the five answered `-32601` and a client got a `MessageException` instead of a coverage report.

Everything added is internal. There is no public API change, so
`Jint.Tests.Browser/Verify/PublicApiTest.verified.txt` is untouched and there is no
`docs/guide/migrating-to-v5.md` row.

## Mechanism

**A rule is used when it matched an element in a cascade computation while a window was open.**
`Jint.Browser/Dom/Views/CssRuleUsage.cs` is the seam and `Dom/Views/CssCascade` is where it sits — the one
guarded door every cascade computation already comes through — so `getComputedStyle`, every box the flat
model measures, the accessibility tree's hidden verdict and the domain's own `getComputedStyleForNode` all
feed it.

**A page nobody is tracking pays a static read.** The arming list is a `CssRuleUsageTracker[]`; `Observe` is
a `Volatile.Read` plus a length test, with the recording itself behind a `NoInlining` call so the guard is
the only thing a caller's code carries. That is the same shape `WebSocketObserver` and
`CollectHttpResponseDetails` use — armed only when a client asks.

**The matching is done again rather than read off the cascade, and that is forced by AngleSharp.Css** (see
the upstream findings below). The window re-matches over `IWindow.GetStyleCollection(device)` — AngleSharp's
own flattened, ordered, condition-filtered candidate list, the one the cascade itself matches against — with
the public `ICssStyleRule.TryMatch`, over only the rules it has not already recorded, computing no values at
all. Three of the required behaviours fall out of using that list rather than being coded:

- a rule inside an `@media` or `@supports` whose condition holds is enumerated individually, so it counts on
  its own;
- a rule inside a group whose condition does not hold is never a candidate, so it can never be reported;
- a rule that matched once leaves the candidate list, so a rule that matches in one query and not in another
  still counts once.

Inline `style` attributes are not rules and are nowhere in that list, so they are excluded by construction.
User-agent rules are excluded because their sheet is not among `document.StyleSheets` and so is never given a
`styleSheetId` — which is what the protocol asks for ("absent for user agent stylesheet … rules").

**Starting a window walks the document once, and so does a commit.** Blink's `startRuleUsageTracking` does
not merely arm a counter: `setUsageTrackerStatus(true)` marks every element of every document for style
recalculation and runs it, so coverage describes the page as it stands
([`InspectorCSSAgent.cpp`](https://chromium.googlesource.com/chromium/src/+/90d4ea3d/third_party/WebKit/Source/core/inspector/InspectorCSSAgent.cpp)).
Nothing renders here, so a document nobody queries computes no cascade and a window opened over it would be
empty. The sweep is selector matching and no value computation.

**The offsets index the text this domain hands out and no other string.** `CssStyleSheetText` serializes a
sheet and measures that same serialization; `getStyleSheetText` answers with it. One rule per line, two
spaces of nesting, an LF break everywhere — deliberately not `ICssStyleSheet.ToCss()`, which joins with the
platform's newline (offsets four bytes apart on Windows and Linux for the same page) and writes a grouping
rule on one line (leaving a nested rule with no range of its own). Chrome does the same thing for a sheet
with no source text of its own, a constructed `new CSSStyleSheet()`.

**Sheets are reconciled when a client asks, not watched.** `CssStyleSheetTracker` mints a `styleSheetId` per
document, shared by every attachment exactly as `DomNodeTracker` mints a `nodeId`, and cleared on every
commit. `styleSheetAdded` is emitted at `CSS.enable`, at each document commit (from `PageTarget`'s
`DocumentParsed`, the first moment there is a tree to read sheets off), and before any command that hands out
an offset — which is what makes a sheet inserted mid-window announced before its rules are reported. An
inline sheet's `sourceURL` is the document's, which is Chrome's answer and load-bearing: both clients drop a
header whose `sourceURL` is empty.

**Threading.** Every command runs on the page loop through the target's mailbox, as all page-level commands
do; nothing is added to `PageTarget.RunsOffThread`. The tracker's state is touched only on that loop; the
arming list is behind a lock and read volatile.

The three commands went in through `tools/devtools-protocol/manifest.json` and the generator was re-run.

## Failing-first evidence

A second worktree at unmodified `upstream/main` (`8ea3bd23`), with only the new test files copied in:

```
dotnet test Jint.Tests.Browser -c Release -f net8.0 \
  --filter "FullyQualifiedName~CssCoverageTests|FullyQualifiedName~PuppeteerReadsCssCoverageOffThePage"
Failed! - Failed: 8, Passed: 0, Skipped: 0, Total: 8
```

with, in the messages:

- `'CSS.startRuleUsageTracking' was expected to succeed, and it answered {"code":-32601,…}` (5 cases)
- `Expected error.GetProperty("code").GetInt32() to be -32000, but found -32601` (`CoverageIsRefusedUntilAWindowIsOpen`)
- `'CSS.styleSheetAdded' number 0 never arrived within 60 seconds` (`EveryReportedRangeSlicesTheTextGetStyleSheetTextAnswers`)
- `PuppeteerSharp.MessageException : Protocol error (CSS.startRuleUsageTracking): 'CSS.startRuleUsageTracking' wasn't found` (the client case)

All eight pass on this branch.

The two seam tests (`CssRuleUsageSeamTests`) exercise types this PR adds, so they cannot compile on `main`.
Their failing-first evidence is a mutation instead: **deleting the two `CssRuleUsage.Observe` calls from
`CssCascade`** (leaving everything else, the start sweep included) fails

- `AnArmedWindowRecordsTheRulesACascadeMatchedAndStopsWhenDisarmed` — *Expected value to be greater than 0 …
  but found 0*
- `TwoDeltasReportEachRuleOnceAndTheSecondOnlyWhatBecameUsed` — *Expected secondSlices {empty} to have an
  item matching slice.Contains(".unused", Ordinal)*

so the coverage genuinely comes through the cascade seam rather than through the sweep alone. Restored, both
pass.

## What was verified

Release only, never `--no-build` for the first run of each leg. Base for all of it: `8ea3bd23`.

| Command | Result |
| --- | --- |
| `dotnet build -c Release` (solution) | 0 errors; the one `MSB3277` is a pre-existing `System.Memory` conflict in `Jint.Tests.CommonScripts` `net472` |
| `dotnet test Jint.Tests.Browser -c Release` (net8.0 + net10.0) | **2398** and **2402** passed, 0 failed, 38 skipped |
| `dotnet test Jint.Tests.DevTools -c Release` (net8.0 + net10.0) | 413 and 415 passed, 0 failed — includes `GeneratedProtocolIsCurrentTests` and `ProtocolManifestTests` |
| `Jint.Tests.Browser` filtered to `PageProtocolManifestTests`, `FrontEndDomainTests`, `PageHandshakeReplayTests` | 18 passed |
| `Jint.Tests` filtered to `AgentInstructionFileTests` | 5 passed (`Jint.Browser/DevTools/AGENTS.md` 23.4 KiB, `Jint.Browser/AGENTS.md` 29.3 KiB, both under the 32 KiB cap) |
| `JINT_BROWSER_CLIENTS=1`, filtered to `PlaywrightCourseTests` and `PuppeteerSharp` (net8.0 and net10.0) | 41 passed, 1 failed — `PlaywrightClickDoesNotWaitForARefusedNavigation("http://127.0.0.1:1/blocked")`, `System.TimeoutException : Timeout 2000ms exceeded`. **Reproduced identically on unmodified `upstream/main` in the base worktree**, so it is pre-existing on this machine and not this change |
| new cases | 7 protocol (`CssCoverageTests`), 3 seam (`CssRuleUsageSeamTests`), 1 client (`PuppeteerSharpPageTests.PuppeteerReadsCssCoverageOffThePage`) |

The client case is in `PuppeteerSharpPageTests`, which is ungated and therefore runs on **every** CI leg —
`browser-clients` is only needed for Playwright's Node driver.

## What was deliberately left out

- **`CSS.styleSheetChanged` and `CSS.styleSheetRemoved`.** AngleSharp raises no notification when a sheet
  joins, leaves or is edited — `IStyleSheetList` is a live view with no event on it — so there is nothing to
  publish from. The consequence is stated rather than hidden: a client can cache a text a page has since
  edited. Sheets are instead reconciled at `enable`, at each commit, and before any command that hands out an
  offset.
- **A Playwright coverage case.** `Microsoft.Playwright` for .NET exposes no `Coverage` API at all (it is a
  JavaScript-only surface), so there is nothing to drive it with from `PlaywrightCourseTests`. PuppeteerSharp
  has `IPage.Coverage`, and that is the client lane used.
- **`CSS.getMatchedStylesForNode`, `setStyleTexts`, `addRule`, `createStyleSheet`.** Still `-32601`, and
  `EditingAStyleSheetStaysAbsent` still pins that. `getMatchedStylesForNode` would have to name the rule
  every declaration came from, which is exactly what AngleSharp.Css does not expose.
- **A rule inserted into an `@media` block of a sheet that was already in the document** is not picked up
  until something else moves the sheet set or its top-level rule count. There is no CSSOM mutation signal to
  hang a precise invalidation on, and re-flattening every sheet for every element would make each cascade
  quadratic in the page's rules. A rule inserted at a sheet's top level, and a whole sheet appearing or
  disappearing, are both caught.
- **A rule with no range of its own** — a style rule nested inside another style rule, under CSS nesting —
  is not reported rather than reported with its parent's offsets.

## Upstream findings (AngleSharp.Css)

Reported here rather than worked around silently, per `Jint.Browser/AGENTS.md`. **No issue has been opened on
the AngleSharp repositories.**

1. **The computed-style pipeline exposes no matched-rule identity.** `IElement.ComputeCurrentStyle()`,
   `IStyleCollection.ComputeCascadedStyle`, `ComputeExplicitStyle` and `GetDeclarations` all answer an
   `ICssStyleDeclaration`, and neither it nor the `ICssProperty` objects in it carry the `ICssStyleRule` a
   declaration came from. There is no public member anywhere in the assembly that reports which rules matched
   an element. Rule identity therefore cannot be recovered from a cascade that has already run, which is why
   this implements coverage over `IStyleCollection` + `ICssStyleRule.TryMatch` — a second matching pass, with
   no value computation — rather than over the cascade the page already performed. A seam reporting the
   matched rule list (or an originating rule on `ICssProperty`) would let a coverage recorder ride the
   existing cascade instead.
2. **No `ICssRule` carries a source position.** `IStyleSheet.Source` keeps the authored text, but nothing
   relates a rule to an offset inside it, so an authored-text range cannot be computed at all — the reason
   `getStyleSheetText` answers the CSSOM serialization here and the coverage offsets index that. Chrome
   reports authored bytes and positions within the document for an inline `<style>`; this cannot, and says so
   in `Jint.Browser/DevTools/AGENTS.md`.
3. Neither of these is a standards divergence, so neither belongs in `Jint.Browser/Dom/divergences.md`: they
   are gaps in what the CLR surface exposes.

## Base

`8ea3bd236978b75f90d2543a21b4bcf84a774fea` (`upstream/main`, "DOM collections, the ChildNode mutation order,
and three binding leftovers (#3992)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
