### PR TITLE
Bump AngleSharp.Css to 1.1.1-beta.310, so a translate that names fewer than three axes computes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,14 +11,23 @@
          the two records disagree, because the checked-in Jint.Browser/Dom/Generated/ is a picture of exactly
          these assemblies' [DomName] surface. Bump both together, regenerate, and read the diff. -->
     <PackageVersion Include="AngleSharp" Version="1.8.0" />
-    <!-- A prerelease deliberately, and the maintainer's own preference for this repository: 1.1.1-beta.308 is
-         1.1.0 plus AngleSharp/AngleSharp.Css#244, which stops a composite converter reparsing an unresolved
-         any-value with itself. Without it `translate`, `rotate` and `scale` overflow the stack inside
-         ComputeCurrentStyle(), and a stack overflow is the one failure Dom/Views/CssCascade's guard cannot
-         turn into a null cascade — it ends the process. Jint.Tests.Browser/Views/IndividualTransformStyleTests
-         is what holds the fix. AngleSharp itself stays on 1.8.0: nothing later is published, prerelease
-         included. -->
-    <PackageVersion Include="AngleSharp.Css" Version="1.1.1-beta.308" />
+    <!-- A prerelease deliberately, and the maintainer's own preference for this repository: this package is
+         taken from the preview channel whenever one of them carries something the browser needs, and two of
+         them do. 1.1.1-beta.308 is 1.1.0 plus AngleSharp/AngleSharp.Css#244, which stops a composite
+         converter reparsing an unresolved any-value with itself; without it `translate`, `rotate` and
+         `scale` overflow the stack inside ComputeCurrentStyle(), and a stack overflow is the one failure
+         Dom/Views/CssCascade's guard cannot turn into a null cascade — it ends the process.
+         1.1.1-beta.310 is that plus AngleSharp.Css 8c7ec8b9 and 534c18ec. The half this browser reaches is
+         one null guard: CssTranslateValue leaves the axes a function did not name null — that is how it
+         tells translateX(10px) from translate3d(10px, 0, 0) — and its Compute dereferenced all three, so
+         computing any `transform` whose translate named fewer than three axes raised inside the computed
+         declaration and Dom/Views/CssCascade dropped the property to "". The rest of the two commits is
+         CssRotateValue's and CssMatrixValue's ComputeMatrix, which nothing here calls: there is no
+         transform stage in the flat box model. Jint.Tests.Browser/Views/IndividualTransformStyleTests and
+         Views/TransformFunctionStyleTests are what hold the two fixes. AngleSharp itself stays on 1.8.0:
+         nothing later is published, prerelease included — nuget's flatcontainer index for `anglesharp` ends
+         at 1.8.0, whose newest prerelease (1.8.0-beta.679) precedes it. -->
+    <PackageVersion Include="AngleSharp.Css" Version="1.1.1-beta.310" />
     <!-- Neither of these is in the binding generator's pin, and deliberately: the generator reads AngleSharp
          and AngleSharp.Css and nothing else, and neither of these carries a [DomName] the binding could
          project. Each is referenced for one thing the package's own principle says must not be written here —

--- a/Jint.Tests.Browser/DomBindingsPinTests.cs
+++ b/Jint.Tests.Browser/DomBindingsPinTests.cs
@@ -33,7 +33,7 @@ public sealed class DomBindingsPinTests
         var pinned = ReadPin();
 
         // An assembly version carries a fourth revision component a package version never states, and it
-        // carries no prerelease suffix at all — AngleSharp.Css 1.1.1-beta.308 is assembly 1.1.1.0 — so this
+        // carries no prerelease suffix at all — AngleSharp.Css 1.1.1-beta.310 is assembly 1.1.1.0 — so this
         // compares the three numeric parts of the release portion rather than the whole string.
         Release(typeof(IElement).Assembly.GetName().Version!.ToString()).Should().Be(Release(pinned["AngleSharp"]));
         Release(typeof(ICssStyleDeclaration).Assembly.GetName().Version!.ToString()).Should().Be(Release(pinned["AngleSharp.Css"]));

