### PR TITLE
Backport #3845 to 4.x: Propagate native errors during call argument evaluation

### DIFF
--- a/Jint.Tests/Runtime/CallArgumentAbruptCompletionTests.cs
+++ b/Jint.Tests/Runtime/CallArgumentAbruptCompletionTests.cs
@@ -1,0 +1,120 @@
+#nullable enable
+
+namespace Jint.Tests.Runtime;
+
+public class CallArgumentAbruptCompletionTests
+{
+    [Fact]
+    public void NestedNativeCallPropagatesUriErrorToCatch()
+    {
+        var result = new Engine().Evaluate(
+            """
+            try {
+                JSON.parse(decodeURIComponent("74px 0px -25%"));
+                "unexpected";
+            } catch (error) {
+                error.name;
+            }
+            """);
+
+        result.AsString().Should().Be("URIError");
+    }
+
+    [Theory]
+    [InlineData("decodeURIComponent(value)", "\"%\"", "URIError")]
+    [InlineData("String.fromCodePoint(value)", "-1", "RangeError")]
+    public void GenericArgumentEvaluationStopsBeforeCallingTheNativeFunction(
+        string expression,
+        string input,
+        string expectedError)
+    {
+        var result = new Engine().Evaluate(
+            $$"""
+            const values = [];
+            let laterArguments = 0;
+            function invoke(value) {
+                try {
+                    values.push({{expression}}, laterArguments++, "last");
+                    return "unexpected";
+                } catch (error) {
+                    return error.name;
+                }
+            }
+            const error = invoke({{input}});
+            error + "|" + laterArguments + "|" + values.length;
+            """);
+
+        result.AsString().Should().Be(expectedError + "|0|0");
+    }
+
+    [Fact]
+    public void WarmFastCallDoesNotInvokeTheNativeFunctionAfterAnArgumentThrows()
+    {
+        var result = new Engine().Evaluate(
+            """
+            const values = [];
+            function append(value) {
+                return values.push(decodeURIComponent(value));
+            }
+            append("first");
+            append("second");
+            let caught = "";
+            try {
+                append("%");
+            } catch (error) {
+                caught = error.name;
+            }
+            caught + "|" + values.join(",");
+            """);
+
+        result.AsString().Should().Be("URIError|first,second");
+    }
+
+    [Fact]
+    public void WarmRegisterCallDoesNotInvokeTheScriptFunctionAfterAnArgumentThrows()
+    {
+        var result = new Engine().Evaluate(
+            """
+            let calls = 0;
+            function target(value) {
+                calls++;
+            }
+            function invoke(value) {
+                return target(decodeURIComponent(value));
+            }
+            invoke("first");
+            invoke("second");
+            let caught = "";
+            try {
+                invoke("%");
+            } catch (error) {
+                caught = error.name;
+            }
+            caught + "|" + calls;
+            """);
+
+        result.AsString().Should().Be("URIError|2");
+    }
+
+    [Fact]
+    public void SpreadArgumentEvaluationStopsBeforeCallingTheNativeFunction()
+    {
+        var result = new Engine().Evaluate(
+            """
+            const values = [];
+            let laterArguments = 0;
+            function invoke(value) {
+                try {
+                    values.push(...[decodeURIComponent(value), laterArguments++]);
+                    return "unexpected";
+                } catch (error) {
+                    return error.name;
+                }
+            }
+            const error = invoke("%");
+            error + "|" + laterArguments + "|" + values.length;
+            """);
+
+        result.AsString().Should().Be("URIError|0|0");
+    }
+}

