### PR TITLE
The empty `action` reflects the page's current URL, HTML §4.10.18.6

### DIFF
--- a/Jint.Browser/Dom/ReflectedAttribute.cs
+++ b/Jint.Browser/Dom/ReflectedAttribute.cs
@@ -194,7 +194,9 @@ internal sealed class ReflectedAttribute
     /// HTML §4.10.18.6's exception, which <c>form.action</c> and <c>formAction</c> are the only members
     /// with: "on getting, when the content attribute is missing or its value is the empty string, the
     /// element's node document's URL must be returned instead". It is the document's URL and not the base
-    /// URL, so a <c>&lt;base href&gt;</c> does not move it.
+    /// URL, so a <c>&lt;base href&gt;</c> does not move it — and for a document with a browsing context it
+    /// is the URL <em>the page</em> holds, which a same-document navigation moves and AngleSharp's document
+    /// address does not; <see cref="Get(DomRealm, IElement)"/> is where the two are told apart.
     /// </param>
     internal static ReflectedAttribute Url(string member, string attribute, bool documentUrlWhenEmpty = false)
         => new(member, attribute, ReflectedKind.Url, documentUrlWhenEmpty: documentUrlWhenEmpty);
@@ -238,16 +240,26 @@ internal sealed class ReflectedAttribute
 
     /// <summary>The IDL attribute's value outside a page runtime, resolved against its node document.</summary>
     internal JsValue Get(IElement element)
-        => Get(element, CurrentBaseUri(element.Owner, element.BaseUri));
+    {
+        var owner = element.Owner;
+        return Get(element, CurrentBaseUri(owner, element.BaseUri), owner?.Url);
+    }
 
     /// <summary>The IDL attribute's value inside a page runtime, resolved against its current document base.</summary>
+    /// <remarks>
+    /// Two values come from the runtime and they are different values. The base URL is what a relative
+    /// content attribute resolves against; the document's URL is what <see cref="_documentUrlWhenEmpty"/>
+    /// answers instead of resolving anything, and a <c>&lt;base href&gt;</c> does not move it. Both are the
+    /// runtime's rather than AngleSharp's because a same-document navigation moves
+    /// <see cref="PageRuntime.DocumentUrl"/> and leaves AngleSharp's document address at whatever the parse
+    /// was given — so after <c>history.pushState</c> the AngleSharp answer is the address the page was
+    /// loaded at, which for <c>formAction</c> is the one URL a form posting to itself must not read.
+    /// </remarks>
     internal JsValue Get(DomRealm realm, IElement element)
     {
         var owner = element.Owner;
-        var baseUri = PageRuntime.Find(realm.Engine) is { } runtime && ReferenceEquals(owner, runtime.Document)
-            ? runtime.BaseUri
-            : CurrentBaseUri(owner, element.BaseUri);
-        return Get(element, baseUri);
+        var runtime = PageRuntime.Find(realm.Engine, owner);
+        return Get(element, runtime?.BaseUri ?? CurrentBaseUri(owner, element.BaseUri), runtime?.DocumentUrl ?? owner?.Url);
     }
 
     /// <summary>
@@ -260,7 +272,7 @@ internal sealed class ReflectedAttribute
     /// content attribute, which is what passing no element to the shared getter says.
     /// </remarks>
     internal JsValue Get(IDocument document)
-        => Get(ElementIn(document), CurrentBaseUri(document, document.BaseUri));
+        => Get(ElementIn(document), CurrentBaseUri(document, document.BaseUri), document.Url);
 
     /// <summary>The same member's setter, which does nothing when the target element is absent.</summary>
     internal JsValue Set(DomRealm realm, IDocument document, JsValue[] arguments)
@@ -298,7 +310,7 @@ internal sealed class ReflectedAttribute
         return PageUrl.Resolve(href, address) ?? address;
     }
 
-    private JsValue Get(IElement? element, string? baseUri)
+    private JsValue Get(IElement? element, string? baseUri, string? documentUrl)
     {
         var value = element?.GetAttribute(_attribute);
 
@@ -317,8 +329,9 @@ internal sealed class ReflectedAttribute
                 return DomConvert.Text(element is null ? "" : CryptographicNonce.Get(element));
 
             case ReflectedKind.Url when _documentUrlWhenEmpty && string.IsNullOrEmpty(value):
-                // "...the element's node document's URL must be returned instead."
-                return DomConvert.Text(element?.Owner?.Url ?? "");
+                // "...the element's node document's URL must be returned instead." The caller resolved which
+                // URL that is, because for the page's own document it is the runtime's and not AngleSharp's.
+                return DomConvert.Text(documentUrl ?? "");
 
             case ReflectedKind.Url:
                 return DomConvert.Text(ResolveUrl(value, baseUri));

--- a/Jint.Browser/Runtime/PageRuntime.cs
+++ b/Jint.Browser/Runtime/PageRuntime.cs
@@ -268,8 +268,8 @@ internal sealed class PageRuntime
     internal string WindowName { get; set; } = "";
 
     /// <summary>
-    /// The document's URL as the page knows it, which is what <c>location</c>, <c>document.URL</c> and
-    /// relative resolution read.
+    /// The document's URL as the page knows it, which is what <c>location</c>, <c>document.URL</c>,
+    /// relative resolution and HTML §4.10.18.6's empty-<c>action</c> default read.
     /// </summary>
     /// <remarks>
     /// It is the runtime's rather than AngleSharp's because <c>pushState</c> and a fragment navigation move

--- a/Jint.Tests.Browser/DomReflectionTests.cs
+++ b/Jint.Tests.Browser/DomReflectionTests.cs
@@ -118,6 +118,64 @@ public sealed class DomReflectionTests
         (await page.EvaluateAsync<string>("otherLink.href")).Should().BeEmpty();
     }
 