--- a/Jint.Tests.Browser/Views/TransformFunctionStyleTests.cs
+++ b/Jint.Tests.Browser/Views/TransformFunctionStyleTests.cs
@@ -1,0 +1,99 @@
+namespace Jint.Tests.Browser.Views;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// The <c>transform</c> property's translate functions —
+/// <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate">CSS Transforms Level 1
+/// §12.1</a>'s <c>translate()</c>, <c>translateX()</c>, <c>translateY()</c> and
+/// <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-three-d-transform-translatez">Level 2
+/// §11.2</a>'s <c>translateZ()</c> — reach a computed style with the components the page omitted still
+/// omitted, rather than being dropped from the cascade.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this is a suite of its own.</b> <c>CssTranslateValue</c> holds one <c>ICssValue</c> per axis and
+/// leaves the axes the function did not name <see langword="null"/> — that is how it tells
+/// <c>translateX(10px)</c> from <c>translate3d(10px, 0, 0)</c> when it serializes itself. Its
+/// <c>ICssValue.Compute</c> dereferenced all three unconditionally, so computing any translate that named
+/// fewer than three axes raised a <c>NullReferenceException</c> inside the computed declaration
+/// (AngleSharp.Css <c>8c7ec8b9</c>, released in 1.1.1-beta.309). That is a failure
+/// <c>Dom/Views/CssCascade</c> does catch, so nothing crashed and nothing was reported: the property simply
+/// answered the empty string, and a page reading <c>getComputedStyle(el).transform</c> was told the element
+/// has no transform at all. Every ordinary 2D spelling is in that set — <c>translate(10px)</c>,
+/// <c>translateX()</c>, <c>translateY()</c> and the two-argument <c>translate()</c> — and only the fully
+/// three-dimensional <c>translate3d()</c> escaped it, which is why the suite beside this one
+/// (<c>IndividualTransformStyleTests</c>) stayed green through the whole of it.
+/// </para>
+/// <para>
+/// <b>What this does not claim.</b> The computed value is the token sequence AngleSharp.Css resolved, not a
+/// browser's <c>matrix()</c> normalization: a browser answers <c>matrix(1, 0, 0, 1, 10, 0)</c> where this
+/// answers <c>translateX(10px)</c>. Nothing here transforms a box either — the flat layout has no transform
+/// stage — so these are assertions about a property being answered, not about where the element moved to.
+/// </para>
+/// </remarks>
+public sealed class TransformFunctionStyleTests
+{
+    /// <summary>
+    /// One case per translate spelling that leaves an axis unnamed, with the serialization the computed
+    /// declaration answers for it. Each of these answered <c>""</c> on 1.1.1-beta.308.
+    /// </summary>
+    [TestCase("translate(10px)", "translateX(10px)")]
+    [TestCase("translateX(10px)", "translateX(10px)")]
+    [TestCase("translateY(20px)", "translateY(20px)")]
+    [TestCase("translateZ(30px)", "translateZ(30px)")]
+    [TestCase("translate(10px, 20px)", "translate(10px, 20px)")]
+    public async Task ATranslateThatNamesFewerThanThreeAxesComputes(string declared, string computedValue)
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='moved' style='transform: " + declared + "'>a</div>");
+
+        (await page.EvaluateAsync<string>(
+            "getComputedStyle(document.getElementById('moved')).getPropertyValue('transform')"))
+            .Should().Be(computedValue, "computing {0} must not dereference the axes it does not name", declared);
+    }
+
+    /// <summary>
+    /// The same defect through a transform list and through a percentage, whose serializations depend on the
+    /// rest of the list and on the page's render device — so these assert that the property is answered at
+    /// all, which is exactly what was lost.
+    /// </summary>
+    [TestCase("translate(0, -50%)", "translate(0, -")]
+    [TestCase("translate(10px) rotate(45deg)", "translateX(10px) rotate(")]
+    public async Task ATranslateInAListOrOverAPercentageComputesToo(string declared, string prefix)
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='moved' style='transform: " + declared + "'>a</div>");
+
+        (await page.EvaluateAsync<string>(
+            "getComputedStyle(document.getElementById('moved')).getPropertyValue('transform')"))
+            .Should().StartWith(prefix, "the whole of {0} is in the computed cascade", declared);
+    }
+
+    /// <summary>
+    /// The transform functions that named every component they have, which computed even on
+    /// 1.1.1-beta.308 — so a green run here is not evidence for the cases above.
+    /// </summary>
+    [TestCase("translate3d(1px, 2px, 3px)", "translate3d(1px, 2px, 3px)")]
+    [TestCase("scale(2)", "scale(2)")]
+    [TestCase("scale(2, 3)", "scale(2, 3)")]
+    [TestCase("perspective(100px)", "perspective(100px)")]
+    [TestCase("matrix(2, 3, 4, 5, 6, 7)", "matrix(2, 3, 4, 5, 6, 7)")]
+    public async Task AFullyArgumentedTransformFunctionStillComputes(string declared, string computedValue)
+    {
+        await using var browser = new Browser();
+        var page = await browser.NewPageAsync();
+
+        await page.SetContentAsync("<div id='moved' style='transform: " + declared + "'>a</div>");
+
+        (await page.EvaluateAsync<string>(
+            "getComputedStyle(document.getElementById('moved')).getPropertyValue('transform')"))
+            .Should().Be(computedValue);
+    }
+}