--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -309,22 +309,24 @@ public class DateTests
     [Fact]
     public void FormattingTheFirstInstantOfYear10000DoesNotThrowAClrException()
     {
+        var engine = new Engine(options => options.TimeZone = TimeZoneInfo.Utc);
+
         // How many digits the expanded year gets is a separate defect; what this asserts is that a
         // string comes back at all.
-        _engine.Evaluate("new Date(253402300800000).toISOString()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
-        _engine.Evaluate("new Date(253402300800000).toJSON()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
-        _engine.Evaluate("JSON.stringify({ d: new Date(253402300800000) })").AsString().Should().EndWith("10000-01-01T00:00:00.000Z\"}");
-        _engine.Evaluate("new Date(253402300800000).getUTCFullYear()").AsNumber().Should().Be(10000);
+        engine.Evaluate("new Date(253402300800000).toISOString()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
+        engine.Evaluate("new Date(253402300800000).toJSON()").AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
+        engine.Evaluate("JSON.stringify({ d: new Date(253402300800000) })").AsString().Should().EndWith("10000-01-01T00:00:00.000Z\"}");
+        engine.Evaluate("new Date(253402300800000).getUTCFullYear()").AsNumber().Should().Be(10000);
 
         // toUTCString reached the same value through DateTimeOffset.FromUnixTimeMilliseconds, whose own
-        // message names 253402300799999 as the largest it accepts. toString renders in local time, so
-        // only the year is worth asserting there.
-        _engine.Evaluate("new Date(253402300800000).toUTCString()").AsString().Should().Be("Sat, 01 Jan 10000 00:00:00 GMT");
-        _engine.Evaluate("new Date(253402300800000).toString()").AsString().Should().Contain("10000");
+        // message names 253402300799999 as the largest it accepts. toString renders in the configured
+        // local time zone, so use UTC above to keep this boundary instant in year 10000 on every host.
+        engine.Evaluate("new Date(253402300800000).toUTCString()").AsString().Should().Be("Sat, 01 Jan 10000 00:00:00 GMT");
+        engine.Evaluate("new Date(253402300800000).toString()").AsString().Should().Contain("10000");
 
         // The escape itself: a CLR exception is invisible to script, so this used to throw out of
         // Evaluate rather than run the catch clause or return a value.
-        _engine.Evaluate("(function () { try { return new Date(253402300800000).toISOString(); } catch (e) { return 'caught'; } })()")
+        engine.Evaluate("(function () { try { return new Date(253402300800000).toISOString(); } catch (e) { return 'caught'; } })()")
             .AsString().Should().EndWith("10000-01-01T00:00:00.000Z");
     }
 

--- a/Jint/Engine.GlobalSnapshot.cs
+++ b/Jint/Engine.GlobalSnapshot.cs
@@ -277,7 +277,6 @@ public partial class Engine
         // depend on whether a wait happened to have a timeout.
         DiscardAtomicsWaiterDeadlines();
 
-        _error = null;
         _lastSyntaxElement = null;
 
         // RegExp legacy statics: every successful match writes them, so RegExp.$1 in the next

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -45,14 +45,14 @@ public sealed partial class Engine : IDisposable
 
     private readonly ExecutionContextStack _executionContexts;
 
-    // Invariant for engine-level ambient mutable fields (e.g. _error, _lastSyntaxElement): they must
+    // Invariant for engine-level ambient mutable fields (e.g. _lastSyntaxElement): they must
     // not hold an in-flight result across a call that can re-enter the engine (anything that may run
     // RunAvailableContinuations, or a CLR callback that calls Evaluate/Execute/Invoke). Either
     // save-and-restore around the re-entrant region, or carry the value out-of-band rather than in a
     // field. A script's completion value used to live here as a field and was clobbered by a
     // re-entrant drain (https://github.com/sebastienros/jint/issues/2492); it is now returned from
-    // ScriptEvaluation as a per-frame local. _error and _lastSyntaxElement are safe because they are
-    // produced and consumed synchronously with no re-entrant drain in between.
+    // ScriptEvaluation as a per-frame local. _lastSyntaxElement is safe because it is produced and
+    // consumed synchronously with no re-entrant drain in between.
 
     /// <summary>
     /// The context threaded through every statement and expression handler. Per <em>engine</em>, not
@@ -107,8 +107,6 @@ public sealed partial class Engine : IDisposable
     // set by DebugHandler.Evaluate around watch/breakpoint-condition expression evaluation so the
     // host-boundary constraint checks can exempt it (see CheckAmortizedConstraintsAtHostBoundary)
     internal bool _debuggerEvaluating;
-    internal ErrorDispatchInfo? _error;
-
     // Per-engine cache of interpreter function definitions — hoisted declarations, class methods,
     // class field initializers and static blocks — keyed on the stable AST node. The definition
     // owns the lazily-built body handler tree — and through it every per-node inline cache — so
@@ -2814,9 +2812,11 @@ public sealed partial class Engine : IDisposable
         return result;
     }
 
-    internal void SignalError(ErrorDispatchInfo error)
+    [DoesNotReturn]
+    internal void ThrowError(ErrorDispatchInfo error)
     {
-        _error = error;
+        var location = GetLastSyntaxElement()?.Location ?? default;
+        throw new JavaScriptException(error.ErrorConstructor, error.Message).SetJavaScriptLocation(in location);
     }
 
     internal void RegisterTypeReference(TypeReference reference)

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -417,7 +417,7 @@ public sealed partial class GlobalObject : ObjectInstance
 
 uriError:
         builder.Dispose();
-        _engine.SignalError(UriError);
+        _engine.ThrowError(UriError);
         return JsEmpty.Instance;
     }
 
@@ -607,7 +607,7 @@ uriError:
 
 uriError:
         builder.Dispose();
-        _engine.SignalError(UriError);
+        _engine.ThrowError(UriError);
         return JsEmpty.Instance;
     }
 

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -130,7 +130,7 @@ internal sealed partial class StringConstructor : Constructor
         return JsString.Create(result.ToString());
 
 rangeError:
