### PR TITLE
Backport #3751 to 4.x: Temporal: the persian calendar extends into proleptic years on the 33-year cycle

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -276,7 +276,14 @@
     "intl402/Temporal/PlainDate/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDate/prototype/inLeapYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainDate/prototype/with/basic-islamic-umalqura.js",
+    // The three `*/prototype/withCalendar/extreme-dates.js` files are out on `chinese`, not on a
+    // calendar this branch reckons: their persian rows pass since #3751 was backported, and the run
+    // now stops at "chinese minimum non-approximated date". That is the lunisolar reckoning chain
+    // (#3482/#3502/#3519), which 4.x does not carry -- on main these four came out together.
     "intl402/Temporal/PlainDate/prototype/withCalendar/extreme-dates.js",
+    // Still out, but on a range check rather than a calendar: one of its extremes raises
+    // "Date is outside valid range" from PlainDateTime.from. The persian rows it shares with the
+    // withCalendar files pass (https://github.com/sebastienros/jint/issues/3604).
     "intl402/Temporal/PlainDateTime/from/extreme-dates.js",
     "intl402/Temporal/PlainDateTime/from/roundtrip-from-property-bag.js",
     "intl402/Temporal/PlainDateTime/prototype/daysInMonth/basic-islamic-umalqura.js",
@@ -291,7 +298,6 @@
     "intl402/Temporal/PlainYearMonth/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainYearMonth/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/PlainYearMonth/prototype/inLeapYear/basic-islamic-umalqura.js",
-    "intl402/Temporal/ZonedDateTime/from/extreme-dates.js",
     "intl402/Temporal/ZonedDateTime/from/roundtrip-from-property-bag.js",
     "intl402/Temporal/ZonedDateTime/prototype/daysInMonth/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/prototype/daysInYear/basic-islamic-umalqura.js",

--- a/Jint.Tests/Runtime/NonIsoCalendarTests.cs
+++ b/Jint.Tests/Runtime/NonIsoCalendarTests.cs
@@ -73,4 +73,58 @@ public class NonIsoCalendarTests
         combinations.Should().Be(Calendars.Length * Years.Length * MonthCodes.Length * 15 * Days.Length);
         failures.ToString().Should().BeEmpty();
     }
+
+    /// <summary>
+    /// The Persian calendar at both ends of Temporal's own range, where the arithmetic rule is the only
+    /// thing that can answer: <c>PersianCalendar</c>'s table stops at ISO 622-03-22 and 9999-12-31, and
+    /// these two dates are a quarter of a million years outside it in either direction.
+    /// </summary>
+    /// <remarks>
+    /// The expected values are test262's own — the three
+    /// <c>intl402/Temporal/*/prototype/withCalendar/extreme-dates.js</c> files assert exactly these, and
+    /// <c>ZonedDateTime/from/extreme-dates.js</c> asserts the way back — which is to say they are ICU's
+    /// 33-year cycle. The 2820-year cycle Jint used to extend the calendar with put both ends about two
+    /// months out, and therefore in the wrong Persian year
+    /// (<see href="https://github.com/sebastienros/jint/issues/3604"/>). <c>eraYear</c> is the same number
+    /// as <c>year</c> because <c>ap</c> is the calendar's only era, which is why the off-by-one was first
+    /// read as an era defect.
+    /// </remarks>
+    [Theory]
+    [InlineData("-271821-04-20", -272442, 1, "M01", 10)]
+    [InlineData("+275760-09-13", 275139, 7, "M07", 12)]
+    public void ThePersianCalendarPlacesTheEndsOfTemporalsRangeWhereTheStandardLibrariesDo(
+        string iso, int year, int month, string monthCode, int day)
+    {
+        var engine = new Engine();
+        var date = $"Temporal.PlainDate.from('{iso}').withCalendar('persian')";
+
+        engine.Evaluate($"{date}.year").AsNumber().Should().Be(year);
+        engine.Evaluate($"{date}.month").AsNumber().Should().Be(month);
+        engine.Evaluate($"{date}.monthCode").AsString().Should().Be(monthCode);
+        engine.Evaluate($"{date}.day").AsNumber().Should().Be(day);
+        engine.Evaluate($"{date}.era").AsString().Should().Be("ap");
+        engine.Evaluate($"{date}.eraYear").AsNumber().Should().Be(year);
+
+        // And the way back, which is what ZonedDateTime/from/extreme-dates.js failed on: the fields are
+        // an answer only if they name the day they came from.
+        engine.Evaluate($"Temporal.PlainDate.from({{ calendar: 'persian', year: {year}, month: {month}, day: {day} }}).toString()")
+            .AsString().Should().Be($"{iso}[u-ca=persian]");
+    }
+
+    /// <summary>
+    /// The years <c>PersianCalendar</c> does cover are still its own to place, which the arithmetic rule
+    /// never reaches: Nowruz 1403 fell on ISO 2024-03-20, and the revolution of 22 Bahman 1357 on
+    /// 1979-02-11.
+    /// </summary>
+    [Theory]
+    [InlineData("2024-03-20", 1403, 1, 1)]
+    [InlineData("1979-02-11", 1357, 11, 22)]
+    public void ThePersianCalendarStillPlacesTheYearsItsTableCovers(string iso, int year, int month, int day)
+    {
+        var engine = new Engine();
+        var date = $"Temporal.PlainDate.from('{iso}').withCalendar('persian')";
+
+        engine.Evaluate($"[{date}.year, {date}.month, {date}.day].join('-')")
+            .AsString().Should().Be($"{year}-{month}-{day}");
+    }
 }