--- a/tools/dom-bindings/pin.json
+++ b/tools/dom-bindings/pin.json
@@ -7,7 +7,7 @@
   ],
   "packages": {
     "AngleSharp": "1.8.0",
-    "AngleSharp.Css": "1.1.1-beta.308"
+    "AngleSharp.Css": "1.1.1-beta.310"
   },
-  "retrieved": "2026-09-08"
+  "retrieved": "2026-09-09"
 }


### PR DESCRIPTION
## The mechanism

`CssTranslateValue` holds one `ICssValue` per axis and leaves the axes the function did not name `null` —
that is how it tells `translateX(10px)` from `translate3d(10px, 0, 0)` when it serializes itself. Its
`ICssValue.Compute` dereferenced all three unconditionally:

```csharp
var x = _x.Compute(context);   // NullReferenceException for translateY(20px)
var y = _y.Compute(context);   // ... and for translate(10px)
var z = _z.Compute(context);   // ... and for translate(10px, 20px)
```

So computing a `transform` whose translate named fewer than three axes raised inside the computed
declaration. That is a failure `Dom/Views/CssCascade` **does** catch — its `catch (… or NullReferenceException)`
arm — so nothing crashed and nothing was reported: `getComputedStyle(el).transform` simply answered `""`, and
a page was told the element has no transform at all. Every ordinary 2D spelling was in that set;
`translate3d()` alone escaped it, which is why the suite beside the new one
(`Views/IndividualTransformStyleTests`) stayed green through the whole of it.