-        _engine.SignalError(Throw.CreateRangeError(_realm, "Invalid code point " + codePoint));
+        _engine.ThrowError(Throw.CreateRangeError(_realm, "Invalid code point " + codePoint));
         return JsEmpty.Instance;
     }
 

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -168,10 +168,10 @@ internal sealed class EvaluationContext
 
     /// <summary>
     /// Establishes <paramref name="node"/> as the node an error would be reported against. This is
-    /// the whole of the per-node ceremony: abrupt completions travel out of band (as a
-    /// <see cref="JavaScriptException"/> or through <see cref="Engine._error"/>) and a break or
-    /// continue label travels on the <see cref="Completion"/> it belongs to, so there is no
-    /// completion state on the context left to reset.
+    /// the whole of the per-node ceremony: abrupt completions travel out of band as a
+    /// <see cref="JavaScriptException"/>, and a break or continue label travels on the
+    /// <see cref="Completion"/> it belongs to, so there is no completion state on the context left
+    /// to reset.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void PrepareFor(Node node) => LastSyntaxElement = node;

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -159,12 +159,6 @@ internal sealed class JintStatementList
                     {
                         c = pair.Statement.Execute(context);
                     }
-
-                    if (context.Engine._error is not null)
-                    {
-                        c = HandleError(context.Engine, pair.Statement);
-                        break;
-                    }
                 }
                 else
                 {
@@ -318,26 +312,6 @@ internal sealed class JintStatementList
         }
 
         return completion;
-    }
-
-    internal static Completion HandleError(Engine engine, JintStatement? s)
-    {
-        var error = engine._error!;
-        engine._error = null;
-        var completion = CreateThrowCompletion(error.ErrorConstructor, error.Message, engine._lastSyntaxElement ?? s!._statement);
-
-        if (engine._isDebugMode)
-        {
-            engine.Debugger.OnExceptionThrown(completion.Value, completion.Location);
-        }
-
-        return completion;
-    }
-
-    private static Completion CreateThrowCompletion(ErrorConstructor errorConstructor, string? message, Node s)
-    {
-        var error = errorConstructor.Construct(message);
-        return new Completion(CompletionType.Throw, error, s);
     }
 
     private static Completion CreateThrowCompletion(ErrorConstructor errorConstructor, Exception e, Node s)

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -338,8 +338,7 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
     /// <summary>
     /// Tight-loop entry; see <see cref="JintStatement.ExecuteDiscarded"/>. Valid only for blocks
     /// without lexical declarations (enforced by the enclosing loop's shape predicate), so no block
