### PR TITLE
Wait for the queued selectionchange before reading the log it lands in

### DIFF
--- a/Jint.Tests.Browser/Events/SelectionChangeTests.cs
+++ b/Jint.Tests.Browser/Events/SelectionChangeTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Jint.Tests.Browser.Events;
 
 using Browser = global::Jint.Browser.Browser;
+using Page = global::Jint.Browser.Page;
 
 /// <summary>
 /// <c>selectionchange</c>: what fires it, where it is fired, and how often.
@@ -10,6 +11,29 @@ using Browser = global::Jint.Browser.Browser;
 /// </summary>
 public sealed class SelectionChangeTests
 {
+    /// <summary>
+    /// The delivery boundary <c>SelectionChange</c>'s own documentation names, and the one thing that
+    /// separates an input dispatch from the event it queues.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Awaiting <c>BrowserTestAccess.DispatchKeyAsync</c> completes a <i>mailbox request</i>, while
+    /// <c>selectionchange</c> is queued on the engine's task queue rather than fired in place — the
+    /// Selection API says so, which is what makes a caret moved ten times in one turn heard once.
+    /// <c>PageLoop.Pump</c> drains arriving mailbox requests before it processes a queued task, so a read
+    /// posted straight after the dispatch can be answered first and see a log the event has not reached yet
+    /// (https://github.com/sebastienros/jint/issues/3978). Nothing is wrong with the scheduling: awaiting a
+    /// mailbox request is simply not an event-delivery boundary, and this is.
+    /// </para>
+    /// <para>
+    /// <see cref="TestBudgets.WedgeCeiling"/> is the hang bound and never the assertion. What is asserted is
+    /// that the page went idle — a healthy run reaches that in microseconds and spends none of the budget —
+    /// so the number cannot hide anything this file is about.
+    /// </para>
+    /// </remarks>
+    private static async Task DeliveredAsync(Page page)
+        => (await page.WaitForIdleAsync(TestBudgets.WedgeCeiling)).Should().BeTrue();
+
     /// <summary>
     /// Moving the document's selection fires <c>selectionchange</c> at the document, once per turn however
     /// many times it moved, and it does not bubble.
@@ -31,7 +55,10 @@ public sealed class SelectionChangeTests
             """);
 
         // Three moves in one turn. The specification's "has scheduled selectionchange event" flag is what
-        // makes them one event, fired after the script that made them returns.
+        // makes them one event, fired after the script that made them returns. No DeliveredAsync here and
+        // that is not an omission: Engine.Evaluate drains the event loop before it answers, so a task the
+        // evaluated script queued has already run by the time this request completes. What needs the
+        // boundary is a dispatch that is not a script — the tests below.
         await page.EvaluateAsync(
             """
             (() => {
@@ -82,11 +109,13 @@ public sealed class SelectionChangeTests
             """);
 
         await BrowserTestAccess.DispatchKeyAsync(page, "ArrowRight");
+        await DeliveredAsync(page);
 
         (await page.EvaluateAsync<string>("window.seen.join(';')")).Should().Be("t,true,4");
 
         // Typing moves the caret too, so it is a second one.
         await BrowserTestAccess.DispatchKeyAsync(page, "x");
+        await DeliveredAsync(page);
         (await page.EvaluateAsync<string>("window.seen.join(';')")).Should().Be("t,true,4;t,true,5");
 
         page.Errors.Should().BeEmpty();
@@ -114,12 +143,16 @@ public sealed class SelectionChangeTests
             </script>
             """);
 
-        // The caret is already at the end, so the clamp turns the move into no move at all.
+        // The caret is already at the end, so the clamp turns the move into no move at all. The boundary is
+        // what makes that a claim rather than a coincidence: without it a zero could equally be an event
+        // still sitting on the queue.
         await BrowserTestAccess.DispatchKeyAsync(page, "ArrowRight");
+        await DeliveredAsync(page);
         (await page.EvaluateAsync<int>("window.seen")).Should().Be(0);
 
         // And one that does move is heard, so the assertion above is about the move and not about the wiring.
         await BrowserTestAccess.DispatchKeyAsync(page, "ArrowLeft");
+        await DeliveredAsync(page);
         (await page.EvaluateAsync<int>("window.seen")).Should().Be(1);
 
         page.Errors.Should().BeEmpty();
@@ -146,6 +179,7 @@ public sealed class SelectionChangeTests
             """);
 
         await BrowserTestAccess.DispatchKeyAsync(page, "c");
+        await DeliveredAsync(page);
 
         (await page.EvaluateAsync<int>("window.seen.length")).Should().BeGreaterThan(0);
         (await page.EvaluateAsync<bool>("window.seen.every(Boolean)")).Should().BeTrue();


### PR DESCRIPTION
### Mechanism

`SelectionChangeTests` awaited `BrowserTestAccess.DispatchKeyAsync` and read `window.seen` on the next line. That await completes a **mailbox request**; `selectionchange` is queued on the engine's task queue rather than fired in place. `PageLoop.Pump` drains arriving mailbox requests before it processes a queued task, so the read could be answered first and see a log the event had not reached yet.

The three tests that dispatch input now take the delivery boundary `Jint.Browser/Events/SelectionChange.cs`'s own documentation names — `Page.WaitForIdleAsync`, bounded by `TestBudgets.WedgeCeiling`. That budget is a hang bound and never the assertion: what is asserted is that the page *went idle*, which a healthy run reaches in microseconds, so widening it could hide nothing this file is about. Every event-content assertion is unchanged, and **no product scheduling changed**.

`MovingTheDocumentSelectionFiresOneEventPerTurnAtTheDocument` deliberately does *not* get the boundary, and a comment now says why: it moves the selection from a script, and `Engine.Evaluate` drains the event loop (`ScriptEvaluation` → `RunAvailableContinuations`) before it answers, so the queued task has already run when that request completes.

One assertion gained meaning rather than only stability: `AKeyThatLeavesTheSelectionWhereItIsFiresNothing` asserts `window.seen === 0` after a clamped move. Without a delivery boundary a zero could equally have been an event still sitting on the queue, so the negative case was previously unfalsifiable.

### Spec citation

Selection API, [scheduling a selectionchange event](https://w3c.github.io/selection-api/#scheduling-a-selectionchange-event) and the [`selectionchange` event](https://w3c.github.io/selection-api/#selectionchange-event): the event is queued, and the per-target *has scheduled selectionchange event* flag coalesces a turn's moves into one — which is exactly why awaiting the dispatch is not a delivery boundary.

### Premise validation

The premise holds, and the mechanism in the issue is the right one. The race window is narrower than the issue's description suggests, though, and worth recording: the mailbox request that reads the log has to arrive between `completion.TrySetResult(...)` at the end of the dispatch request and the loop's next `reader.TryRead` a few hundred nanoseconds later — after that the pump runs the queued `selectionchange` task before returning to the mailbox. A plain `await`'s thread-pool hand-off does not normally win that race on an idle 32-core Windows box (**0 misses in 500 iterations**), which is why the flake was seen under a loaded full-suite run.

### Failing-first counts

A 25-iteration probe (a caret walked along a long value, `window.seen` read after each dispatch, counting reads that observed fewer events than dispatches) was extended to 500 iterations and had the pool hand-off's latency removed — the same shape the test has, `await`ing the dispatch, with the awaiting thread busy-spinning on `IsCompleted` so the read reaches the mailbox while the loop is still draining it. On the unfixed test shape, three runs on `net10.0`:

```
missed 11 / 500
missed 34 / 500
missed 48 / 500
```

With `await page.WaitForIdleAsync(TestBudgets.WedgeCeiling)` between the dispatch and the read, and nothing else changed, three runs:

```
missed 0 / 500
missed 0 / 500
missed 0 / 500
```

The probe is not committed — it exists to prove the boundary, not to be run in CI.

Full suite, freshly built Release, both frameworks:

- `dotnet test Jint.Tests.Browser -c Release -f net10.0` — **2636 passed, 0 failed**, 38 skipped
- `dotnet test Jint.Tests.Browser -c Release -f net8.0` — **2632 passed, 0 failed**, 38 skipped

### Exclusion delta

None — no web-platform-tests exclusion row is touched.

### Upstream (AngleSharp) findings

None; nothing here reaches AngleSharp.

### Base

`upstream/main` at rebase time: `edcd94d92` ("Source set selection and img.decode(): HTML §4.8.4.3.6 and §4.8.4.2 (#4014)").

Closes #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