--- a/Jint.Tests/Runtime/PersianCalendarBoundaryTests.cs
+++ b/Jint.Tests/Runtime/PersianCalendarBoundaryTests.cs
@@ -1,0 +1,391 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using Jint.Native.Temporal;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Where the <c>persian</c> calendar stops delegating to <see cref="PersianCalendar"/> and starts
+/// reckoning on the 33-year cycle, and that each side of that seam is answered by one rule alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The seam used to be wherever the runner's own calendar data put it — <c>MinSupportedDateTime</c>,
+/// <c>MaxSupportedDateTime</c>, and the refusal <c>ToDateTime</c> raises outside them — so "outside the
+/// table" was a different set of dates on a runtime whose data differed, and every proleptic answer moved
+/// with it. It is now an ISO window Jint states for itself, 622-03-22 through 9999-12-31
+/// (<see href="https://github.com/sebastienros/jint/issues/3604"/>).
+/// </para>
+/// <para>
+/// So there are two kinds of assertion here, and neither is a date written down because a run once
+/// produced it. <see cref="ThePlatformsPersianTableCoversExactlyTheWindowJintStates"/> asserts the
+/// constants against the platform, so a runtime that ever moves its window fails there, naming the
+/// reason, rather than moving a date a quarter of a million years away on one CI leg. Everything else
+/// asserts Jint against the 33-year cycle, which this file writes out for itself — a test that asked the
+/// engine what the engine's arithmetic ought to be would say nothing — and that cycle is integer
+/// arithmetic on a fixed epoch, so its answers are the same on every runner by construction.
+/// </para>
+/// <para>
+/// Both rules are needed, which is why the delegation is still there. Over the 9,377 whole years the two
+/// share they disagree about 4,144 year-starts, and about which Persian month 1,514,413 of the window's
+/// 3,425,164 days fall in: the table derives a year from the true vernal equinox at Tehran and is what
+/// makes a date anybody keeps right, while the cycle is what every other Temporal implementation answers
+/// a proleptic date with.
+/// </para>
+/// </remarks>
+public class PersianCalendarBoundaryTests
+{
+    // The window Jint states, restated here so that moving it has to be a decision taken twice.
+    private static readonly DateTime FirstIsoDay = new(622, 3, 22);
+    private static readonly DateTime LastIsoDay = new(9999, 12, 31);
+    private const int LastTableYear = 9378;
+    private const int LastTableMonth = 10;
+    private const int LastTableDay = 13;
+
+    // The 33-year cycle, written out rather than reached for. The epoch is the Julian Day Number of ISO
+    // 622-03-21, which is where the cycle starts Persian year 1 — a day before the table does.
+    private const long PersianEpochJdn = 1948320L;
+    private const long JdnOfEpochDay = 2440588L; // ISO 1970-01-01, the day count Temporal reckons in
+
+    private static long FloorDiv(long a, long b)
+    {
+        var q = a / b;
+        if ((a ^ b) < 0L && q * b != a)
+        {
+            q--;
+        }
+
+        return q;
+    }
+
+    private static long FloorMod(long a, long b)
+    {
+        var r = a % b;
+        if (r != 0L && (r ^ b) < 0L)
+        {
+            r += b;
+        }
+
+        return r;
+    }
+
+    private static bool CycleIsLeapYear(long year) => FloorMod(25L * year + 11L, 33L) < 8L;
+
+    private static long CycleYearStartJdn(long year)
+        => PersianEpochJdn + 365L * (year - 1L) + FloorDiv(8L * year + 21L, 33L);
+
+    private static int CycleDaysInMonth(long year, int month)
+    {
+        if (month <= 6)
+        {
+            return 31;
+        }
+
+        if (month <= 11)
+        {
+            return 30;
+        }
+
+        return CycleIsLeapYear(year) ? 30 : 29;
+    }
+
+    /// <summary>The Persian date the cycle puts on a Julian Day Number.</summary>
+    private static (long Year, int Month, int Day) CyclePlace(long jdn)
+    {
+        var year = FloorDiv(jdn - PersianEpochJdn, 365L) + 1L;
+        while (CycleYearStartJdn(year + 1L) <= jdn)
+        {
+            year++;
+        }
+
+        while (CycleYearStartJdn(year) > jdn)
+        {
+            year--;
+        }
+
+        var dayOfYear = jdn - CycleYearStartJdn(year) + 1L;
+
+        if (dayOfYear <= 186L)
+        {
+            var early = (int) ((dayOfYear - 1L) / 31L) + 1;
+            return (year, early, (int) (dayOfYear - (early - 1) * 31L));
+        }
+
+        var remaining = dayOfYear - 186L;
+        var late = (int) ((remaining - 1L) / 30L) + 7;
+        return (year, late, (int) (remaining - (late - 7) * 30L));
+    }
+
+    private static long JdnOfIsoDay(DateTime day)
+        => TemporalHelpers.IsoDateToDays(day.Year, day.Month, day.Day) + JdnOfEpochDay;
+
+    private static (long Year, int Month, int Day) PlacedByJint(long jdn)
+    {
+        var iso = TemporalHelpers.DaysToIsoDate(jdn - JdnOfEpochDay);
+        var placed = NonIsoCalendars.IsoToCalendarDate("persian", in iso);
+        return (placed.Year, placed.Month, placed.Day);
+    }
+
+    /// <summary>
+    /// The platform's table still covers exactly the window Jint says it does, in ISO days and in Persian
+    /// fields both. This is the one assertion here that can fail for a reason which is not Jint's, and it
+    /// exists so that reason gets named: every proleptic Persian date in the engine is decided by these
+    /// numbers agreeing with the runtime underneath.
+    /// </summary>
+    [Fact]
+    public void ThePlatformsPersianTableCoversExactlyTheWindowJintStates()
+    {
+        var cal = new PersianCalendar();
+
+        cal.MinSupportedDateTime.Date.Should().Be(FirstIsoDay);
+        cal.MaxSupportedDateTime.Date.Should().Be(LastIsoDay);
+
+        cal.GetYear(FirstIsoDay).Should().Be(1);
+        cal.GetMonth(FirstIsoDay).Should().Be(1);
+        cal.GetDayOfMonth(FirstIsoDay).Should().Be(1);
+
+        cal.GetYear(LastIsoDay).Should().Be(LastTableYear);
+        cal.GetMonth(LastIsoDay).Should().Be(LastTableMonth);
+        cal.GetDayOfMonth(LastIsoDay).Should().Be(LastTableDay);
+
+        cal.ToDateTime(1, 1, 1, 0, 0, 0, 0).Should().Be(FirstIsoDay);
+        cal.ToDateTime(LastTableYear, LastTableMonth, LastTableDay, 0, 0, 0, 0).Should().Be(LastIsoDay);
+
+        // And nothing past either end, which is the question PersianTableHolds now answers by comparison
+        // rather than by catching this.
+        Action pastTheLastDay = () => cal.ToDateTime(LastTableYear, LastTableMonth, LastTableDay + 1, 0, 0, 0, 0);
+        Action pastTheLastMonth = () => cal.ToDateTime(LastTableYear, LastTableMonth + 1, 1, 0, 0, 0, 0);
+        Action pastTheLastYear = () => cal.ToDateTime(LastTableYear + 1, 1, 1, 0, 0, 0, 0);
+        Action beforeTheFirstYear = () => cal.ToDateTime(0, 12, 29, 0, 0, 0, 0);
+
+        pastTheLastDay.Should().Throw<ArgumentOutOfRangeException>();
+        pastTheLastMonth.Should().Throw<ArgumentOutOfRangeException>();
+        pastTheLastYear.Should().Throw<ArgumentOutOfRangeException>();
+        beforeTheFirstYear.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// The last day the window holds is still placed by the table, on the day the constants name: Persian
+    /// 9378-10-13, in a year of twelve months.
+    /// </summary>
+    /// <remarks>
+    /// Upstream this test also asserts that the year the window stops <em>inside</em> reports its lengths
+    /// from the reckoning rather than from <c>DateTime</c>'s end — 9378 answering with 289 days and a
+    /// tenth month thirteen days long is
+    /// <see href="https://github.com/sebastienros/jint/issues/3523"/>. That is a separate main fix
+    /// (#3528) which this branch does not carry, and it is untouched either way by the hand-off this file
+    /// is about, so those three assertions are left out here rather than pinned to the truncated answer.
+    /// </remarks>
+    [Fact]
+    public void TheLastDayTheWindowHoldsIsStillTheTablesToPlace()
+    {
+        var lastDay = new IsoDate(LastIsoDay.Year, LastIsoDay.Month, LastIsoDay.Day);
+        var placed = NonIsoCalendars.IsoToCalendarDate("persian", in lastDay);
+
+        placed.Year.Should().Be(LastTableYear);
+        placed.Month.Should().Be(LastTableMonth);
+        placed.Day.Should().Be(LastTableDay);
+
+        placed.MonthsInYear.Should().Be(12);
+    }
+
+    /// <summary>
+    /// Every day for four hundred either side of each edge of the window: inside it the answer is the
+    /// table's, outside it the cycle's, and the change happens on the day the constants name and on no
+    /// other. The sweep is dense rather than sampled because the seam is one day wide.
+    /// </summary>
+    [Fact]
+    public void TheHandOffHappensOnTheDayTheWindowNamesAndOnNoOther()
+    {
+        var cal = new PersianCalendar();
+        var firstJdn = JdnOfIsoDay(FirstIsoDay);
+        var lastJdn = JdnOfIsoDay(LastIsoDay);
+
+        var failures = new StringBuilder();
+        var days = 0;
+
+        foreach (var edge in new[] { firstJdn, lastJdn })
+        {
+            for (var jdn = edge - 400L; jdn <= edge + 400L; jdn++)
+            {
+                days++;
+                var iso = TemporalHelpers.DaysToIsoDate(jdn - JdnOfEpochDay);
+
+                (long Year, int Month, int Day) expected;
+                string by;
+
+                if (jdn >= firstJdn && jdn <= lastJdn)
+                {
+                    var dt = new DateTime(iso.Year, iso.Month, iso.Day);
+                    expected = (cal.GetYear(dt), cal.GetMonth(dt), cal.GetDayOfMonth(dt));
+                    by = "the table";
+                }
+                else
+                {
+                    expected = CyclePlace(jdn);
+                    by = "the cycle";
+                }
+
+                var actual = PlacedByJint(jdn);
+                if (actual != expected)
+                {
+                    failures.AppendLine(
+                        $"ISO {iso.Year:D4}-{iso.Month:D2}-{iso.Day:D2}: {actual.Year}-{actual.Month}-{actual.Day}, "
+                        + $"but {by} says {expected.Year}-{expected.Month}-{expected.Day}");
+                }
+            }
+        }
+
+        days.Should().Be(2 * 801);
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The seam is a seam: the two rules answer differently on the very day the window ends, so the sweep
+    /// above is asserting a choice rather than a coincidence.
+    /// </summary>
+    /// <remarks>
+    /// At the bottom the cycle begins Persian year 1 a day before the table does, so ISO 622-03-21 and
+    /// 622-03-22 both read as 1-01-01. At the top the table is thirteen days into Persian 9378's tenth
+    /// month where the cycle is ten, so the answer steps two days backwards at ISO 10000-01-01. Each is
+    /// one day of the year the two rules change over in, and neither is reachable from a date anything
+    /// keeps.
+    /// </remarks>
+    [Fact]
+    public void TheTwoRulesDisagreeAtBothEdgesOfTheWindow()
+    {
+        var firstJdn = JdnOfIsoDay(FirstIsoDay);
+        var lastJdn = JdnOfIsoDay(LastIsoDay);
+
+        CyclePlace(firstJdn).Should().NotBe(PlacedByJint(firstJdn));
+        CyclePlace(lastJdn).Should().NotBe(PlacedByJint(lastJdn));
+
+        PlacedByJint(firstJdn - 1L).Should().Be((1L, 1, 1));
+        PlacedByJint(firstJdn).Should().Be((1L, 1, 1));
+        PlacedByJint(lastJdn).Should().Be((9378L, 10, 13));
+        PlacedByJint(lastJdn + 1L).Should().Be((9378L, 10, 11));
+    }
+
+    /// <summary>
+    /// A proleptic Persian year is as long as the cycle's leap rule says it is, and the next one starts
+    /// exactly that many days later — which is the whole of what a calendar past the end of its table is.
+    /// </summary>
+    /// <remarks>
+    /// Read through the engine in both directions, so the year-start formula, the leap predicate and the
+    /// month lengths have to agree with each other as well as with the cycle. Nothing here touches the
+    /// platform: every year sampled lies outside the window.
+    /// </remarks>
+    [Theory]
+    [InlineData(-272442, 200)]
+    [InlineData(-100000, 100)]
+    [InlineData(-200, 190)]
+    [InlineData(9379, 400)]
+    [InlineData(43666, 100)]
+    [InlineData(275000, 100)]
+    public void AProlepticYearIsAsLongAsTheCyclesLeapRuleSaysAndTheNextStartsThere(int firstYear, int years)
+    {
+        var failures = new StringBuilder();
+
+        for (var year = firstYear; year < firstYear + years; year++)
+        {
+            var start = NonIsoCalendars.CalendarDateToIso("persian", year, "M01", 1, 1, "reject");
+            var next = NonIsoCalendars.CalendarDateToIso("persian", year + 1, "M01", 1, 1, "reject");
+
+            if (start is null || next is null)
+            {
+                failures.AppendLine($"{year}: the calendar declined to place its own first day");
+                continue;
+            }
+
+            var startIso = start.Value;
+            var startDay = TemporalHelpers.IsoDateToDays(startIso.Year, startIso.Month, startIso.Day);
+            var nextDay = TemporalHelpers.IsoDateToDays(next.Value.Year, next.Value.Month, next.Value.Day);
+            var expectedLength = CycleIsLeapYear(year) ? 366 : 365;
+
+            var offBy = startDay + JdnOfEpochDay - CycleYearStartJdn(year);
+            if (offBy != 0L)
+            {
+                failures.AppendLine(
+                    $"{year}-01-01 is ISO {startIso.Year:D4}-{startIso.Month:D2}-{startIso.Day:D2}, "
+                    + $"{offBy} days off the cycle's");
+            }
+
+            if (nextDay - startDay != expectedLength)
+            {
+                failures.AppendLine($"{year} is {nextDay - startDay} days long, not {expectedLength}");
+            }
+
+            var placed = NonIsoCalendars.IsoToCalendarDate("persian", in startIso);
+            if (placed.Year != year || placed.Month != 1 || placed.Day != 1)
+            {
+                failures.AppendLine($"{year}-01-01 read back as {placed.Year}-{placed.Month}-{placed.Day}");
+            }
+
+            if (placed.DaysInYear != expectedLength || placed.InLeapYear != CycleIsLeapYear(year))
+            {
+                failures.AppendLine(
+                    $"{year} reports {placed.DaysInYear} days and inLeapYear={placed.InLeapYear}, "
+                    + $"not {expectedLength} and {CycleIsLeapYear(year)}");
+            }
+        }
+
+        failures.ToString().Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Every day of every month of a proleptic year, placed and read back: six months of 31 days, five of
+    /// 30, and a twelfth of 30 or 29 as the leap rule says, laid end to end with no day left over.
+    /// </summary>
+    [Theory]
+    [InlineData(-272442)]
+    [InlineData(9379)]
+    [InlineData(9380)]
+    [InlineData(43666)]
+    [InlineData(275139)]
+    public void EveryMonthOfAProlepticYearIsWhereTheCyclePutsIt(int year)
+    {
+        var failures = new StringBuilder();
+        var jdn = CycleYearStartJdn(year);
+
+        for (var month = 1; month <= 12; month++)
+        {
+            var length = CycleDaysInMonth(year, month);
+
+            for (var day = 1; day <= length; day++, jdn++)
+            {
+                var iso = NonIsoCalendars.CalendarDateToIso("persian", year, $"M{month:D2}", month, day, "reject");
+                if (iso is null)
+                {
+                    failures.AppendLine($"{year}-{month:D2}-{day:D2} was declined");
+                    continue;
+                }
+
+                var isoDate = iso.Value;
+                var placedJdn = TemporalHelpers.IsoDateToDays(isoDate.Year, isoDate.Month, isoDate.Day) + JdnOfEpochDay;
+                if (placedJdn != jdn)
+                {
+                    failures.AppendLine($"{year}-{month:D2}-{day:D2} is {placedJdn - jdn} days off the cycle's day");
+                }
+
+                var placed = NonIsoCalendars.IsoToCalendarDate("persian", in isoDate);
+                if (placed.Year != year || placed.Month != month || placed.Day != day || placed.DaysInMonth != length)
+                {
+                    failures.AppendLine(
+                        $"{year}-{month:D2}-{day:D2} read back as {placed.Year}-{placed.Month}-{placed.Day} "
+                        + $"in a month of {placed.DaysInMonth} days, not {length}");
+                }
+            }
+
+            var pastTheMonth = NonIsoCalendars.CalendarDateToIso("persian", year, $"M{month:D2}", month, length + 1, "reject");
+            if (pastTheMonth is not null)
+            {
+                failures.AppendLine($"{year}-{month:D2} accepted a day {length + 1}");
+            }
+        }
+
+        (jdn - CycleYearStartJdn(year)).Should().Be(CycleIsLeapYear(year) ? 366 : 365);
+        failures.ToString().Should().BeEmpty();
+    }
+}

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -1717,28 +1717,89 @@ internal static class NonIsoCalendars
 
     #region Persian Calendar
 
-    // Persian arithmetic calendar (2820-year cycle, Reingold–Dershowitz / Birashk).
-    // Used as a proleptic fallback for years outside the .NET PersianCalendar range
-    // (which only supports years 1–9999, ≈ ISO 622–10620). The 2820-year cycle has
-    // 683 leap years; year 1 starts at JDN 1948321 = ISO 622-03-22 (proleptic Gregorian).
-    private const long PersianEpochJdn = 1948321L;
+    // The Persian (Solar Hijri) arithmetic calendar on its 33-year cycle, which is the rule ICU's own
+    // PersianCalendar is and therefore the one every other Temporal implementation answers a proleptic
+    // `persian` date with: a year's first day is 365 × (year − 1) + floor((8 × year + 21) / 33) days after
+    // the epoch, and a year is a leap year when floorMod(25 × year + 11, 33) < 8, so eight years in every
+    // thirty-three are 366 days long and the mean year is 365 + 8/33 = 365.2424 days. *Which* arithmetic
+    // rule this is was what https://github.com/sebastienros/jint/issues/3604 was about: the 2820-year
+    // cycle it used to be (Reingold–Dershowitz / Birashk) drifts from ICU's by two months over Temporal's
+    // own range, so both ends of that range came back in the wrong Persian year.
+    //
+    // It answers outside the window below, and only outside it. Inside, PersianCalendar places the date,
+    // because inside it that calendar is not arithmetic at all — it derives a year from the true vernal
+    // equinox at Tehran — and the two answers really are different. Over the 9,377 whole years they share,
+    // 4,144 year-starts differ, by −1 to +3 days, and 1,514,413 of the window's 3,425,164 days fall in a
+    // different Persian month; the disagreement is 19 years per thousand around the present, none of them
+    // between 1300 and 1500 AP, and grows past 4,000 AP as the mean year drifts from the equinox. So the
+    // delegation earns its keep at both ends: the table is what makes a date anybody keeps right, and the
+    // cycle is what makes a proleptic one agree with the rest of the world. Far outside the window only an
+    // arithmetic rule can answer at all — no ephemeris covers a quarter of a million years.
+    //
+    // *Where the hand-off happens is stated here rather than asked of the platform.* It used to be
+    // PersianCalendar's own MinSupportedDateTime, MaxSupportedDateTime and the ArgumentOutOfRangeException
+    // ToDateTime raises outside them, which is to say it was whatever calendar data the runner shipped: a
+    // runtime that moved its window by a day would have moved every proleptic answer with it, and the only
+    // symptom would have been a date a quarter of a million years away landing somewhere else on one CI
+    // leg. The window is the same on net472 and on .NET 10 today, and PersianCalendarBoundaryTests is what
+    // says so on every runner — it asserts these constants against the platform, so a platform that ever
+    // disagrees fails there, naming the reason, rather than silently moving the proleptic years.
+    //
+    // Two rules meeting leaves the junctions imperfect, as they already were: at the top the answer
+    // steps two days backwards at ISO 10000-01-01, because the table stops part-way through Persian
+    // 9378 (https://github.com/sebastienros/jint/issues/3523), and at the bottom ISO 622-03-21 and
+    // 622-03-22 both read as Persian 1-01-01, because the cycle begins Persian year 1 a day before the
+    // table does. Each is one day of the year the two rules change over in, and neither is reachable
+    // from a date anything actually keeps.
+    private const long PersianEpochJdn = 1948320L;
+
+    /// <summary>
+    /// The ISO window <see cref="PersianCal"/> places a date in — 622-03-22 to 9999-12-31 inclusive — as
+    /// the pair of Julian Day Numbers the placement is decided by. Everything outside it is the 33-year
+    /// cycle's.
+    /// </summary>
+    private static readonly long PersianTableFirstJdn = IsoToJulianDay(622, 3, 22);
+
+    /// <inheritdoc cref="PersianTableFirstJdn"/>
+    private static readonly long PersianTableLastJdn = IsoToJulianDay(9999, 12, 31);
+
+    /// <summary>
+    /// The same window read in Persian fields, which is the direction <see cref="PersianDateToIso"/> asks
+    /// it in: 1-01-01 through 9378-10-13. The last year is a part of one — DateTime's end falls inside
+    /// Persian 9378 — so the top edge needs the month and the day as well as the year.
+    /// </summary>
+    private const int PersianTableLastYear = 9378;
+
+    /// <inheritdoc cref="PersianTableLastYear"/>
+    private const int PersianTableLastMonth = 10;
+
+    /// <inheritdoc cref="PersianTableLastYear"/>
+    private const int PersianTableLastDay = 13;
+
+    /// <summary>
+    /// Whether <see cref="PersianCal"/>'s window holds these Persian fields, which is the question the
+    /// <c>try</c> around <c>ToDateTime</c> used to ask by catching the refusal.
+    /// </summary>
+    private static bool PersianTableHolds(int year, int month, int day)
+    {
+        if (year < 1 || year > PersianTableLastYear)
+        {
+            return false;
+        }
+
+        if (year < PersianTableLastYear)
+        {
+            return true;
+        }
+
+        return month < PersianTableLastMonth || (month == PersianTableLastMonth && day <= PersianTableLastDay);
+    }
 
     private static bool IsPersianLeapYearAlgorithmic(int year)
-    {
-        long yp = (long) year - 474L;
-        long mod = ((yp % 2820L) + 2820L) % 2820L;
-        long yc = mod + 474L;
-        return ((yc + 38L) * 682L) % 2816L < 682L;
-    }
+        => FloorMod(25L * year + 11L, 33L) < 8L;
 
     private static long PersianYearStartJdn(int year)
-    {
-        long yp = (long) year - 474L;
-        long mod = ((yp % 2820L) + 2820L) % 2820L;
-        long cycle = (yp - mod) / 2820L;
-        long yc = mod + 474L;
-        return PersianEpochJdn + cycle * 1029983L + 365L * (yc - 1L) + (yc * 682L - 110L) / 2816L;
-    }
+        => PersianEpochJdn + 365L * ((long) year - 1L) + FloorDiv(8L * year + 21L, 33L);
 
     /// <summary>
     /// Days in a Persian month, computed algorithmically for the years PersianCalendar cannot answer for.
@@ -1755,10 +1816,8 @@ internal static class NonIsoCalendars
         return IsPersianLeapYearAlgorithmic(year) ? 30 : 29;
     }
 
-    private static CalendarDate PersianAlgorithmicFromIso(in IsoDate isoDate)
+    private static CalendarDate PersianAlgorithmicFromIso(long jdn)
     {
-        long jdn = IsoToJulianDay(isoDate.Year, isoDate.Month, isoDate.Day);
-
         // Estimate Persian year then walk to exact.
         long days = jdn - PersianEpochJdn;
         int yearEst = (int) (days / 365L) + 1;
@@ -1799,19 +1858,16 @@ internal static class NonIsoCalendars
 
     private static CalendarDate PersianToCalendarDate(in IsoDate isoDate)
     {
+        var jdn = IsoToJulianDay(isoDate.Year, isoDate.Month, isoDate.Day);
+
+        if (jdn < PersianTableFirstJdn || jdn > PersianTableLastJdn)
+        {
+            return PersianAlgorithmicFromIso(jdn);
+        }
+
+        // Inside the window the ISO year is 622 to 9999, which is DateTime's own range.
         var cal = PersianCal;
-
-        if (isoDate.Year < 1 || isoDate.Year > 9999)
-        {
-            return PersianAlgorithmicFromIso(in isoDate);
-        }
-
         var dt = new DateTime(isoDate.Year, isoDate.Month, isoDate.Day);
-
-        if (dt < cal.MinSupportedDateTime || dt > cal.MaxSupportedDateTime)
-        {
-            return PersianAlgorithmicFromIso(in isoDate);
-        }
 
         var year = cal.GetYear(dt);
         var ordinalMonth = cal.GetMonth(dt);
@@ -1869,7 +1925,10 @@ internal static class NonIsoCalendars
             return null;
         }
 
-        // Constrain day
+        // Constrain day. The algorithmic computation answers for every year past the last whole one the
+        // table holds, which includes the partial year at the end of it: there the table's month lengths
+        // are DateTime's end rather than the calendar's. The placement below still asks the window first,
+        // so a day it still holds keeps the table's answer.
         int maxDay;
         try
         {
@@ -1890,16 +1949,13 @@ internal static class NonIsoCalendars
             return null;
         }
 
-        try
+        if (!PersianTableHolds(year, ordinalMonth, day))
         {
-            var dt = cal.ToDateTime(year, ordinalMonth, day, 0, 0, 0, 0);
-            return new IsoDate(dt.Year, dt.Month, dt.Day);
-        }
-        catch
-        {
-            // Year is outside .NET PersianCalendar range — use algorithmic conversion.
             return PersianAlgorithmicToIso(year, ordinalMonth, day);
         }
+
+        var dt = cal.ToDateTime(year, ordinalMonth, day, 0, 0, 0, 0);
+        return new IsoDate(dt.Year, dt.Month, dt.Day);
     }
 
     #endregion


### PR DESCRIPTION
Backport of #3751 (`5a57a7dc9`) to `4.x`.

## What the main PR fixed

`PersianCalendar` covers ISO 622-03-22 through 9999-12-31 and derives those years astronomically. Everything outside them has to be answered by an arithmetic rule, because no ephemeris covers a quarter of a million years — and the rule Jint used was the wrong one. It was the 2820-year cycle (Reingold–Dershowitz / Birashk); the `persian` calendar the platform and every other Temporal implementation mean is ICU's 33-year cycle, which places a year's first day `365 × (year − 1) + floor((8 × year + 21) / 33)` days after the epoch and calls a year a leap year when `floorMod(25 × year + 11, 33) < 8`. The two drift about two months apart over Temporal's own range, which put **both ends of that range in the wrong Persian year**.

The PR also stopped asking the platform *where* the hand-off happens. It used to be `PersianCalendar.MinSupportedDateTime`, `MaxSupportedDateTime` and the `ArgumentOutOfRangeException` `ToDateTime` raises outside them — i.e. whatever calendar data the runner shipped. It is now an ISO window this repository states (`PersianTableFirstJdn`/`PersianTableLastJdn`, and `PersianTableHolds` for the direction that asks in Persian fields), with `PersianCalendarBoundaryTests` asserting those constants *against* the platform so a runtime that ever disagrees fails there naming the reason instead of silently moving every proleptic answer.

## Why a 4.x user hits it

The ledger's judgement, verified here: 4.x's unsplit `NonIsoCalendars.cs` carries the identical 2820-cycle comment and code (`yp % 2820L`), so both ends of Temporal's range land in the wrong Persian year on 4.x too, and where the table stops depends on the runner's calendar data. Measured on unfixed 4.x, `Temporal.PlainDate.from('-271821-04-20').withCalendar('persian')` answers `-272443-M11-08` where every other implementation says `-272442-M01-10`. It is a conformance fix with no API or default change, and it does not depend on the un-ported lunisolar reckoning chain.

## What was adapted

- **`PersianDateToIso`'s maximum-day lookup keeps 4.x's `try`/`catch`** around `PersianCal.GetDaysInMonth`. Main reaches for `SupportsYear`/`TryGetDaysInMonth`, which arrived with the #3502/#3528 chain that is not on this branch. Behaviourally the same question, asked the way 4.x asks it.
- **The `HebrewMonthSteppingTests` hunk is dropped** — that file arrived with #3525, which 4.x does not carry.
- **Only one of main's four test262 exclusions comes out.** `intl402/Temporal/ZonedDateTime/from/extreme-dates.js` passes. The three `*/prototype/withCalendar/extreme-dates.js` files get *past* their persian rows and stop at `chinese minimum non-approximated date`, which is the lunisolar reckoning chain (#3482/#3502/#3519) 4.x does not have — so they stay excluded, with that reason recorded in `Test262Harness.settings.json`. The comment main added to `PlainDateTime/from/extreme-dates.js` is accurate here too: measured, it fails with `Date is outside valid range`, a range check rather than a calendar.
- **Tests transcribed from NUnit to xUnit**, which is what 4.x's `Jint.Tests` still is.
- **`TheYearTheWindowStopsInsideIsStillAWholeYear` is narrowed** to `TheLastDayTheWindowHoldsIsStillTheTablesToPlace`. Its three length assertions (289 days, a tenth month thirteen days long) pin #3528's answer for the part-year 9378, and #3528 is not on this branch; the placement assertions it shares with #3751 are kept, and the remark says why the rest are absent.

## Verification

Everything below on **net472 and net10.0**, the two legs `Jint.Tests` runs on this branch.

| | unfixed 4.x | with the fix |
| --- | --- | --- |
| `PersianCalendarBoundaryTests` + `NonIsoCalendarTests` | **15 of 21 fail** on both legs | **21 of 21 pass** on both legs |
| `Jint.Tests` (whole suite) | — | 7121/7125 net10.0, 7036/7040 net472, 0 failed |
| `Jint.Tests.PublicInterface` (whole suite) | — | no change (not touched) |

test262, `--filter FullyQualifiedName~Temporal` (13,284 cases):

| | passed | failed | skipped |
| --- | --- | --- | --- |
| stock `4.x` | 13,218 | 0 | 66 |
| this branch | **13,220** | 0 | 64 |

The whole suite agrees: **102,501 passed / 0 failed / 183 skipped of 102,684** on this branch against the
4.x control of 102,499 / 0 / 185, with no flake in either run.

The two extra are the strict and non-strict halves of `ZonedDateTime/from/extreme-dates.js`. Its failure on unfixed 4.x is `persian minimum supported date Expected SameValue(«-8639994729600000000000n», «-8640000000000000000000n»)`; `PlainDate/prototype/withCalendar/extreme-dates.js` fails there on `persian minimum supported date: eraYear result: Expected SameValue(«-272443», «-272442»)` and, with the fix, moves on to the `chinese` row.

`dotnet build -c Release` is clean (the one warning is 4.x's pre-existing MSB3277 in `Jint.Tests.CommonScripts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