-    /// environment is created or attached. A statement after a deferred error must not run, so the
-    /// engine error slot is polled between statements; the caller polls after the last one.
+    /// environment is created or attached.
     /// </summary>
     internal void ExecuteDiscardedContents(EvaluationContext context)
     {
@@ -360,10 +359,6 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         for (var i = 0; i < count; i++)
         {
             list.GetStatement(i).ExecuteDiscarded(context);
-            if (context.Engine._error is not null)
-            {
-                return;
-            }
         }
     }
 
@@ -373,10 +368,6 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         try
         {
             blockValue = _singleStatement!.Execute(context);
-            if (context.Engine._error is not null)
-            {
-                blockValue = JintStatementList.HandleError(context.Engine, _singleStatement);
-            }
         }
         // The filter is what keeps a single-statement block out of the unwind of an exception it could
         // only rethrow; see JintStatementList.ShouldCatch for why that matters at recursion depth.

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -127,7 +127,7 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
     /// <summary>
     /// The bare per-iteration loop for structurally-Normal bodies — the do-while twin of
     /// <see cref="JintWhileStatement"/>'s tight lane (body first, then test); see there for the
-    /// deferred-error and amortized-constraint reasoning.
+    /// amortized-constraint reasoning.
     /// </summary>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private Completion TightDoWhileBody(EvaluationContext context)
@@ -135,7 +135,6 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
         var test = _test;
         var single = _tightSingleStatement;
         var list = _tightBodyList;
-        var engine = context.Engine;
 
         // See JintForStatement.TightForBody: a non-single body costs the generic lane one extra
         // statement-counter charge per iteration (the block, or the bare EmptyStatement body).
@@ -153,10 +152,6 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
             if (single is not null)
             {
                 single.ExecuteDiscarded(context);
-                if (engine._error is not null)
-                {
-                    return JintStatementList.HandleError(engine, single);
-                }
             }
             else if (list is not null)
             {
@@ -164,10 +159,6 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
                 {
                     var statement = list.GetStatement(i);
                     statement.ExecuteDiscarded(context);
-                    if (engine._error is not null)
-                    {
-                        return JintStatementList.HandleError(engine, statement);
-                    }
                 }
             }
         } while (test.GetBooleanValue(context));

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -769,12 +769,10 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     /// <summary>
     /// The bare test → body-statements → update cycle. Exceptions propagate to the enclosing
     /// statement list exactly as on the generic path (ForBodyEvaluation catches nothing); the
-    /// loop's Normal completion value is dead by the caller's gate, so Undefined stands in.
-    /// Deferred errors surface as Engine._error instead of a .NET throw; the statement list
-    /// converts them per statement, and so must the tight loop. Under flattening the pooled
-    /// loop environment carries the body's slots: their TDZ is re-established per iteration
-    /// before the body statements run, mirroring the generic flattened arm — skipped when the
-    /// block scan proved every slot initializes before any use (leftovers are unobservable).
+    /// loop's Normal completion value is dead by the caller's gate, so Undefined stands in. Under
+    /// flattening the pooled loop environment carries the body's slots: their TDZ is re-established
+    /// per iteration before the body statements run, mirroring the generic flattened arm — skipped
+    /// when the block scan proved every slot initializes before any use (leftovers are unobservable).
     /// Amortized constraints stay live through the context's shared countdown, driven once per
     /// iteration (a tripped constraint throws and propagates like any other exception); exact
     /// constraints and debug mode never reach this lane by the caller's gate.
@@ -814,10 +812,6 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
             if (single is not null)
             {
                 single.ExecuteDiscarded(context);
-                if (engine._error is not null)
-                {
-                    return JintStatementList.HandleError(engine, single);
-                }
             }
             else if (list is not null)
             {
@@ -825,10 +819,6 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 {
                     var statement = list.GetStatement(i);
                     statement.ExecuteDiscarded(context);
-                    if (engine._error is not null)
-                    {
-                        return JintStatementList.HandleError(engine, statement);
-                    }
                 }
             }
 

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -80,7 +80,6 @@ internal sealed class JintIfStatement : JintStatement<IfStatement>
     /// Tight-loop entry. The enclosing loop's shape predicate guarantees neither branch is a
     /// FunctionDeclaration (no AnnexB handling) and the frame cannot suspend (no resume probes);
     /// the branch statements are themselves tight, so no Completion needs materializing.
