### PR TITLE
Backport #3922 to 4.x: Restore realm construction state after nesting or failure

### DIFF
--- a/Jint.Tests.PublicInterface/HostRealmConstructionTests.cs
+++ b/Jint.Tests.PublicInterface/HostRealmConstructionTests.cs
@@ -1,0 +1,112 @@
+#nullable enable
+
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+public sealed class HostRealmConstructionTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AFailedRealmConstructionRestoresThePrincipalRealm(bool failInIntrinsics)
+    {
+        var host = new ObservingHost();
+        using var engine = new Engine(options => options.UseHostFactory(_ => host));
+        var global = engine.Global;
+        var intrinsics = engine.Intrinsics;
+        var failure = new InvalidOperationException("Realm construction failed");
+        Action<Realm> fail = _ => throw failure;
+        if (failInIntrinsics)
+        {
+            host.BeforeIntrinsics = fail;
+        }
+        else
+        {
+            host.BeforeGlobal = fail;
+        }
+
+        Record.Exception(() => host.CreateAdditionalRealm()).Should().BeSameAs(failure);
+        host.BeforeIntrinsics = null;
+        host.BeforeGlobal = null;
+
+        engine.Global.Should().BeSameAs(global);
+        engine.Intrinsics.Should().BeSameAs(intrinsics);
+        engine.Evaluate("Object.getPrototypeOf({}) === Object.prototype").Should().BeTrue();
+        var next = host.CreateAdditionalRealm();
+        next.GlobalObject.Should().NotBeSameAs(global);
+        engine.Global.Should().BeSameAs(global);
+        engine.Intrinsics.Should().BeSameAs(intrinsics);
+    }
+
+    [Theory]
+    [InlineData("none")]
+    [InlineData("intrinsics")]
+    [InlineData("global")]
+    public void ANestedConstructionRestoresTheOuterRealmBeforeItsFactoryContinues(string failurePhase)
+    {
+        var host = new ObservingHost();
+        using var engine = new Engine(options => options.UseHostFactory(_ => host));
+        var global = engine.Global;
+        var intrinsics = engine.Intrinsics;
+        var failure = new InvalidOperationException("Nested realm construction failed");
+        Intrinsics? afterNested = null;
+        Exception? observedFailure = null;
+        Realm? nested = null;
+
+        host.BeforeGlobal = _ =>
+        {
+            host.BeforeGlobal = null;
+            if (failurePhase == "intrinsics")
+            {
+                host.BeforeIntrinsics = _ => throw failure;
+            }
+            else if (failurePhase == "global")
+            {
+                host.BeforeGlobal = _ => throw failure;
+            }
+
+            observedFailure = Record.Exception(() => nested = host.CreateAdditionalRealm());
+            host.BeforeIntrinsics = null;
+            host.BeforeGlobal = null;
+            afterNested = engine.Intrinsics;
+        };
+
+        var outer = host.CreateAdditionalRealm();
+
+        afterNested.Should().BeSameAs(outer.Intrinsics, "the outer factory resumes in its own construction realm");
+        if (failurePhase == "none")
+        {
+            observedFailure.Should().BeNull();
+            nested!.Intrinsics.Should().NotBeSameAs(outer.Intrinsics);
+        }
+        else
+        {
+            observedFailure.Should().BeSameAs(failure);
+        }
+        engine.Global.Should().BeSameAs(global);
+        engine.Intrinsics.Should().BeSameAs(intrinsics);
+        engine.Evaluate("Object.getPrototypeOf({}) === Object.prototype").Should().BeTrue();
+    }
+
+    private sealed class ObservingHost : Host
+    {
+        public Action<Realm>? BeforeIntrinsics { get; set; }
+        public Action<Realm>? BeforeGlobal { get; set; }
+
+        public Realm CreateAdditionalRealm() => base.CreateRealm();
+
+        protected override void CreateIntrinsics(Realm realmRec)
+        {
+            BeforeIntrinsics?.Invoke(realmRec);
+            base.CreateIntrinsics(realmRec);
+        }
+
+        protected override ObjectInstance CreateGlobalObject(Realm realm)
+        {
+            BeforeGlobal?.Invoke(realm);
+            return base.CreateGlobalObject(realm);
+        }
+    }
+}

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -85,19 +85,26 @@ public class Host
     protected internal virtual Realm CreateRealm()
     {
         var realmRec = new Realm();
+        var previousRealm = Engine._realmInConstruction;
         Engine._realmInConstruction = realmRec;
+        try
+        {
+            CreateIntrinsics(realmRec);
 
-        CreateIntrinsics(realmRec);
+            var globalObject = CreateGlobalObject(realmRec);
 
-        var globalObject = CreateGlobalObject(realmRec);
+            var globalEnv = CreateGlobalEnvironment(globalObject);
+            realmRec.GlobalEnv = globalEnv;
+            realmRec.GlobalObject = globalObject;
 
-        var globalEnv = CreateGlobalEnvironment(globalObject);
-        realmRec.GlobalEnv = globalEnv;
-        realmRec.GlobalObject = globalObject;
-
-        Engine._realmInConstruction = null!;
-
-        return realmRec;
+            return realmRec;
+        }
+        finally
+        {
+            // Host factories may throw or create another realm before this one is complete. Restore
+            // their caller's construction realm, rather than hiding it or leaving this partial one active.
+            Engine._realmInConstruction = previousRealm;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Backport of #3922 (`c729d818c`) to `4.x`.

## What the main PR fixed

`Host.CreateRealm` set `Engine._realmInConstruction` on the way in and cleared it to `null!` on the way out. That is only correct if realm construction can be neither nested nor failed, and it can be both:

- a host factory that creates a second realm while the first is still being built leaves the **outer** factory running against `null` for the rest of its work;
- a factory whose `CreateIntrinsics` or `CreateGlobalObject` throws leaves the engine pointing at a **half-built** realm nothing will ever finish.

The fix is the ordinary save-and-restore -- remember the caller's construction realm, put it back in a `finally`.

## Why a 4.x user hits it

The ledger's judgement, confirmed: `Jint/Runtime/Host.cs` on 4.x has the identical `Engine._realmInConstruction = realmRec ... = null!` shape, byte for byte. `CreateRealm` is `protected internal virtual` and `CreateIntrinsics`/`CreateGlobalObject` are `protected virtual`, so this is reachable by any embedder with a custom `Host` -- which is the documented way to extend one. Measured on unfixed 4.x, after a factory throws, `engine.Global` is **`null`**: the engine that raised the failure is no longer usable, and the exception the host sees says nothing about that.

25 lines plus tests; no API and no default changes.

## What was adapted

- **The `docs/guide/migrating-to-v5.md` hunk is dropped** -- that file does not exist on this branch.
- **`Jint/Runtime/Host.cs` applied unchanged**: the method is identical on both branches.
- **The test is transcribed from NUnit to xUnit**, which is what 4.x's `Jint.Tests.PublicInterface` still is, and `Caught.Exception` -- a main-side helper that replaced xUnit's own vocabulary -- becomes `Record.Exception`, the thing it replaced.

## Verification

Everything below on **net472 and net10.0**.

| | unfixed 4.x | with the fix |
| --- | --- | --- |
| `HostRealmConstructionTests` (the new file) | **5 of 5 fail** on both legs | **5 of 5 pass** on both legs |
| `Jint.Tests.PublicInterface` (whole suite) | -- | 1841/1850 net10.0, 1833/1842 net472, 0 failed |
| `Jint.Tests` (whole suite) | -- | 7102/7106 net10.0, 7017/7021 net472, 0 failed |

The two failure messages on unfixed 4.x are exactly the two defects:

- `AFailedRealmConstructionRestoresThePrincipalRealm` -- `Expected engine.Global to refer to [object Object], but found <null>.` (both the intrinsics and the global-object failure phases)
- `ANestedConstructionRestoresTheOuterRealmBeforeItsFactoryContinues` -- `Expected afterNested to refer to Jint.Runtime.Intrinsics ...` (all three phases, including `none`: nesting alone is enough, no failure required)

test262: **102,497 passed / 2 failed / 185 skipped of 102,684**, both failures being the strict and sloppy halves
of `intl402/supportedLocalesOf-unicode-extensions-ignored.js` at 34 s each under the loaded run -- the load flake
this branch already knows, 2 s and green in isolation. Effective **102,499 / 0 / 185**, the 4.x control exactly.

`dotnet build -c Release` is clean (the one warning is 4.x's pre-existing MSB3277 in `Jint.Tests.CommonScripts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