+    /// <summary>
+    /// HTML §4.10.18.6's exception to URL reflection — a missing or empty <c>action</c> answers the element's
+    /// node document's URL — is the document's <b>current</b> URL, which for a document with a browsing
+    /// context is the one <c>pushState</c> moved and not the address AngleSharp was parsed at.
+    /// </summary>
+    /// <remarks>
+    /// The two are the same value until a same-document navigation separates them: <c>pushState</c> moves
+    /// <c>PageRuntime.DocumentUrl</c> without touching AngleSharp's document at all, deliberately, because
+    /// writing its location would raise <c>Location.Changed</c> and reopen the browsing context. So a form
+    /// posting to itself — the whole reason the rule exists — read the address the page was first loaded at.
+    /// It is the document's URL and not its base URL, which is why the <c>&lt;base href&gt;</c> here moves
+    /// neither answer, and it is the <em>owning</em> document's, which is what a secondary document with no
+    /// runtime of its own tests.
+    /// </remarks>
+    [Test]
+    public async Task AFormActionUrlDefaultsToTheOwningDocumentUrl()
+    {
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            "<base href='https://base.example/other/'>"
+            + "<form id='f' action=''><input id='i' formaction=''><button id='b'></button></form>",
+            "https://document.example/root/page.html#fragment");
+
+        const string members = "[f.action, i.formAction, b.formAction].join('|')";
+        const string page1 = "https://document.example/root/page.html#fragment";
+
+        // An empty attribute, on all three members with the rule.
+        (await page.EvaluateAsync<string>(members)).Should().Be(string.Join('|', page1, page1, page1));
+
+        // And an absent one, which is the other half of "missing or its value is the empty string".
+        await page.EvaluateAsync("f.removeAttribute('action'); i.removeAttribute('formaction')");
+        (await page.EvaluateAsync<string>(members)).Should().Be(string.Join('|', page1, page1, page1));
+
+        // A same-document navigation moves the document's URL, so all three follow it.
+        await page.EvaluateAsync("history.pushState({}, '', '/pushed?q=1')");
+        const string page2 = "https://document.example/pushed?q=1";
+        (await page.EvaluateAsync<string>(members)).Should().Be(string.Join('|', page2, page2, page2));
+
+        // A non-empty value is ordinary URL reflection again, so the <base href> applies to it and not to
+        // the default above.
+        await page.EvaluateAsync("i.setAttribute('formaction', 'submit')");
+        (await page.EvaluateAsync<string>("i.formAction")).Should().Be("https://base.example/other/submit");
+
+        // A document with no page runtime answers its own URL, and adoption moves the answer with the node.
+        await page.EvaluateAsync(
+            """
+            globalThis.other = document.implementation.createHTMLDocument('other');
+            other.body.innerHTML = "<input id='otherControl' formaction=''>";
+            globalThis.otherControl = other.getElementById('otherControl');
+            """);
+        (await page.EvaluateAsync<bool>("otherControl.formAction === other.URL")).Should().BeTrue();
+        (await page.EvaluateAsync<bool>("otherControl.formAction === document.URL")).Should().BeFalse();
+
+        await page.EvaluateAsync("document.adoptNode(otherControl)");
+        (await page.EvaluateAsync<string>("otherControl.formAction")).Should().Be(page2);
+    }
+
     [Test]
     public void ABooleanAttributeReflectsPresence()
     {


### PR DESCRIPTION
## Mechanism

`Jint.Browser/Dom/ReflectedAttribute.cs`'s `documentUrlWhenEmpty` arm answered `element.Owner.Url` — which is
**AngleSharp's** document address, the URL the parse was given.

The page's URL is not that value once a same-document navigation has happened. `Page.CommitSameDocumentUrl`
writes `PageRuntime.DocumentUrl` and touches AngleSharp's document not at all, deliberately: writing its
location would raise `Location.Changed`, a fire-and-forget `IBrowsingContext.OpenAsync` on the page's own
thread. That is why `document.URL` is a getter hook reading
`PageRuntime.Find(engine, document)?.DocumentUrl ?? document.Url` (`DomHostHooks.cs`) rather than AngleSharp's
property.

So after `history.pushState('/x')` — the first move of every client-side router — `form.action`,
`input.formAction` and `button.formAction` answered the address the page was **first loaded at**, while
`document.URL` beside them answered the current one.

`Get(DomRealm, IElement)` now resolves both URLs it needs from one `PageRuntime.Find(engine, owner)` lookup:

* the **base URL** a relative content attribute resolves against — `runtime?.BaseUri`, else the owner
  document's current first `base[href]`; and
* the **document URL** an empty or absent attribute answers instead — `runtime?.DocumentUrl`, else
  `owner?.Url`.

The private `Get` takes that second value rather than re-deriving it, so a document with no runtime of its own
(one `DOMParser` or `createHTMLDocument` made) answers its own URL and adoption moves the answer with the
node. `HTMLFormElement.action` and `HTMLButtonElement.formAction` are the same `url` + `documentUrlWhenEmpty`
rows and reach the same code, and the test asserts all three together.

Incidental: the runtime lookup was open-coded as
`PageRuntime.Find(engine) is { } r && ReferenceEquals(owner, r.Document)` and is now the
`Find(Engine, IDocument?)` overload that says exactly that. The one behaviour that changes is a detached
element whose `Owner` is null, which now takes the `element.BaseUri` arm instead of matching a runtime whose
`Document` was also null.

## Spec citation

[HTML §4.10.18.6](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action) —
"The `action` IDL attribute must reflect the content attribute of the same name, except that on getting, when
the content attribute is missing or its value is the empty string, the element's node document's URL must be
returned instead." It is the document's URL, not its base URL, so a `<base href>` moves neither answer; and
for a document with a browsing context the node document's URL is the one a same-document navigation moved.

## Premise validation

Reproduced on the unfixed tree before the fix, and the reproduction is the new test. Reading the tree
confirmed both halves first: `Page.Navigation.cs:364` writes `runtime.DocumentUrl` and nothing else, and
`DomHostHooks.cs:631` already reads the runtime for `document.URL` — the reflected getter was the one reader
that did not.

The three sub-cases the brief asked to check all held as stated, and the two that were *not* broken are
asserted too so they stay that way: the `<base href>` does not move the empty-`action` answer (it is the
document's URL, not the base URL), and a non-empty value is still ordinary URL reflection that *does* resolve
against the base.

## Failing-first

`dotnet test -c Release -f net8.0 --filter FullyQualifiedName~AFormActionUrlDefaultsToTheOwningDocumentUrl`
on the unfixed tree — **Failed: 1, Passed: 0**:

```
Expected (page.EvaluateAsync<string>(members)) to be the same string, but they differ at index 25:
           ↓ (actual)
"…t.example/root/page.html#fragment|https://document…"
"…t.example/pushed?q=1|https://document.example/push…"
           ↑ (expected).
   at Jint.Tests.Browser.DomReflectionTests.AFormActionUrlDefaultsToTheOwningDocumentUrl() … line 176
```

Line 176 is the assertion after `history.pushState({}, '', '/pushed?q=1')`; the two assertions before it (empty
attribute, absent attribute) passed, which is the point — the two URLs agree until a same-document navigation
separates them. After the fix the same filter passes, and `DomReflectionTests` is Passed 64, Failed 0.

## Exclusion delta

**None.** No `WptBrowserExclusions` row and no census figure moves: no vendored document combines a
same-document navigation with a form-action read, which is exactly why the defect survived
`reflection-forms-weekmonth.html` passing whole.

## Verification

| Run | Result |
| --- | --- |
| `Jint.Tests.Browser` `-f net8.0` | Passed 2,633, Failed 0, Skipped 38 |
| `Jint.Tests.Browser` `-f net10.0` | Passed 2,637, Failed 0, Skipped 38 |
| `Jint.Tests.Browser` `-f net8.0` `--filter ~Dom` with `JINT_HOST_CONTRACT_VERIFICATION=1` | Passed 1,150, Failed 0 |

Both framework runs were repeated after the rebase onto `0a6d10255`.

## Upstream findings, recorded not filed

None. This is Jint's own descriptor reading the wrong one of two URLs it already had access to — AngleSharp's
document address is *correct* for what it is, and `PageRuntime.DocumentUrl`'s own remarks say why the page
keeps a second one. No issue or PR was opened on any AngleSharp repository; `Jint.Browser/Dom/divergences.md`
gains no row, because there is no AngleSharp divergence here.

## Base

`upstream/main` at `0a6d10255cbc899d5b5edbc26ed8906610f83369`.

Independent of #4020 — different files, no shared commit; the two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