-    /// A deferred error signalled by the test must suppress the branch — the caller converts it.
     /// </summary>
     internal override void ExecuteDiscarded(EvaluationContext context)
     {
@@ -88,20 +87,10 @@ internal sealed class JintIfStatement : JintStatement<IfStatement>
 
         if (_test.GetBooleanValue(context))
         {
-            if (context.Engine._error is not null)
-            {
-                return;
-            }
-
             _statementConsequent.ExecuteDiscarded(context);
         }
         else
         {
-            if (context.Engine._error is not null)
-            {
-                return;
-            }
-
             _alternate?.ExecuteDiscarded(context);
         }
     }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -45,9 +45,8 @@ internal abstract class JintStatement
     /// prove it dead. Callers guarantee a non-suspendable frame, no exact constraint/debug checks
     /// (amortized constraints stay live via the caller's own countdown-driven cadence), dead
     /// completion values, and a statement shape vetted by <see cref="JintForStatement"/>'s tight-body
-    /// predicate (no break/continue/return/labels, so only Normal completions can occur). Deferred
-    /// errors surface via <see cref="Engine._error"/>, which the caller polls after each statement.
-    /// The base implementation falls back to the full <see cref="Execute"/> ceremony.
+    /// predicate (no break/continue/return/labels, so only Normal completions can occur). The base
+    /// implementation falls back to the full <see cref="Execute"/> ceremony.
     /// <para>
     /// Overrides must call <see cref="EvaluationContext.ChargeStatement"/> first: it stands in for the
     /// statement-counting constraint that <see cref="Execute"/> would have charged here, and its cadence

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -128,12 +128,10 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
     }
 
     /// <summary>
-    /// The bare per-iteration loop for structurally-Normal bodies: test, discarded body
-    /// statements, deferred-error polls — nothing else. The loop's Normal completion value is
-    /// dead by the caller's gate, so Undefined stands in. Deferred errors surface as
-    /// Engine._error and convert per statement, exactly as JintStatementList would. Amortized
-    /// constraints are driven once per iteration through the context's shared countdown; exact
-    /// constraints and debug mode never reach this lane by the caller's gate.
+    /// The bare per-iteration loop for structurally-Normal bodies: test and discarded body
+    /// statements. The loop's Normal completion value is dead by the caller's gate, so Undefined
+    /// stands in. Amortized constraints are driven once per iteration through the context's shared
+    /// countdown; exact constraints and debug mode never reach this lane by the caller's gate.
     /// </summary>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private Completion TightWhileBody(EvaluationContext context)
@@ -141,7 +139,6 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
         var test = _test;
         var single = _tightSingleStatement;
         var list = _tightBodyList;
-        var engine = context.Engine;
 
         // See JintForStatement.TightForBody: a non-single body costs the generic lane one extra
         // statement-counter charge per iteration (the block, or the bare EmptyStatement body).
@@ -159,10 +156,6 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
             if (single is not null)
             {
                 single.ExecuteDiscarded(context);
-                if (engine._error is not null)
-                {
-                    return JintStatementList.HandleError(engine, single);
-                }
             }
             else if (list is not null)
             {
@@ -170,10 +163,6 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
                 {
                     var statement = list.GetStatement(i);
                     statement.ExecuteDiscarded(context);
-                    if (engine._error is not null)
-                    {
-                        return JintStatementList.HandleError(engine, statement);
-                    }
                 }
             }
         }


### PR DESCRIPTION
Backport of #3845 (`f83893e0c`) to `4.x`.

## What the main PR fixed

A native built-in that failed did not throw. It wrote an `ErrorDispatchInfo` into `Engine._error`, returned `JsEmpty`, and left the statement lane to notice the slot between statements. That works when the call *is* the statement, and not at all when it is an argument: the caller receives `JsEmpty` and runs anyway, and the deferred error -- if it survives -- is reported against whichever node the statement lane happened to be on rather than the one that raised it.