`AngleSharp.Css` [`8c7ec8b9`](https://github.com/AngleSharp/AngleSharp.Css/commit/8c7ec8b90b8e2d3fa57eb140badbee46ecbad628)
is the null guard, released in `1.1.1-beta.309`.

**The other half of the bump does not reach this repository, and rides along.** `8c7ec8b9`'s
`CssRotateValue` fix (it read `_x` for all three axis components) and
[`534c18ec`](https://github.com/AngleSharp/AngleSharp.Css/commit/534c18ec235e2e7b97710d56deb41767676ab9c2)'s
column-major 4×4 embedding of the 2D `matrix()` function are both entirely inside `ComputeMatrix`, which
nothing here calls — the flat box model has no transform stage. `matrix(2, 3, 4, 5, 6, 7)` computes to the
same string on both versions, and there is nothing to regression-test for it.

**AngleSharp core stays at 1.8.0**, per the maintainer's rule that the preview channel is taken only for
`AngleSharp.Css`, and only when a preview carries something the browser needs. Verified against the
flatcontainer index for `anglesharp`: its newest version is `1.8.0`, and its newest prerelease
(`1.8.0-beta.679`) precedes it — there is no post-1.8.0 prerelease to take.

## Spec

- [CSS Transforms Level 1 §12.1](https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate) —
  `translate()`, `translateX()`, `translateY()`
- [CSS Transforms Level 2 §11.2](https://drafts.csswg.org/css-transforms-2/#funcdef-three-d-transform-translatez) —
  `translateZ()`
- The failing member is CSSOM's [`CSSStyleDeclaration.getPropertyValue`](https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue)
  over a [resolved value](https://drafts.csswg.org/cssom/#resolved-values), reached through
  `Jint.Browser/Dom/Views/CssCascade`.

## Premise validation

The brief was a chore bump. It is not only a chore: the two preview commits fix a **live, silent defect in
this browser**, measured on the unfixed tree.

Probe over `getComputedStyle(el).getPropertyValue('transform')`, one declaration per row, `net8.0`:

| declaration | 1.1.1-beta.308 | 1.1.1-beta.310 |
| --- | --- | --- |
| `translate(10px)` | `""` | `translateX(10px)` |
| `translateX(10px)` | `""` | `translateX(10px)` |
| `translateY(20px)` | `""` | `translateY(20px)` |
| `translateZ(30px)` | `""` | `translateZ(30px)` |
| `translate(10px, 20px)` | `""` | `translate(10px, 20px)` |
| `translate(0, -50%)` | `""` | `translate(0, -640px)` |
| `translate(10px) rotate(45deg)` | `""` | `translateX(10px) rotate(0.785398163397448rad)` |
| `translate3d(1px, 2px, 3px)` | `translate3d(1px, 2px, 3px)` | same |
| `rotate(45deg)` | `rotate(0.785398163397448rad)` | same |
| `rotate3d(1, 0, 0, 45deg)` | `rotate3d(1, 0, 0, 0.785398163397448rad)` | same |
| `scale(2)` / `scale(2, 3)` | `scale(2)` / `scale(2, 3)` | same |
| `skew(10deg)` | `skew(0.174532925199433rad)` | same |
| `perspective(100px)` | `perspective(100px)` | same |
| `matrix(2, 3, 4, 5, 6, 7)` | `matrix(2, 3, 4, 5, 6, 7)` | same |

The negative case is the bottom half of that table: every function that named all of its components computed
identically before and after, so the fix is the null guard and not a change of serialization. The rest of the
cascade was intact in both runs (`visibility` answered `visible` for every row) — the defect took one property,
not the declaration, which is exactly why it was invisible.

## Failing-first

`Jint.Tests.Browser/Views/TransformFunctionStyleTests` is new. Built once against `1.1.1-beta.308` (the only
change to the tree being the version in `Directory.Packages.props`) and run on both target frameworks:

```
net8.0   Failed:  7, Passed:  5, Total: 12
net10.0  Failed:  7, Passed:  5, Total: 12
```

The 7 failures are the 5 unnamed-axis spellings plus the list and percentage cases; the 5 passes are the
fully-argumented controls, which is the point of keeping them in the file. On `1.1.1-beta.310`:

```
net8.0   Failed:  0, Passed: 12, Total: 12
net10.0  Failed:  0, Passed: 12, Total: 12
```

## What was searched for a retired row, and found not to exist

Nothing in this repository worked around either defect, so no row, test or workaround was retired. The
searches, all over the whole tree unless narrowed:

- `ComputeMatrix|TransformMatrix|CssMatrixValue|CssRotateValue|CssTranslateValue` over `*.cs`, `*.md`,
  `*.json` — **zero hits**. `ComputeMatrix` is unreachable from this repository, which is what makes the
  `matrix()`/`rotate()` half of the bump unobservable here.
- `matrix` over `Jint.Browser/`, `Jint.Tests.Browser/`, `tools/` — only `tools/devtools-protocol/handshakes/matrix.md`
  (the CDP client handshake matrix) and one "nesting matrix" comment in `Events/ActivationBehaviorTests`.
- `transform` over the same three — the generated `CSSStyleDeclaration.transform` / `transformOrigin` /
  `transformStyle` / `textTransform` accessors, `Accessibility/AccessibleName`'s note that `text-transform`
  is not applied, and `Views/IndividualTransformStyleTests`. No workaround, no skip, no override entry.
- `transform|matrix|beta\.30` over `Jint.Browser/Dom/divergences.md` — **zero hits**; there was no row to
  retire, and none is added, because the divergence is fixed upstream rather than worked around here.
- `translate(|rotate(|matrix(|translateX|translate3d|skew|perspective(` over `Jint.Browser/`,
  `Jint.Tests.Browser/`, `tools/dom-bindings/` — only the unrelated `DomFailures.Translate` and
  `PageNetworkRecorder.Translate` methods.
- `transform` over `Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs`, `Wpt/README.md` and
  `Jint.Tests/Wpt/WptExclusions.cs` — only `TransformStream` rows, which are Streams and unrelated. The
  browser lane vendors no CSS suite (`WptCorpus.BrowserSuites` is `dom/*`, `html/*` and `custom-elements/*`),
  so no wpt outcome can move on a CSSOM fix.

## Exclusion delta

**None.** No row added, none removed, `Wpt/README.md` untouched. The full `Jint.Tests.Browser` run is green
on both frameworks, so no excluded case started passing, and the census check
(`JINT_WPT_BROWSER_CENSUS=1`, full `~Wpt` filter, `net8.0`) passes unchanged: `Passed: 434, Failed: 0`.

## The pin, and the regeneration

`tools/dom-bindings/pin.json` moves with `Directory.Packages.props` (`DomBindingsPinTests.ThePinAndTheCentralPackageVersionsAgree`
and `TheLoadedAssembliesAreThePinnedOnes` both pass), and the generator was re-run against the newly resolved
assemblies as `tools/dom-bindings/README.md#a-bump-is-a-code-change` requires:

```
dotnet run --project tools/dom-bindings/Jint.Browser.BindingGenerator -c Release -- \
    --core artifacts/bin/Jint.Tests.Browser/release_net8.0/AngleSharp.dll \
    --css  artifacts/bin/Jint.Tests.Browser/release_net8.0/AngleSharp.Css.dll \
    --overrides tools/dom-bindings/overrides.json --output Jint.Browser/Dom/Generated --report ...
```

`Jint.Browser/Dom/Generated` came back **byte-identical** — no `[DomName]` moved between the two previews —
with **0 diagnostics** and the same 20 skipped members, each with the reason it already had. So there is no
generated output in this diff, which is the correct outcome to read rather than an omission.

The `Directory.Packages.props` comment is rewritten rather than renumbered: it now states the preview-channel
rule itself, what each of the two previews carries, and which half of `beta.310` this browser can reach.
`DomBindingsPinTests`' illustrative "AngleSharp.Css 1.1.1-beta.308 is assembly 1.1.1.0" is updated to name the
version actually pinned (`beta.310` is also assembly `1.1.1.0`, which is what the test asserts).

## Upstream findings — recorded, not filed

Nothing was opened on any AngleSharp repository. Both defects were already fixed upstream before this bump;
this pull request only consumes them. One observation worth having on the record: `CssTranslateValue.Name`
already reasoned about all four null combinations, and `Compute` beside it dereferenced them anyway — the
serializer and the computer disagreed about the same fields inside one class.

## Verification

Everything in Release, no `--no-build`.

| Run | Result |
| --- | --- |
| `dotnet build -c Release` (solution) | 0 errors, 1 pre-existing MSB3277 in `Jint.Tests.CommonScripts` (net472 test-platform assembly conflict, untouched by this change) |
| `Jint.Tests.Browser` `-f net8.0` | `Passed: 2644, Failed: 0, Skipped: 38` |
| `Jint.Tests.Browser` `-f net10.0` | `Passed: 2648, Failed: 0, Skipped: 38` |
| `Jint.Tests.Browser` `-f net8.0`, `JINT_HOST_CONTRACT_VERIFICATION=1` | `Passed: 2644, Failed: 0` |
| `Jint.Tests.Browser` `-f net10.0`, `JINT_HOST_CONTRACT_VERIFICATION=1` | `Passed: 2648, Failed: 0` |
| `Jint.Tests.Browser` `--filter ~Wpt`, `JINT_WPT_BROWSER_CENSUS=1`, `net8.0` | `Passed: 434, Failed: 0` |
| `Jint.Tests.PublicInterface` (net8.0 / net10.0 / net472) | `3718 / 3728 / 2945` passed, 0 failed |

`Jint.Tests.PublicInterface` needed no baseline update: no public surface moved.

Base: `upstream/main` at `edcd94d92929da846c33b5ad902f7b4647797476`.

Refs #3888

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