`SignalError` becomes a `[DoesNotReturn] ThrowError` that constructs the error and throws it at the node that raised it. The `_error` field, the polls the tight-loop lane made between statements, and `JintStatementList.HandleError` go with it. The signalling sites are `decodeURI`/`decodeURIComponent`, `encodeURI`/`encodeURIComponent` and `String.fromCodePoint`.

## Why a 4.x user hits it

The premise is verbatim on 4.x (`Engine.cs:110 _error`, `:2817 SignalError`, both `GlobalObject` URI decoders signalling it). It is worse than that. On unfixed 4.x this script **ends the process**:

```js
try { JSON.parse(decodeURIComponent("74px 0px -25%")); } catch (e) { }
```

```
Stack overflow.
Repeated 8744 times:
   at Jint.Runtime.TypeConverter.ToStringNonString(Jint.Native.JsValue)
   at Jint.Runtime.TypeConverter.ToString(Jint.Native.JsValue)
   at Jint.Native.Json.JsonInstance.Parse(...)
```

`decodeURIComponent` signals and returns the `JsEmpty` sentinel, `JSON.parse` is handed it, and `TypeConverter.ToString` recurses on it without bound. No `catch` and no constraint can see that. With the fix the same script prints `caught URIError`.

Internals only -- no public API, no default changes.

## What was adapted

- **One conflict, in `Engine.GlobalSnapshot.cs`, and it is context only.** Main's neighbourhood of the deleted `_error = null;` carries the `Jint/WebApi` reset lines (`DiscardPendingRejectionNotifications`, `_webApi?.ResetTransientState()`, `AbandonHostStreamBridges`) that 4.x has no counterpart for. The change itself is the deletion, taken as such.
- **Everything else applied unchanged, the tight-loop lane included.** That lane was the one thing worth a divergence check here: `ExecuteDiscarded`, `TightForBody`, `TightWhileBody`, `TightDoWhileBody` and `ExecuteDiscardedContents` have the same shape on this branch, so all four poll sites are the same deletions and `git cherry-pick` produced them without conflict.
- **Tests transcribed from NUnit to xUnit**, which is what 4.x's `Jint.Tests` still is.
- **`DateTests.FormattingTheFirstInstantOfYear10000DoesNotThrowAClrException` keeps the commit's second half**, which pins that test's engine to `TimeZoneInfo.Utc` so the year-10000 boundary instant does not depend on the host's time zone.

## Verification

Everything below on **net472 and net10.0**.

| | unfixed 4.x | with the fix |
| --- | --- | --- |
| `CallArgumentAbruptCompletionTests` (the new file) | net10.0: **4 ran, 4 failed**, then `[FATAL ERROR] Xunit.Sdk.TestPipelineException`; net472: **5 ran, 5 failed**, same fatal error -- the host is killed by the stack overflow above before the rest run | **6 of 6 pass** on both legs |
| `Jint.Tests` (whole suite) | -- | 7108/7112 net10.0, 7023/7027 net472, 0 failed |
| `Jint.Tests.PublicInterface` (whole suite) | -- | 1836/1845 net10.0, 1828/1837 net472, 0 failed |
| `Jint.Tests --filter "Constraint\|Limit\|TightLoop"` (the tight-loop-lane check) | -- | 235/235 net10.0, 232/232 net472, 0 failed |

Sample failures on unfixed 4.x, for the ones that did run: `"URIError|1|3"` where `"URIError|0|0"` is owed -- the native function ran, and the argument expression's later side effects ran, after the error -- and `"...rst,second,"` where `"...rst,second"` is owed, a value pushed from a failed decode.

test262: the full run reports **102,497 passed / 2 failed / 185 skipped of 102,684**, and both failures are `intl402/supportedLocalesOf-unicode-extensions-ignored.js` (strict and sloppy), which took 32 s each under the loaded run and pass in 2 s green in isolation -- the load flake this branch already knows. Re-run alone: 2/2 passed. Effective **102,499 / 0 / 185**, which is the 4.x control exactly.

`dotnet build -c Release` is clean (the one warning is 4.x's pre-existing MSB3277 in `Jint.Tests.CommonScripts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLCujwvKtTvtWD9f6RTyiF
