### PR TITLE
Vendor HTML §4.16.3's own selector suite, and name what each of its 68 failures is

### DIFF
--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -37,11 +37,12 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 2 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
 | `html/semantics/embedded-content/the-img-element/` | 4 | 0 | 99 | 0 |
+| `html/semantics/selectors/pseudo-classes/` | 27 | 0 | 122 | 68 |
 | `custom-elements/` | 16 | 0 | 513 | 13 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
-| **total** | **365** | **9** | **66,794** | **852** |
+| **total** | **392** | **9** | **66,916** | **920** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -267,6 +268,40 @@ is one. Their siblings are about other interfaces — `HTMLFormControlsCollectio
 `RadioNodeList`, `DOMStringList` and HTML's obsolete document colours — and vendoring one moves the census's
 `Documents` and `Tests` columns, so it is a change of its own rather than a passenger on this one.
 
+## What the pseudo-classes suite says about this browser
+
+`html/semantics/selectors/pseudo-classes/` is HTML §4.16.3's own suite: one document per selector, run
+against a page's real selector engine rather than against a table of strings. **27 documents, 122 tests, 68
+of which do not pass**, and every failure is one of eleven bounded things AngleSharp's
+`DefaultPseudoClassSelectorFactory` does. That is the reason the suite is here: the page already owns
+`:target`, `:link`/`:visited`/`:any-link`, `:enabled`/`:disabled` and `:default`
+(`Runtime/Parsing/PagePseudoClassSelectorFactory`), and nothing until now measured the rest.
+
+None of these eleven has a row in the cause table above, and that is by construction: the table counts the
+six DOM suites, and every one of these is a failure of this suite alone.
+
+| Tests | What it is |
+| ---: | --- |
+| 20 | **`:read-write` is "mutable" rather than "the `readonly` attribute applies and the control is mutable".** So a checkbox is read-write; and `IsContentEditable` answers false, so an editing host and everything inside one is read-only. Two of the rows want a form-associated custom element. |
+| 10 | **`:in-range` matches any validation candidate that is neither overflowing nor underflowing**, where HTML asks for one that *has* range limitations — so `<input type=text min=0 max=10>` matches. A `range` control's value is also not clamped to its limits, so it can report an overflow §4.10.5.4 says cannot arise. |
+| 9 | **`:dir()` compares its argument with the `dir` content attribute of that element alone.** Directionality is inherited and its `auto` value is resolved from text, so an element declaring no `dir` matches neither keyword. |
+| 8 | **`:valid`/`:invalid` skip the `<fieldset>`.** They answer from `IValidation.CheckValidity()` and a form's; the same document's `<form>` rows pass. Two more documents want a constraint state kept across a removal and across a clone. |
+| 5 | **`:active` is a hyperlink-only flag nothing sets**, so no element matches while a click is in flight. |
+| 5 | **`:focus` is AngleSharp's `IElement.IsFocused`, which nothing assigns.** The page's own focus model is `Events/FocusController`, which is what `document.activeElement` reads, so `focus()` moves the active element where no selector can see it. |
+| 4 | **An opaque colour is serialized as `rgba(r, g, b, 1)`**, and these four rows read `getComputedStyle().color` against a literal. Each already gets the colour the selector should produce; `Dom/divergences.md` records why the process-global switch is not flipped. |
+| 3 | **`:checked` answers for the historical `<menuitem>`**, which `checked.html` keeps two of precisely so that they do not match. |
+| 2 | **`:indeterminate` has no radio-button-group rule**, so an unchecked radio in a group with no checked member never matches. |
+| 1 | **`:placeholder-shown` ignores whether `placeholder` applies to the type state, and never answers for a `<textarea>`.** |
+| 1 | **`:required`/`:optional` read the attribute wherever it is written**, including on a hidden input, which it does not apply to. |
+
+**Four of the directory's files are not vendored and none of the reasons is a defect.** `autofill.html`'s two
+assertions are `test_valid_selector`, which lives in `/css/support/parsing-testcommon.js` — a helper root this
+corpus does not hold — so the file throws at file scope and reports nothing; `indeterminate-radio-group.html`
+is a reftest and its `-ref.html` is the reference it is judged against; and the two `.window.js` files are the
+glob every suite here has. `checked-001-manual.html` is covered by the lane's own `-manual.` marker.
+`focus-iframe.html` *is* vendored, as a frame body: `focus.html` loads it to assert that `:focus` does not
+match a focused element inside a frame.
+
 ## What the DOM corpus says about this browser
 
 All **43 assertions in the eight `dom/collections/` documents pass**, with no exclusions.
@@ -487,7 +522,7 @@ different from the engine lane's. **Almost every row is a document that cannot p
 — a harness `ERROR` or `TIMEOUT` — which is what puts it there rather than in the exclusion table: a harness
 error covers the whole file and no per-test exclusion can name it. The rest are the globs upstream's own
 markers and this lane's directory rule earn, and the helper files of documents nothing here runs. They fall
-into twenty-eight groups; the counts are rows rather than files, since several are globs. Ninety of
+into twenty-nine groups; the counts are rows rather than files, since several are globs. Ninety of
 the rows belong to the six DOM suites, which is what a corpus about every member of every node interface
 costs: half of them are one member reached at file scope. **A twenty-ninth answer is not in this table at
 all**: `WptBrowserExclusions.FrameBodies` names the documents that are vendored and served and never run,
@@ -522,6 +557,7 @@ which is what a fixture sitting beside the cases that load it needs — see belo
 | a DOM frame that runs script | 14 | listed when a frame had neither a document nor a realm; it has a document now ([#3771](https://github.com/sebastienros/jint/issues/3771)) and each row is owed a re-examination against the half that is left. Three have had it: the selector documents are cases |
 | a member reached at file scope | 30 | `createCDATASection` (31 documents, 24 of them `dom/ranges/`, through `dom/common.js`), `createDocument` (5) and `setAttributeNode` (1) |
 | one DOM file each | 3 | a `SyntaxError` no `error` event carries to the harness, and two `MutationObserver` documents waiting for a record that never comes |
+| the pseudo-classes suite's four non-cases | 4 | a helper root this corpus does not hold, a `.window.js` glob, and a reftest with its reference |
 | too slow to be a case | 2 | the six `NodeList-static-length-getter-tampered*` documents and their helper: a static `NodeList` re-reads its tampered `length` getter, so each spends between 5.9 s and 18.8 s and one of them crossed the driver's 30 s deadline on a loaded machine |
 
 **A document can also be vendored, served and never run.** `WptBrowserExclusions.FrameBodies` is that
@@ -535,6 +571,10 @@ the corpus really holds, directly under a suite this lane claims, and no row may
 pattern — a path cannot be absent and served at once. It takes no minimum-test entry and appears in no census
 column, because neither counts anything about a document that reports nothing; what holds it to its job is
 the three cases that load it, which fail loudly if the frame they wait for never arrives.
+
+**There are two rows now.** `focus-iframe.html` is the second: `focus.html` frames it and asserts that
+`:focus` does not match a focused element inside it, which is a document that has to be served and must
+not be a case of its own.
 
 **And that is what let the selector table in.** `Element-matches.html`, `Element-webkitMatchesSelector.html`
 and `ParentNode-querySelector-All.html` are the whole of wpt's Selectors-API suite, run three times over —

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -390,6 +390,12 @@ internal static class WptBrowserExclusions
         ("dom/nodes/MutationObserver-attributes.html", "thirty-four of its tests report and one waits forever for a record the observer never delivers"),
         ("dom/nodes/MutationObserver-childList.html", "the same, after thirty-eight"),
 
+        // ============================================================ html/semantics/selectors/pseudo-classes
+        // HTML §4.16.3's own suite. Four of its files are out, and none of the reasons is a defect.
+        ("html/semantics/selectors/pseudo-classes/autofill.html", "its two assertions are test_valid_selector, which is /css/support/parsing-testcommon.js - a helper root this corpus does not vendor - so the file throws at file scope and reports nothing at all"),
+        ("html/semantics/selectors/pseudo-classes/*.window.js", "a .window.js script, whose generated wrapper this lane does not synthesize"),
+        ("html/semantics/selectors/pseudo-classes/indeterminate-radio-group.html", "a reftest: it loads no testharness.js and is judged against a reference rendering, which this browser has no way to produce"),
+        ("html/semantics/selectors/pseudo-classes/indeterminate-radio-group-ref.html", "the reference of the reftest above"),
     ];
 
     /// <summary>
@@ -419,6 +425,7 @@ internal static class WptBrowserExclusions
     internal static readonly (string Path, string Reason)[] FrameBodies =
     [
         ("dom/nodes/ParentNode-querySelector-All-content.html", "the fixture Element-matches.html, Element-webkitMatchesSelector.html and ParentNode-querySelector-All.html each load into a frame and run their whole table against"),
+        ("html/semantics/selectors/pseudo-classes/focus-iframe.html", "the frame focus.html loads to assert that :focus does not match a focused element inside it"),
     ];
 
     /// <summary>
@@ -855,6 +862,33 @@ internal static class WptBrowserExclusions
         ["html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-3.html"] = 1,
         ["html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-4.html"] = 1,
         ["html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-5.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/active-disabled.html"] = 5,
+        ["html/semantics/selectors/pseudo-classes/checked.html"] = 3,
+        ["html/semantics/selectors/pseudo-classes/checked-type-change.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/default.html"] = 2,
+        ["html/semantics/selectors/pseudo-classes/dir.html"] = 3,
+        ["html/semantics/selectors/pseudo-classes/dir-dynamic.html"] = 4,
+        ["html/semantics/selectors/pseudo-classes/dir-html-input-dynamic-text.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/dir01.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/disabled.html"] = 7,
+        ["html/semantics/selectors/pseudo-classes/enabled.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/focus.html"] = 5,
+        ["html/semantics/selectors/pseudo-classes/focus-autofocus.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/indeterminate.html"] = 6,
+        ["html/semantics/selectors/pseudo-classes/indeterminate-radio.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/indeterminate-type-change.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/inrange-outofrange.html"] = 6,
+        ["html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html"] = 4,
+        ["html/semantics/selectors/pseudo-classes/inrange-outofrange-type-change.html"] = 2,
+        ["html/semantics/selectors/pseudo-classes/invalid-after-clone.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/link.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/placeholder-shown-type-change.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/readwrite-readonly.html"] = 25,
+        ["html/semantics/selectors/pseudo-classes/readwrite-readonly-type-change.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/required-optional.html"] = 6,
+        ["html/semantics/selectors/pseudo-classes/required-optional-hidden.html"] = 1,
+        ["html/semantics/selectors/pseudo-classes/valid-invalid.html"] = 30,
+        ["html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html"] = 2,
     };
 
     // ---------------------------------------------------------------- 8. AngleSharp.Css refuses an unparseable media query
@@ -1401,6 +1435,175 @@ internal static class WptBrowserExclusions
         new("html/dom/access-key-label.html", "*invalid", WptDivergence.NeedsTriage),
     ];
 
+    // ---------------------------------------------------------------- the pseudo-classes suite: :active
+    private static readonly WptExclusion[] _thePseudoClassesSuiteActive =
+    [
+        // HTML §4.16.3 leaves :active to the user agent's own "currently activated" notion, and says a
+        // disabled control still enters it. AngleSharp's IsActive() answers for a hyperlink and nothing else, off
+        // an IElement.IsActive flag no part of this package sets, so no element ever matches while a click is in
+        // flight - the five rows are one testdriver click each.
+        new("html/semantics/selectors/pseudo-classes/active-disabled.html", "Clicking on a disabled button should make it match the :active selector.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/active-disabled.html", "Clicking the label for a disabled button should make the button match the :active selector.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/active-disabled.html", "Clicking on a child of a disabled button should make the button match the :active selector.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/active-disabled.html", "Clicking on a disabled input should make it match the :active selector.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/active-disabled.html", "Clicking on a disabled textarea should make it match the :active selector.", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :focus
+    private static readonly WptExclusion[] _thePseudoClassesSuiteFocus =
+    [
+        // :focus is AngleSharp's IElement.IsFocused, which nothing in this package assigns. The page has a
+        // focus model of its own - Events/FocusController, which is what document.activeElement and every focus
+        // event read - so element.focus() moves the active element and no selector can see that it did.
+        new("html/semantics/selectors/pseudo-classes/focus.html", "input1 has the focus", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/focus.html", "tabindex attribute makes the element focusable", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/focus.html", "editable elements are focusable", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/focus.html", "':focus' matches focussed body with tabindex", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/focus-autofocus.html", ":focus selector should work with an autofocused element.", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :dir()
+    private static readonly WptExclusion[] _thePseudoClassesSuiteDir =
+    [
+        // :dir() asks for HTML §3.2.6.6's *directionality*: an inherited property whose `auto` value is
+        // resolved from the first strong character of the element's text - of an input's or textarea's value for
+        // those two. AngleSharp's DirFunctionState compares the argument with IHtmlElement.Direction, which
+        // reflects the `dir` content attribute of that element alone, so an element declaring none matches
+        // neither keyword: dir01.html asks for every element of an iso-8859-8 document and gets an empty list.
+        new("html/semantics/selectors/pseudo-classes/dir.html", "':dir(rtl)' matches all elements whose directionality is 'rtl'.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/dir.html", "':dir(ltr)' matches all elements whose directionality is 'ltr'.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/dir.html", "':dir(ltr)' doesn't match elements not in the document.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/dir01.html", "direction doesn't affect :dir()", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/dir-dynamic.html", "Dynamically changing dir, text on input element", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/dir-dynamic.html", "Dynamically changing dir, text on textarea element", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/dir-dynamic.html", "Dynamically changing dir, text on div element", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/dir-dynamic.html", "Dynamically changing dir, text on pre element", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/dir-html-input-dynamic-text.html", ":dir on <input> isn't altered by text children", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :checked
+    private static readonly WptExclusion[] _thePseudoClassesSuiteChecked =
+    [
+        // AngleSharp still models the historical &lt;menuitem&gt;, and its IsChecked() answers for one: the two
+        // checked menu items the document keeps precisely so that they do *not* match are the whole of the
+        // difference in all three rows. HTML §4.16.3's :checked is an input, an option and nothing else.
+        new("html/semantics/selectors/pseudo-classes/checked.html", "':checked' matches checked <input>s in checkbox and radio button states, selected <option>s", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/checked.html", "':checked' should no longer match <input>s whose type checkbox/radio has been removed", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/checked.html", "':checked' matches clicked checkbox and radio buttons", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :indeterminate
+    private static readonly WptExclusion[] _thePseudoClassesSuiteIndeterminate =
+    [
+        // HTML §4.16.3 gives :indeterminate three sources: a checkbox whose indeterminate IDL attribute is
+        // set, a radio button whose radio button group holds no checked member, and a progress element with no
+        // value. AngleSharp's IsIndeterminate() has the first and the third and not the second, so the four
+        // unchecked radios of the document's two groups match nothing.
+        new("html/semantics/selectors/pseudo-classes/indeterminate.html", "':progress' matches <input>s radio buttons whose radio button group contains no checked input and <progress> elements without value attribute", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/indeterminate.html", "dynamically check a radio input in a radio button group", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :in-range and :out-of-range
+    private static readonly WptExclusion[] _thePseudoClassesSuiteInRange =
+    [
+        // Two things at once. AngleSharp's IsInRange() answers true for *any* IValidation element that is
+        // neither overflowing nor underflowing, so every input without range limitations - text, checkbox,
+        // hidden, button - matches :in-range, where HTML §4.16.3 asks for an element that has range limitations
+        // to begin with. And a range control's value is not clamped to its limits, so range2 and range3 report an
+        // overflow and an underflow that the value sanitization algorithm (§4.10.5.4) says cannot arise.
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange.html", "':in-range' matches all elements that are candidates for constraint validation, have range limitations, and that are neither suffering from an underflow nor suffering from an overflow", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange.html", "':out-of-range' matches all elements that are candidates for constraint validation, have range limitations, and that are either suffering from an underflow or suffering from an overflow", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange.html", "':in-range' update number1's value < min", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange.html", "':out-of-range' update number1's value < min", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange.html", "':in-range' update number3's min < value", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange.html", "':out-of-range' update number3's min < value", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html", "':in-range' matches time inputs whose value is within a reversed range (>= min OR <= max)", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html", "':out-of-range' matches time inputs whose value is in the gap of a reversed range (> max AND < min)", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html", "Dynamic update from out-of-range to in-range in a reversed time range", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange-type-change.html", "Evaluation of :in-range changes for input type change.", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :read-only and :read-write
+    private static readonly WptExclusion[] _thePseudoClassesSuiteReadOnly =
+    [
+        // AngleSharp reads :read-write as "mutable", which for an input is only !disabled &amp;&amp; !readOnly -
+        // the readonly attribute's *applicability* is never consulted, so a checkbox is read-write where HTML
+        // §4.16.3 makes every control the attribute does not apply to read-only. The editing half is missing
+        // too: IsContentEditable answers false for a contenteditable element, so no editing host and nothing
+        // inside one is read-write; the last two rows want a form-associated custom element.
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must not match input elements to which the readonly attribute does not apply", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must match input elements to which the readonly attribute does not apply", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must match input elements to which the readonly attribute applies, and that are mutable", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must not match input elements to which the readonly attribute applies, and that are mutable", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must not match input elements after the readonly attribute has been added", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must match input elements after the readonly attribute has been added", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must not match input elements after the readonly attribute has been removed", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must match input elements after the readonly attribute has been removed", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must not match input elements after the disabled attribute has been added", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must match input elements after the disabled attribute has been added", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must match input elements after the disabled attribute has been removed", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must not match input elements after the disabled attribute has been removed", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must match elements that are editable", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must not match elements that are editable", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must match elements that are editing hosts", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must not match elements that are editing hosts", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-only pseudo-class must match form-associated custom elements", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly.html", "The :read-write pseudo-class must match form-associated contenteditable custom elements", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/readwrite-readonly-type-change.html", "Evaluation of :read-write and :read-only changes for input type change.", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :placeholder-shown
+    private static readonly WptExclusion[] _thePseudoClassesSuitePlaceholderShown =
+    [
+        // AngleSharp's IsPlaceholderShown() asks any input for a non-empty placeholder and an empty value, with
+        // no regard for whether the placeholder attribute applies to that type state - so a submit button with a
+        // placeholder matches - and it never answers for a textarea, which HTML §4.16.3 names beside the input.
+        new("html/semantics/selectors/pseudo-classes/placeholder-shown-type-change.html", "Evaluation of :placeholder-shown changes for input type change.", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :required and :optional
+    private static readonly WptExclusion[] _thePseudoClassesSuiteRequired =
+    [
+        // The required attribute does not apply to a hidden input (HTML §4.10.5.1.7), so such an input is
+        // neither :required nor :optional; AngleSharp reads the attribute wherever it is written.
+        new("html/semantics/selectors/pseudo-classes/required-optional-hidden.html", "Evaluation of :required and :optional changes for input type change.", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: :valid and :invalid
+    private static readonly WptExclusion[] _thePseudoClassesSuiteValid =
+    [
+        // AngleSharp's IsValid()/IsInvalid() are CheckValidity() and its negation, and CheckValidity() is
+        // WillValidate && Validity.IsValid - so an element §4.10.19.2 bars from constraint validation answers
+        // false and comes back :invalid, where HTML §4.16.3 has it match neither. A fieldset is barred and
+        // carries no constraints of its own, so every one of them is :valid whatever it contains, where the
+        // standard makes it :invalid when a descendant candidate fails; the same document's form rows pass,
+        // which is what says the fieldset half is the missing one. The other two documents want a constraint
+        // state kept across a removal and across a clone.
+        new("html/semantics/selectors/pseudo-classes/valid-invalid.html", "':valid' matches fieldset elements that have no descendant elements that themselves are candidates for constraint validation but do not satisfy their constraints", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/valid-invalid.html", "':invalid' matches fieldset elements that have of one or more descendant elements that themselves are candidates for constraint validation but do not satisfy their constraints", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/valid-invalid.html", "invalid fieldset correctly styled on page-load", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/valid-invalid.html", "programmatically adding invalid to empty fieldset results in correct style", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/valid-invalid.html", "programmatically-invalidated fieldset correctly styled", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html", "<input> element becomes invalid inside disconnected <fieldset>", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html", "<select> element becomes valid inside disconnected <fieldset>", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/invalid-after-clone.html", "Cloned invalid inputs / textareas with interactive changes get their validity state copied correctly", WptDivergence.NeedsTriage),
+    ];
+
+    // ---------------------------------------------------------------- the pseudo-classes suite: an opaque colour serialized as rgba()
+    private static readonly WptExclusion[] _thePseudoClassesSuiteOpaqueColour =
+    [
+        // Not a selector at all: these four rows read getComputedStyle(...).color and every one of them already
+        // gets the colour the selector should produce. CSSOM serializes an opaque colour as rgb(r, g, b) and
+        // AngleSharp.Css writes rgba(r, g, b, 1); Dom/divergences.md records why the process-global
+        // CssColorValue.UseSpecSerialization switch is not flipped on every AngleSharp consumer's behalf. The
+        // style rows that compare two computed values rather than a literal are unaffected and pass.
+        new("html/semantics/selectors/pseudo-classes/checked-type-change.html", "Evaluation of :checked changes on input type change.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/indeterminate-radio.html", ":indeterminate and input type=radio", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/indeterminate-type-change.html", "Evaluation of :indeterminate changes on input type change.", WptDivergence.NeedsTriage),
+        new("html/semantics/selectors/pseudo-classes/inrange-outofrange-type-change.html", "Evaluation of :out-of-range changes for input type change.", WptDivergence.NeedsTriage),
+    ];
+
     /// <summary>The causes this corpus found, each one the exclusions that are it.</summary>
     /// <remarks>
     /// A cause was a comment until it became a value a run could count. Its unique name is the hidden key
@@ -1430,6 +1633,17 @@ internal static class WptBrowserExclusions
         new("the Selectors-API table and selector-only element states", _theSelectorsAPITableAndSelectorOnlyElementStates),
         new("MutationObserver's records", _mutationObserverSRecords),
         new("one assertion each", _oneAssertionEach),
+        new("the pseudo-classes suite: :active", _thePseudoClassesSuiteActive),
+        new("the pseudo-classes suite: :focus", _thePseudoClassesSuiteFocus),
+        new("the pseudo-classes suite: :dir()", _thePseudoClassesSuiteDir),
+        new("the pseudo-classes suite: :checked", _thePseudoClassesSuiteChecked),
+        new("the pseudo-classes suite: :indeterminate", _thePseudoClassesSuiteIndeterminate),
+        new("the pseudo-classes suite: :in-range and :out-of-range", _thePseudoClassesSuiteInRange),
+        new("the pseudo-classes suite: :read-only and :read-write", _thePseudoClassesSuiteReadOnly),
+        new("the pseudo-classes suite: :placeholder-shown", _thePseudoClassesSuitePlaceholderShown),
+        new("the pseudo-classes suite: :required and :optional", _thePseudoClassesSuiteRequired),
+        new("the pseudo-classes suite: :valid and :invalid", _thePseudoClassesSuiteValid),
+        new("the pseudo-classes suite: an opaque colour serialized as rgba()", _thePseudoClassesSuiteOpaqueColour),
     ];
 
     /// <summary>

--- a/Jint.Tests.Browser/Wpt/WptBrowserTestRunner.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserTestRunner.cs
@@ -80,6 +80,9 @@ public class WptBrowserTestRunner
     [TestCaseSource(nameof(ImgElementCases))]
     public Task RunsTheImgElementSuite(string path) => RunCaseAsync(path);
 
+    [TestCaseSource(nameof(PseudoClassSelectorCases))]
+    public Task RunsThePseudoClassSelectorSuite(string path) => RunCaseAsync(path);
+
     [TestCaseSource(nameof(CustomElementsCases))]
     public Task RunsTheCustomElementsSuite(string path) => RunCaseAsync(path);
 
@@ -115,6 +118,8 @@ public class WptBrowserTestRunner
     public static IEnumerable<object[]> ScriptingProcessingModelCases() => Cases("html/webappapis/scripting/processing-model-2");
 
     public static IEnumerable<object[]> ImgElementCases() => Cases("html/semantics/embedded-content/the-img-element");
+
+    public static IEnumerable<object[]> PseudoClassSelectorCases() => Cases("html/semantics/selectors/pseudo-classes");
 
     public static IEnumerable<object[]> CustomElementsCases() => Cases("custom-elements");
 

--- a/Jint.Tests/Wpt/Vendor/README.md
+++ b/Jint.Tests/Wpt/Vendor/README.md
@@ -1621,7 +1621,7 @@ SHA=$(grep -oE '\b[0-9a-f]{40}\b' README.md | head -1)
 # every extension the corpus vendors, so a bump that brings a new one in is walked rather than skipped
 TYPES='-name *.asis -o -name *.headers -o -name *.htm -o -name *.html -o -name *.js -o -name *.json -o -name *.txt -o -name *.xhtml -o -name *.xml'
 
-# one call per directory that holds a vendored file (82 at this pin)
+# one call per directory that holds a vendored file (83 at this pin)
 for d in $(find . -type f \( $TYPES \) -printf '%h\n' | sort -u | sed 's|^\./||'); do
   gh api "repos/web-platform-tests/wpt/contents/$d?ref=$SHA" \
      --jq '.[] | select(.type=="file") | "\(.sha) \(.path)"'
@@ -1635,8 +1635,8 @@ find . -type f \( $TYPES \) | sort | while read -r f; do
 done
 ```
 
-Silence is a clean corpus, and at this pin there are 908 files in 82 directories to be silent
-about — 374 of them the documents the browser lane navigates to, the rest the scripts, payloads and
+Silence is a clean corpus, and at this pin there are 937 files in 83 directories to be silent
+about — 402 of them the documents the browser lane navigates to, the rest the scripts, payloads and
 sidecars every lane reads.
 
 <!-- end generated -->
@@ -1655,6 +1655,13 @@ were copied in the first place — `git show HEAD:<path>` out of such a clone �
 over the whole tree afterwards is the check, not the copy: 862 files, no drift, nothing absent upstream
 (the 863rd is `wpt-LICENSE.md`, whose blob id the paragraph above states).
 Use it when a clone is to hand and the recipe above when one is not; they compare the same bytes.
+
+**`html/semantics/selectors/pseudo-classes/` was compared the first way as it was vendored.** Its 29 files
+were read out of `repos/web-platform-tests/wpt/contents/html/semantics/selectors/pseudo-classes?ref=<pin>`
+and every blob id upstream reports matches `git hash-object` of what is here, which is the same comparison
+the loop above makes for one directory. The two generated figures moved with them, so by this file's own
+rule the whole-tree runs the two paragraphs above describe are runs of a smaller corpus — 937 files in 83
+directories is what a re-run would now have to be silent about.
 
 The figures above are what say which corpus that run was a run *of*: they were four vendored suites out of
 date when [#3647](https://github.com/sebastienros/jint/issues/3647) was filed, and the recipe was walking five

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/active-disabled.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/active-disabled.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/pull/7465">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<label id=buttonlabel for=disabledbutton>label for disabled button</label>
+<button id=disabledbutton disabled>disabled</button>
+
+<button id=buttonparent disabled>
+  <div id=buttonchild>child of disabled</div>
+</button>
+
+<input id=disabledinput disabled>
+
+<textarea id=disabledtextarea disabled>disabled textarea</textarea>
+
+<script>
+function testElement(description, clickElement, checkElement) {
+  promise_test(async () => {
+    if (!checkElement)
+      checkElement = clickElement;
+
+    await (new test_driver.Actions()
+      .pointerMove(2, 2, {origin: clickElement})
+      .pointerDown())
+      .send();
+
+    assert_true(checkElement.matches(':active'));
+
+    await (new test_driver.Actions()
+      .pointerUp())
+      .send();
+  }, description);
+}
+
+testElement('Clicking on a disabled button should make it match the :active selector.',
+    disabledbutton);
+
+testElement('Clicking the label for a disabled button should make the button match the :active selector.',
+    buttonlabel, disabledbutton);
+
+testElement('Clicking on a child of a disabled button should make the button match the :active selector.',
+    buttonchild, buttonparent);
+
+testElement('Clicking on a disabled input should make it match the :active selector.',
+    disabledinput);
+
+testElement('Clicking on a disabled textarea should make it match the :active selector.',
+    disabledtextarea);
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/checked-type-change.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/checked-type-change.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selector: pseudo-class :checked input type change</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#pseudo-classes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  span { color: red }
+  :checked + span { color: green }
+</style>
+<input id="checked" type="text" checked>
+<span id="sibling">This text should be green.</span>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(sibling).color, "rgb(255, 0, 0)",
+      "Not matching :checked for type=text");
+
+    checked.type = "radio";
+
+    assert_equals(getComputedStyle(sibling).color, "rgb(0, 128, 0)",
+      "Matching :checked for type=radio");
+  }, "Evaluation of :checked changes on input type change.");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/checked.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/checked.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:checked)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+<select id=select1>
+ <optgroup label="options" id=optgroup1>
+  <option value="option1" id=option1 selected>option1
+  <option value="option2" id=option2>option2
+  <option value="option2" id=option3 checked>option3
+</select>
+<input type=checkbox id=checkbox1 checked>
+<input type=checkbox id=checkbox2>
+<input type=checkbox id=checkbox3 selected>
+<input type=radio id=radio1 checked>
+<input type=radio id=radio2>
+<form>
+  <p><input type=submit contextmenu=formmenu id="submitbutton"></p>
+  <menu type=context id=formmenu>
+    <!-- historical; these should *not* match -->
+    <menuitem type=checkbox checked default id=menuitem1>
+    <menuitem type=checkbox default id=menuitem2>
+    <menuitem type=checkbox id=menuitem3>
+    <menuitem type=radio checked id=menuitem4>
+    <menuitem type=radio id=menuitem5>
+  </menu>
+</form>
+
+<script>
+  testSelectorIdsMatch(":checked", ["option1", "checkbox1", "radio1"], "':checked' matches checked <input>s in checkbox and radio button states, selected <option>s");
+
+  document.getElementById("checkbox1").removeAttribute("type");  // change type of input
+  document.getElementById("radio1").removeAttribute("type");  // change type of input
+  testSelectorIdsMatch(":checked", ["option1"], "':checked' should no longer match <input>s whose type checkbox/radio has been removed");
+
+  document.getElementById("option2").selected = "selected";  // select option2
+  document.getElementById("checkbox2").click();  // check chekbox2
+  document.getElementById("radio2").click();  // check radio2
+  testSelectorIdsMatch(":checked", ["option2", "checkbox2", "radio2"], "':checked' matches clicked checkbox and radio buttons");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/default.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/default.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:default)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+<form>
+  <button id=button1 type=button>button1</button>
+  <button id=button2 type=submit>button2</button>
+</form>
+<form>
+  <button id=button3 type=reset>button3</button>
+  <button id=button4>button4</button>
+</form>
+<button id=button5 type=submit>button5</button>
+<form id=form1>
+  <input type=text id=input1>
+</form>
+<input type=text id=input2 form=form1>
+<form>
+  <input type=submit id=input3>
+  <input type=submit id=input4>
+</form>
+<form>
+  <input type=image id=input5>
+  <input type=image id=input6>
+</form>
+<form>
+  <input type=submit id=input7>
+</form>
+<input type=checkbox id=checkbox1 checked>
+<input type=checkbox id=checkbox2>
+<input type=checkbox id=checkbox3 default>
+<input type=radio name=radios id=radio1 checked>
+<input type=radio name=radios id=radio2>
+<input type=radio name=radios id=radio3 default>
+<select id=select1>
+ <optgroup label="options" id=optgroup1>
+  <option value="option1" id=option1>option1
+  <option value="option2" id=option2 selected>option2
+</select>
+<dialog id="dialog">
+  <input type=submit id=input8>
+</dialog>
+<form>
+  <button id=button6 type='invalid'>button6</button>
+  <button id=button7>button7</button>
+</form>
+<form>
+  <button id=button8>button8</button>
+  <button id=button9>button9</button>
+</form>
+
+
+<script>
+  testSelectorIdsMatch(":default", ["button2", "button4", "input3", "input5", "input7", "checkbox1", "radio1", "option2", "button6", "button8"], "':default' matches <button>s that are their form's default button, <input>s of type submit/image that are their form's default button, checked <input>s and selected <option>s");
+
+  document.getElementById("button1").type = "submit"; // change the form's default button
+  testSelectorIdsMatch(":default", ["button1", "button4", "input3", "input5", "input7", "checkbox1", "radio1", "option2", "button6", "button8"], "':default' matches dynamically changed form's default buttons");
+
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/dir-dynamic.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/dir-dynamic.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <link rel="author" title="Vincent Hilla" href="mailto:vhilla@mozilla.com">
+  <link rel="help" href="https://html.spec.whatwg.org/#the-directionality">
+</head>
+<body>
+  <input id="inp"/>
+  <textarea id="ta"></textarea>
+  <div id="div"></div>
+  <pre id="pre"></pre>
+
+  <script>
+    function doTest(e) {
+      e.dir = "ltr";
+      assert_true(e.matches(":dir(ltr)"), "dir to ltr on " + e.tagName + " element");
+
+      e.dir = "rtl";
+      assert_true(e.matches(":dir(rtl)"), "dir to rtl on " + e.tagName + " element");
+
+      e.dir = "auto";
+      assert_true(e.matches(":dir(ltr)"), "dir to auto, empty text on " + e.tagName + " element");
+
+      e.value = "\u05D0;";
+      e.textContent = "\u05D0;";
+      assert_true(e.matches(":dir(rtl)"), "auto dir, text to Hebrew on " + e.tagName + " element");
+
+      e.dir = "ltr";
+      assert_true(e.matches(":dir(ltr)"), "dir to ltr, Hebrew text on " + e.tagName + " element");
+
+      e.dir = "auto";
+      assert_true(e.matches(":dir(rtl)"), "dir to auto, Hebrew text on " + e.tagName + " element");
+
+      e.removeAttribute("dir");
+      assert_true(e.matches(":dir(ltr)"), "dir removed, Hebrew text on " + e.tagName + " element");
+    }
+
+    const elements = [inp, ta, div, pre];
+    for (const e of elements) {
+      test(() => doTest(e), "Dynamically changing dir, text on " + e.tagName.toLowerCase() + " element");
+    }
+  </script>
+</body>
+</html>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/dir-html-input-dynamic-text.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/dir-html-input-dynamic-text.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1622900">
+<link rel="help" href="https://html.spec.whatwg.org/#the-directionality">
+<input value="ltr" dir="auto">
+<script>
+test(function() {
+  let input = document.querySelector("input");
+  assert_true(input.matches(":dir(ltr)"), "Input with ltr value should match dir(ltr)");
+  input.textContent = "ﷺ";
+  assert_true(input.matches(":dir(ltr)"), "Should still match dir(ltr) after text change");
+  input.value = "ltr2";
+  assert_true(input.matches(":dir(ltr)"), "Should still match dir(ltr) after value change");
+  input.value = "ﷺ";
+  assert_true(input.matches(":dir(rtl)"), "Should match dir(rtl) after value change");
+  input.textContent = "ltr";
+  assert_true(input.matches(":dir(rtl)"), "Should match dir(rtl) after text change");
+}, ":dir on <input> isn't altered by text children")
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/dir.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/dir.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html id=html>
+  <head id=head>
+    <meta charset=utf-8 id=meta>
+    <title id=title>Selector: pseudo-classes (:dir(ltr), :dir(rtl))</title>
+    <link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+    <link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+    <script src="/resources/testharness.js" id=script1></script>
+    <script src="/resources/testharnessreport.js" id=script2></script>
+    <script src="utils.js" id=script3></script>
+    <style id=style>
+      #span1 {direction: rtl;}
+      #span5, #span6 {display: none;}
+    </style>
+  </head>
+  <body id=body>
+    <div id="log"></div>
+    <bdo dir="rtl" id=bdo1>WERBEH</bdo>
+    <bdo dir="ltr" id=bdo2>HEBREW</bdo>
+    <bdi id=bdi1>HEBREW</bdi>
+    <bdi dir="rtl" id=bdi2>WERBEH</bdi>
+    <bdi dir="ltr" id=bdi3>HEBREW</bdi>
+    <bdi id=bdi4>إيان</bdi>
+    <span id=span1>WERBEH</span>
+    <span dir="rtl" id=span2>WERBEH</span>
+    <span dir="ltr" id=span3>HEBREW</span>
+    &#x202E;<span id=span4>WERBEH</span>&#x202C;
+    <span dir="rtl" id=span5>WERBEH</span>
+    <span dir="ltr" id=span6>HEBREW</span>
+    <span dir="rtl" id=span7>
+     <input type=tel id=input-tel1>
+     <input type=tel id=input-tel2 dir="invalid">
+    </span>
+    <input type=tel id=input-tel3 dir="rtl">
+    <bdo dir="auto" id=bdo3>HEBREW</bdo>
+    <bdo dir="auto" id=bdo4>إيان</bdo>
+    <bdo dir="ltr" id=bdo5>עברית</bdo>
+    <textarea dir="auto" id="ta1">إيان</textarea>
+    <textarea dir="auto" id="ta2">HEBREWإيان</textarea>
+    <textarea dir="auto" id="ta3">إيان</textarea>
+    <pre dir="auto" id="pre1">إيان</pre>
+    <pre dir="auto" id="pre2">HEBREWإيان</pre>
+
+    <script id=script4>
+      ta3.value = "HEBREW";
+
+      const rtlElements = [
+        "bdo1",
+        "bdi2",
+        "bdi4",
+        "span2",
+        "span5",
+        "span7",
+        "input-tel3",
+        "bdo4",
+        "ta1",
+        "pre1",
+      ];
+
+      testSelectorIdsMatch(":dir(rtl)", rtlElements, "':dir(rtl)' matches all elements whose directionality is 'rtl'.");
+
+      const ltrElements = [
+        "html",
+        "head",
+        "meta",
+        "title",
+        "link1",
+        "link2",
+        "script1",
+        "script2",
+        "script3",
+        "style",
+        "body",
+        "log",
+        "bdo2",
+        "bdi1",
+        "bdi3",
+        "span1",
+        "span3",
+        "span4",
+        "span6",
+        "input-tel1",
+        "input-tel2",
+        "bdo3",
+        "bdo5",
+        "ta2",
+        "ta3",
+        "pre2",
+        "script4",
+      ];
+
+      testSelectorIdsMatch(":dir(ltr)", ltrElements, "':dir(ltr)' matches all elements whose directionality is 'ltr'.");
+
+      const bdo = document.createElement("bdo");
+      bdo.setAttribute("dir", "ltr");
+      testSelectorIdsMatch(":dir(ltr)", ltrElements, "':dir(ltr)' doesn't match elements not in the document.");
+    </script>
+  </body>
+</html>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/dir01.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/dir01.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset=iso-8859-8 id=meta>
+<title id=title>Selector: pseudo-classes (:dir(ltr), :dir(rtl)) in iso-8859-8 documents</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js" id=script1></script>
+<script src="/resources/testharnessreport.js" id=script2></script>
+<script src="utils.js" id=script3></script>
+<div id="log"></div>
+<div>This text is left to right<div id=div1 style="direction:rtl">this is right to left</div></div>
+<div>This text is left to right<span id=div2 style="direction:rtl">this is left to right</span></div>
+
+<script>
+  var ltr = new Array(),
+      all = document.querySelectorAll('*');
+  for(var i = all.length; i--; ltr.unshift(all[i]));
+  testSelectorElementsMatch(":dir(ltr)", ltr, "direction doesn't affect :dir()");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/disabled.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/disabled.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:disabled)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<style>
+  #input4 {display:none;}
+</style>
+<div id="log"></div>
+<button id=button1 type=submit>button1</button>
+<button id=button2 disabled>button2</button>
+<input id=input1>
+<input id=input2 disabled>
+<input id=input3 readonly>
+<input id=input4>
+<select id=select1>
+ <optgroup label="options" id=optgroup1>
+  <option value="option1" id=option1 selected>option1
+</select>
+<select disabled id=select2>
+ <optgroup label="options" disabled id=optgroup2>
+  <option value="option2" disabled id=option2>option2
+</select>
+<textarea id=textarea1>textarea1</textarea>
+<textarea disabled id=textarea2>textarea2</textarea>
+<fieldset id=fieldset1></fieldset>
+<fieldset disabled id=fieldset2>
+  <legend><input type=checkbox id=club></legend>
+  <p><label>Name on card: <input id=clubname required></label></p>
+  <p><label>Card number: <input id=clubnum required pattern="[-0-9]+"></label></p>
+</fieldset>
+<label disabled></label>
+<object disabled></object>
+<output disabled></output>
+<img disabled/>
+<meter disabled></meter>
+<progress disabled></progress>
+
+<script>
+  testSelectorIdsMatch(":disabled", ["button2", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should match only disabled elements");
+
+  document.getElementById("button2").removeAttribute("disabled");
+  testSelectorIdsMatch(":disabled", ["input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should not match elements whose disabled attribute has been removed");
+
+  document.getElementById("button1").setAttribute("disabled", "disabled");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set");
+
+  document.getElementById("button1").setAttribute("disabled", "disabled");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set twice");
+
+  document.getElementById("input2").setAttribute("type", "submit"); // change input type to submit
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match disabled elements whose type has changed");
+
+  var input = document.createElement("input");
+  input.setAttribute("disabled", "disabled");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should not match elements not in the document");
+
+  var fieldset = document.createElement("fieldset");
+  fieldset.id = "fieldset_nested";
+  fieldset.innerHTML = `
+    <input id=input_nested>
+    <button id=button_nested>button nested</button>
+    <select id=select_nested>
+      <optgroup label="options" id=optgroup_nested>
+        <option value="options" id=option_nested>option nested</option>
+      </optgroup>
+    </select>
+    <textarea id=textarea_nested>textarea nested</textarea>
+    <object id=object_nested></object>
+    <output id=output_nested></output>
+    <fieldset id=fieldset_nested2>
+      <input id=input_nested2>
+    </fieldset>
+  `;
+  document.getElementById("fieldset2").appendChild(fieldset);
+  testSelectorIdsMatch("#fieldset2 :disabled", ["clubname", "clubnum", "fieldset_nested", "input_nested", "button_nested", "select_nested", "optgroup_nested", "option_nested", "textarea_nested", "fieldset_nested2", "input_nested2"], "':disabled' should match elements that are appended to a disabled fieldset dynamically");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/enabled.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/enabled.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:enabled)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+<a id=link3></a>
+<area id=link4></area>
+<link id=link5></link>
+<a href="http://www.w3.org" id=link6></a>
+<area href="http://www.w3.org" id=link7></area>
+<link href="http://www.w3.org" id=link8></link>
+<button id=button1>button1</button>
+<button id=button2 disabled>button2</button>
+<input id=input1>
+<input id=input2 disabled>
+<select id=select1>
+ <optgroup label="options" id=optgroup1>
+  <option value="option1" id=option1 selected>option1
+</select>
+<select disabled id=select2>
+ <optgroup label="options" disabled id=optgroup2>
+  <option value="option2" disabled id=option2>option2
+</select>
+<textarea id=textarea1>textarea1</textarea>
+<textarea disabled id=textarea2>textarea2</textarea>
+<form>
+ <p><input type=submit contextmenu=formmenu id=submitbutton></p>
+ <menu type=context id=formmenu>
+  <!-- historical; these should *not* match -->
+  <menuitem command="submitbutton" default id=menuitem1>
+  <menuitem command="resetbutton" disabled id=menuitem2>
+ </menu>
+</form>
+<fieldset id=fieldset1></fieldset>
+<fieldset disabled id=fieldset2></fieldset>
+
+<script>
+  testSelectorIdsMatch(":enabled", ["button1", "input1", "select1", "optgroup1", "option1", "textarea1", "submitbutton", "fieldset1"], "':enabled' elements that are not disabled");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/focus-autofocus.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/focus-autofocus.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:focus for autofocus)</title>
+<link rel="author" title="Kent Tamura" href="mailto:tkent@chromium.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes">
+<link rel=help href="https://html.spec.whatwg.org/multipage/forms.html#autofocusing-a-form-control:-the-autofocus-attribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// This test can't be merged to focus.html because element.focus() may affect
+// autofocus behavior.
+var autofocusTest = async_test(":focus selector should work with an autofocused element.");
+var input = document.createElement("input");
+input.autofocus = true;
+input.addEventListener("focus", function() {
+  autofocusTest.step(function() {
+    assert_array_equals(document.querySelectorAll(":focus"), [input])
+    autofocusTest.done();
+  });
+}, false);
+document.body.appendChild(input);
+</script>
+</body>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/focus-iframe.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/focus-iframe.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:focus)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
+<input id="inputiframe" type=text value="foobar" />

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/focus.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/focus.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:focus)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<body id=body tabindex=0>
+  <div id="log"></div>
+  <button id=button1 type=submit>button1</button>
+  <input id=input1>
+  <input id=input2 disabled>
+  <textarea id=textarea1>textarea1</textarea>
+  <input type=checkbox id=checkbox1 checked>
+  <input type=radio id=radio1 checked>
+  <div tabindex=0 id=div1>hello</div>
+  <div contenteditable id=div2>content</div>
+  <iframe src="focus-iframe.html" id=iframe></iframe>
+
+  <script>
+    setup({explicit_done: true});
+
+    onload = function() {
+      if (document.hasFocus() || frames[0].document.hasFocus()) {
+        run_test()
+      } else {
+        window.onfocus = run_test;
+      }
+    }
+
+    function run_test() {
+      document.getElementById("input1").focus(); // set the focus on input1
+      testSelectorIdsMatch(":focus", ["input1"], "input1 has the focus");
+
+      document.getElementById("div1").focus();
+      testSelectorIdsMatch(":focus", ["div1"], "tabindex attribute makes the element focusable");
+
+      document.getElementById("div2").focus();
+      testSelectorIdsMatch(":focus", ["div2"], "editable elements are focusable");
+
+      document.body.focus();
+      testSelectorIdsMatch(":focus", ["body"], "':focus' matches focussed body with tabindex");
+
+      document.getElementById("iframe").contentDocument.getElementById("inputiframe").focus();
+      testSelectorIdsMatch(":focus", [], "':focus' doesn't match focused elements in iframe");
+
+      done();
+    }
+  </script>
+</body>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/indeterminate-radio.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/indeterminate-radio.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>:indeterminate and input type=radio</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style type="text/css">
+#test {
+  color: green;
+}
+input:indeterminate + #test {
+  color: red;
+}
+</style>
+<input type="radio" name="radios">
+<div id="test"></div>
+<input type="radio" name="radios" checked>
+<script type="text/javascript">
+test(function() {
+  document.getElementsByTagName("input")[0].indeterminate = true;
+  var target = document.getElementById("test");
+  var val = getComputedStyle(target, null).getPropertyValue("color");
+  assert_equals(val, "rgb(0, 128, 0)",
+                "The indeterminate IDL attribute should not cause the " +
+                ":indeterminate pseudo-class to match on input type=radio");
+})
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/indeterminate-type-change.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/indeterminate-type-change.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selector: pseudo-class :indeterminate input type change</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#pseudo-classes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  span { color: red }
+  :indeterminate + span { color: green }
+</style>
+<input id="indeterminate" type="text">
+<span id="sibling">This text should be green.</span>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(sibling).color, "rgb(255, 0, 0)",
+      "Not matching :indeterminate for type=text");
+
+    indeterminate.type = "radio";
+
+    assert_equals(getComputedStyle(sibling).color, "rgb(0, 128, 0)",
+      "Matching :indeterminate for type=radio");
+  }, "Evaluation of :indeterminate changes on input type change.");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/indeterminate.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/indeterminate.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:indeterminate)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+<input type=checkbox id=checkbox1>
+<input type=checkbox id=checkbox2>
+<input type=radio id=radio1 checked>
+<input type=radio name=radiogroup id=radio2>
+<input type=radio name=radiogroup id=radio3>
+<input type=radio name=group2 id=radio4>
+<input type=radio name=group2 id=radio5>
+<progress id="progress1"></progress>
+<progress id="progress2" value=10></progress>
+
+<script>
+  testSelectorIdsMatch(":indeterminate", ["radio2", "radio3", "radio4", "radio5", "progress1"], "':progress' matches <input>s radio buttons whose radio button group contains no checked input and <progress> elements without value attribute");
+
+  document.getElementById("radio2").setAttribute("checked", "checked");
+  testSelectorIdsMatch(":indeterminate", ["radio4", "radio5", "progress1"], "dynamically check a radio input in a radio button group");
+
+  document.getElementById("radio4").click();
+  testSelectorIdsMatch(":indeterminate", ["progress1"], "click on radio4 which is in the indeterminate state");
+
+  document.getElementById("progress1").setAttribute("value", "20");
+  testSelectorIdsMatch(":indeterminate", [], "adding a value to progress1 should put it in a determinate state");
+
+  document.getElementById("progress2").removeAttribute("value");
+  testSelectorIdsMatch(":indeterminate", ["progress2"], "removing progress2's value should put it in an indeterminate state");
+
+  document.getElementById("checkbox1").indeterminate = true; // set checkbox1 in the indeterminate state
+  testSelectorIdsMatch(":indeterminate", ["checkbox1", "progress2"], "':progress' also matches <input> checkbox whose indeterminate IDL is set to true");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/inrange-outofrange-time-reversed.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:in-range, :out-of-range) with reversed time ranges</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#selector-in-range">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#selector-out-of-range">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/input.html#has-a-reversed-range">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+
+<!-- Reversed range: min="21:00" max="03:00" wraps around midnight.
+     Valid values: >= 21:00:00 OR <= 03:00:00
+     Out-of-range values: > 03:00:00 AND < 21:00:00 (the gap) -->
+
+<!-- In range: value is after min, before midnight -->
+<input type="time" min="21:00:00" max="03:00:00" value="22:00:00" id="time-after-min">
+<!-- In range: value is after midnight, before max -->
+<input type="time" min="21:00:00" max="03:00:00" value="02:00:00" id="time-before-max">
+<!-- In range: value is exactly at min -->
+<input type="time" min="21:00:00" max="03:00:00" value="21:00:00" id="time-at-min">
+<!-- In range: value is exactly at max -->
+<input type="time" min="21:00:00" max="03:00:00" value="03:00:00" id="time-at-max">
+<!-- Out of range: value is in the gap -->
+<input type="time" min="21:00:00" max="03:00:00" value="12:00:00" id="time-in-gap">
+<!-- Out of range: value is just past max -->
+<input type="time" min="21:00:00" max="03:00:00" value="04:00:00" id="time-past-max">
+<!-- Out of range: value is just before min -->
+<input type="time" min="21:00:00" max="03:00:00" value="20:00:00" id="time-before-min">
+
+<script>
+  testSelectorIdsMatch(":in-range",
+    ["time-after-min", "time-before-max", "time-at-min", "time-at-max"],
+    "':in-range' matches time inputs whose value is within a reversed range (>= min OR <= max)");
+
+  testSelectorIdsMatch(":out-of-range",
+    ["time-in-gap", "time-past-max", "time-before-min"],
+    "':out-of-range' matches time inputs whose value is in the gap of a reversed range (> max AND < min)");
+
+  // Dynamic update: move an in-range value into the gap.
+  document.getElementById("time-after-min").value = "12:00:00";
+  test(function() {
+    assert_false(document.getElementById("time-after-min").matches(":in-range"));
+    assert_true(document.getElementById("time-after-min").matches(":out-of-range"));
+  }, "Dynamic update from in-range to out-of-range in a reversed time range");
+
+  // Dynamic update: move an out-of-range value into the valid range.
+  document.getElementById("time-in-gap").value = "23:00:00";
+  test(function() {
+    assert_true(document.getElementById("time-in-gap").matches(":in-range"));
+    assert_false(document.getElementById("time-in-gap").matches(":out-of-range"));
+  }, "Dynamic update from out-of-range to in-range in a reversed time range");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/inrange-outofrange-type-change.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/inrange-outofrange-type-change.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selector: pseudo-classes (:in-range, :out-of-range) input type change</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#pseudo-classes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  span {
+    color: red;
+  }
+  #t1:in-range + span {
+    color: green;
+  }
+  #t2:out-of-range + span {
+    color: green;
+  }
+</style>
+<input id="t1" type="text" min="0" max="10" value="5">
+<span id="sibling1">This text should be green.</span>
+<input id="t2" type="text" min="0" max="10" value="50">
+<span id="sibling2">This text should be green.</span>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(sibling1).color, "rgb(255, 0, 0)",
+      "Not matching :in-range for type=text");
+
+    t1.type = "number";
+
+    assert_equals(getComputedStyle(sibling1).color, "rgb(0, 128, 0)",
+      "Matching :in-range for type=number");
+  }, "Evaluation of :in-range changes for input type change.");
+
+  test(() => {
+    assert_equals(getComputedStyle(sibling2).color, "rgb(255, 0, 0)",
+      "Not matching :out-of-range for type=text");
+
+    t2.type = "number";
+
+    assert_equals(getComputedStyle(sibling2).color, "rgb(0, 128, 0)",
+      "Matching :in-range for type=number");
+  }, "Evaluation of :out-of-range changes for input type change.");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/inrange-outofrange.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/inrange-outofrange.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:in-range, :out-of-range)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id="link1">
+<link rel="author" title="Chris Rebert" href="http://chrisrebert.com" id="link2">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#selector-in-range" id="link3">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#selector-out-of-range" id="link4">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+<input type=number value=0 min=0 max=10 id=number1>
+<input type=number value=0 min=0 max=10 id=number2 disabled>
+<input type=number value=0 min=1 max=10 id=number3>
+<input type=number value=11 min=0 max=10 id=number4>
+<input type=number value=0 min=0 max=10 id=number5 readonly>
+
+<input type="date" min="2005-10-10" max="2020-10-10" value="2010-10-10" id="datein">
+<input type="date" min="2010-10-10" max="2020-10-10" value="2005-10-10" id="dateunder">
+<input type="date" min="2010-10-10" max="2020-10-10" value="2030-10-10" id="dateover">
+
+<input type="time" min="01:00:00" max="05:00:00" value="02:00:00" id="timein">
+<input type="time" min="02:00:00" max="05:00:00" value="01:00:00" id="timeunder">
+<input type="time" min="02:00:00" max="05:00:00" value="07:00:00" id="timeover">
+
+<input type="week" min="2016-W05" max="2016-W10" value="2016-W07" id="weekin">
+<input type="week" min="2016-W05" max="2016-W10" value="2016-W02" id="weekunder">
+<input type="week" min="2016-W05" max="2016-W10" value="2016-W26" id="weekover">
+
+<input type="month" min="2000-04" max="2000-09" value="2000-06" id="monthin">
+<input type="month" min="2000-04" max="2000-09" value="2000-02" id="monthunder">
+<input type="month" min="2000-04" max="2000-09" value="2000-11" id="monthover">
+
+<input type="datetime-local" min="2008-03-12T23:59:59" max="2015-02-13T23:59:59" value="2012-11-28T23:59:59" id="datetimelocalin">
+<input type="datetime-local" min="2008-03-12T23:59:59" max="2015-02-13T23:59:59" value="2008-03-01T23:59:59" id="datetimelocalunder">
+<input type="datetime-local" min="2008-03-12T23:59:59" max="2015-02-13T23:59:59" value="2016-01-01T23:59:59" id="datetimelocalover">
+
+<!-- None of the following have range limitations since they have neither min nor max attributes -->
+<input type="number" value="0" id="numbernolimit">
+<input type="date" value="2010-10-10" id="datenolimit">
+<input type="time" value="02:00:00" id="timenolimit">
+<input type="week" value="2016-W07" id="weeknolimit">
+<input type="month" value="2000-06" id="monthnolimit">
+<input type="datetime-local" value="2012-11-28T23:59:59" id="datetimelocalnolimit">
+
+<!-- range inputs have default minimum of 0 and default maximum of 100 -->
+<input type="range" value="50" id="range0">
+
+<!-- range input's value gets immediately clamped to the nearest boundary point -->
+<input type="range" min="2" max="7" value="5" id="range1">
+<input type="range" min="2" max="7" value="1" id="range2">
+<input type="range" min="2" max="7" value="9" id="range3">
+
+<!-- None of the following input types can have range limitations -->
+<input min="1" value="0" type="text">
+<input min="1" value="0" type="search">
+<input min="1" value="0" type="url">
+<input min="1" value="0" type="tel">
+<input min="1" value="0" type="email">
+<input min="1" value="0" type="password">
+<input min="1" value="#000000" type="color">
+<input min="1" value="0" type="checkbox">
+<input min="1" value="0" type="radio">
+<input min="1" value="0" type="file">
+<input min="1" value="0" type="submit">
+<input min="1" value="0" type="image">
+<!-- The following types are also barred from constraint validation -->
+<input min="1" value="0" type="hidden">
+<input min="1" value="0" type="button">
+<input min="1" value="0" type="reset">
+
+<script>
+  testSelectorIdsMatch(":in-range", ["number1", "datein", "timein", "weekin", "monthin", "datetimelocalin", "range0", "range1", "range2", "range3"], "':in-range' matches all elements that are candidates for constraint validation, have range limitations, and that are neither suffering from an underflow nor suffering from an overflow");
+
+  testSelectorIdsMatch(":out-of-range", ["number3", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' matches all elements that are candidates for constraint validation, have range limitations, and that are either suffering from an underflow or suffering from an overflow");
+
+  document.getElementById("number1").value = -10;
+  testSelectorIdsMatch(":in-range", ["datein", "timein", "weekin", "monthin", "datetimelocalin", "range0", "range1", "range2", "range3"], "':in-range' update number1's value < min");
+  testSelectorIdsMatch(":out-of-range", ["number1", "number3", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' update number1's value < min");
+
+  document.getElementById("number3").min = 0;
+  testSelectorIdsMatch(":in-range", ["number3", "datein", "timein", "weekin", "monthin", "datetimelocalin", "range0", "range1", "range2", "range3"], "':in-range' update number3's min < value");
+  testSelectorIdsMatch(":out-of-range", ["number1", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' update number3's min < value");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/invalid-after-clone.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/invalid-after-clone.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<input>
+<textarea></textarea>
+<script>
+promise_test(async () => {
+  for (let tag of ["input", "textarea"]) {
+    let element = document.querySelector(tag);
+    await test_driver.send_keys(element, 'something');
+
+    assert_true(element.validity.valid, tag + ' should be valid');
+
+    element.maxLength = 0;
+    assert_true(element.matches(":invalid"), tag + ' should match :invalid');
+    assert_false(element.validity.valid, tag + ' should be invalid');
+
+    let clone = element.cloneNode(true);
+    assert_true(clone.matches(":invalid"), tag + ' clone should match :invalid');
+    assert_false(clone.validity.valid, tag + 'clone should be invalid');
+  }
+}, 'Cloned invalid inputs / textareas with interactive changes get their validity state copied correctly');
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/link.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/link.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:link)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<link rel=stylesheet href="non-existent.css" id=link3>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+<a id=link4></a>
+<area id=link5></area>
+<link id=link6></link>
+<a href="http://www.w3.org" id=link7></a>
+<area href="http://www.w3.org" id=link8></area>
+<link href="http://www.w3.org" id=link9></link>
+<a href="http://[" id=link10></a>
+
+<script>
+  testSelectorIdsMatch(":link", ["link7", "link8", "link10"], "Only <a>s and <area>s that have a href attribute match ':link'");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/placeholder-shown-type-change.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/placeholder-shown-type-change.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selector: pseudo-class :placeholder-shown input type change</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#pseudo-classes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  span {
+    color: red;
+  }
+  :placeholder-shown + span {
+    color: green;
+  }
+</style>
+<input id="input" type="submit" placeholder="placeholder"></input>
+<span id="sibling">This text should be green.</span>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(sibling).color, "rgb(255, 0, 0)",
+      "Not matching :placeholder-shown for type=submit");
+
+    input.type = "text";
+    assert_equals(getComputedStyle(sibling).color, "rgb(0, 128, 0)",
+      "Matching :placeholder-shown for type=text");
+  }, "Evaluation of :placeholder-shown changes for input type change.");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/readwrite-readonly-type-change.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/readwrite-readonly-type-change.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selector: pseudo-classes (:read-write, :read-only) input type change</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#pseudo-classes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  span {
+    color: red;
+    background-color: pink;
+  }
+  :read-write + span {
+    color: green;
+  }
+  :not(:read-only) + span {
+    background-color: lime;
+  }
+</style>
+<input id="hiddenInput" type="hidden" required>
+<span id="sibling">This text should be green on lime background.</span>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(sibling).color, "rgb(255, 0, 0)",
+      "Not matching :read-write for type=hidden");
+    assert_equals(getComputedStyle(sibling).backgroundColor, "rgb(255, 192, 203)",
+      "Matching :read-only for type=hidden");
+
+    hiddenInput.type = "text";
+
+    assert_equals(getComputedStyle(sibling).color, "rgb(0, 128, 0)",
+      "Matching :read-write for type=text");
+    assert_equals(getComputedStyle(sibling).backgroundColor, "rgb(0, 255, 0)",
+      "Matching :not(:read-only) for type=text");
+  }, "Evaluation of :read-write and :read-only changes for input type change.");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:read-write, :read-only)</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<script>
+  class CustomElement extends HTMLElement {
+    static formAssociated = true;
+
+    constructor() {
+      super();
+    }
+  }
+
+  window.customElements.define("custom-element", CustomElement);
+</script>
+<div id="log"></div>
+
+<div id=set0>
+<!-- The readonly attribute does not apply to the following input types -->
+<input id=checkbox1 type=checkbox>
+<input id=hidden1 type=hidden value=abc>
+<input id=range1 type=range>
+<input id=color1 type=color>
+<input id=radio1 type=radio>
+<input id=file1 type=file>
+<input id=submit1 type=submit>
+<input id=image1 type=image>
+<input id=button1 type=button value="Button">
+<input id=reset1 type=reset>
+</div>
+
+<div id=set1>
+<input id=input1>
+<input id=input2 readonly>
+<input id=input3 disabled>
+<input id=input4 type=checkbox>
+<input id=input5 type=checkbox readonly>
+</div>
+
+<div id=set2>
+<textarea id=textarea1>textarea1</textarea>
+<textarea readonly id=textarea2>textarea2</textarea>
+</div>
+
+<div id=set3>
+<textarea id=textarea3>textarea3</textarea>
+<textarea disabled id=textarea4>textarea4</textarea>
+</div>
+
+<div id=set4>
+<p id=p1>paragraph1.</p>
+<p id=p2 contenteditable>paragraph2.</p>
+</div>
+
+<div id=set5>
+  <div id=cd1 contenteditable>
+    <p id=p3></p>
+    <input id=ci1 readonly>
+    <input id=ci2 disabled>
+    <input id=ci3>
+    <input id=ci4>
+    <textarea id=ct1 readonly></textarea>
+    <textarea id=ct2 disabled></textarea>
+    <textarea id=ct3></textarea>
+    <textarea id=ct4></textarea>
+  </div>
+</div>
+
+<div id=set6>
+  <custom-element id=ce1>content</custom-element>
+  <custom-element id=ce2 contenteditable>content</custom-element>
+  <custom-element id=ce3 contenteditable readonly>content</custom-element>
+  <custom-element id=ce4 contenteditable disabled>content</custom-element>
+  <custom-element id=ce5 contenteditable readonly disabled>content</custom-element>
+</div>
+
+<script>
+  testSelectorIdsMatch("#set0 :read-write", [], "The :read-write pseudo-class must not match input elements to which the readonly attribute does not apply");
+
+  testSelectorIdsMatch("#set0 :read-only", ["checkbox1", "hidden1", "range1", "color1", "radio1", "file1", "submit1", "image1", "button1", "reset1"], "The :read-only pseudo-class must match input elements to which the readonly attribute does not apply");
+
+  testSelectorIdsMatch("#set1 :read-write", ["input1"], "The :read-write pseudo-class must match input elements to which the readonly attribute applies, and that are mutable");
+
+  testSelectorIdsMatch("#set1 :read-only", ["input2", "input3", "input4", "input5"], "The :read-only pseudo-class must not match input elements to which the readonly attribute applies, and that are mutable");
+
+  document.getElementById("input1").setAttribute("readonly", "readonly");
+  testSelectorIdsMatch("#set1 :read-write", [], "The :read-write pseudo-class must not match input elements after the readonly attribute has been added");
+
+  testSelectorIdsMatch("#set1 :read-only", ["input1", "input2", "input3", "input4", "input5"], "The :read-only pseudo-class must match input elements after the readonly attribute has been added");
+
+  document.getElementById("input1").removeAttribute("readonly");
+  testSelectorIdsMatch("#set1 :read-write", ["input1"], "The :read-write pseudo-class must not match input elements after the readonly attribute has been removed");
+
+  testSelectorIdsMatch("#set1 :read-only", ["input2", "input3", "input4", "input5"], "The :read-only pseudo-class must match input elements after the readonly attribute has been removed");
+
+  document.getElementById("input1").disabled = true;
+  testSelectorIdsMatch("#set1 :read-write", [], "The :read-write pseudo-class must not match input elements after the disabled attribute has been added");
+
+  testSelectorIdsMatch("#set1 :read-only", ["input1", "input2", "input3", "input4", "input5"], "The :read-only pseudo-class must match input elements after the disabled attribute has been added");
+
+  document.getElementById("input1").disabled = false;
+
+  testSelectorIdsMatch("#set1 :read-write", ["input1"], "The :read-write pseudo-class must match input elements after the disabled attribute has been removed");
+
+  testSelectorIdsMatch("#set1 :read-only", ["input2", "input3", "input4", "input5"], "The :read-only pseudo-class must not match input elements after the disabled attribute has been removed");
+
+  testSelectorIdsMatch("#set2 :read-write", ["textarea1"], "The :read-write pseudo-class must match textarea elements that do not have a readonly attribute, and that are not disabled");
+
+  testSelectorIdsMatch("#set2 :read-only", ["textarea2"], "The :read-only pseudo-class must match textarea elements that have a readonly attribute, or that are disabled");
+
+  document.getElementById("textarea1").setAttribute("readonly", "readonly");
+  testSelectorIdsMatch("#set2 :read-write", [], "The :read-write pseudo-class must match textarea elements after the readonly attribute has been added");
+
+  testSelectorIdsMatch("#set2 :read-only", ["textarea1", "textarea2"], "The :read-only pseudo-class must match textarea elements after the readonly attribute has been added");
+
+  testSelectorIdsMatch("#set3 :read-write", ["textarea3"], "The :read-write pseudo-class must not match textarea elements that are disabled");
+
+  testSelectorIdsMatch("#set3 :read-only", ["textarea4"], "The :read-only pseudo-class must match textarea elements that are disabled");
+
+  testSelectorIdsMatch("#set4 :read-write", ["p2"], "The :read-write pseudo-class must match elements that are editable");
+
+  testSelectorIdsMatch("#set4 :read-only", ["p1"], "The :read-only pseudo-class must not match elements that are editable");
+
+  document.designMode = "on";
+
+  testSelectorIdsMatch("#set4 :read-write", ["p1", "p2"], "The :read-write pseudo-class must match elements that are editing hosts");
+
+  testSelectorIdsMatch("#set4 :read-only", [], "The :read-only pseudo-class must not match elements that are editing hosts");
+
+  document.designMode = "off";
+
+  testSelectorIdsMatch("#set5 :read-write", ["cd1", "p3", "ci3", "ci4", "ct3", "ct4"], "The :read-write pseudo-class must match elements that are inside editing hosts, but not match inputs and textareas inside that aren't");
+
+  testSelectorIdsMatch("#set6 :read-only", ["ce1"], "The :read-only pseudo-class must match form-associated custom elements");
+
+  testSelectorIdsMatch("#set6 :read-write", ["ce2", "ce3", "ce4", "ce5"], "The :read-write pseudo-class must match form-associated contenteditable custom elements");
+
+
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/required-optional-hidden.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/required-optional-hidden.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selector: pseudo-classes (:required, :optional) for hidden input</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:rune@opera.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#pseudo-classes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  span {
+    color: red;
+    background-color: pink;
+  }
+  :required + span {
+    color: green;
+  }
+  :not(:optional) + span {
+    background-color: lime;
+  }
+</style>
+<input id="hiddenInput" type="hidden" required>
+<span id="sibling">This text should be green on lime background.</span>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(sibling).color, "rgb(255, 0, 0)",
+      "Not matching :required for type=hidden");
+    assert_equals(getComputedStyle(sibling).backgroundColor, "rgb(255, 192, 203)",
+      "Matching :optional for type=hidden");
+
+    hiddenInput.type = "text";
+
+    assert_equals(getComputedStyle(sibling).color, "rgb(0, 128, 0)",
+      "Matching :required for type=text");
+    assert_equals(getComputedStyle(sibling).backgroundColor, "rgb(0, 255, 0)",
+      "Matching :not(:optional) for type=text");
+  }, "Evaluation of :required and :optional changes for input type change.");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/required-optional.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/required-optional.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:required, :optional)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<div id="log"></div>
+<input type=text id=text1 value="foobar" required>
+<input type=text id=text2 required>
+<input type=text id=text3>
+<select id=select1 required>
+ <optgroup label="options" id=optgroup1>
+   <option value="option1" id=option1>option1
+</select>
+<select id=select2>
+ <optgroup label="options" id=optgroup2>
+   <option value="option2" id=option2>option2
+</select>
+<textarea required id=textarea1>textarea1</textarea>
+<textarea id=textarea2>textarea2</textarea>
+
+<script>
+  testSelectorIdsMatch(":required", ["text1", "text2", "select1", "textarea1"], "':required' matches required <input>s, <select>s and <textarea>s");
+  testSelectorIdsMatch(":optional", ["text3", "select2", "textarea2"], "':optional' matches elements <input>s, <select>s and <textarea>s that are not required");
+
+  document.getElementById("text1").removeAttribute("required");
+  testSelectorIdsMatch(":required", ["text2", "select1", "textarea1"], "':required' doesn't match elements whose required attribute has been removed");
+  testSelectorIdsMatch(":optional", ["text1", "text3", "select2", "textarea2"], "':optional' matches elements whose required attribute has been removed");
+
+  document.getElementById("select2").setAttribute("required", "required");
+  testSelectorIdsMatch(":required", ["text2", "select1", "select2", "textarea1"], "':required' matches elements whose required attribute has been added");
+  testSelectorIdsMatch(":optional", ["text1", "text3", "textarea2"], "':optional' doesn't match elements whose required attribute has been added");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/utils.js
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/utils.js
@@ -1,0 +1,20 @@
+function getElementsByIds(ids) {
+  var result = [];
+  ids.forEach(function(id) {
+    result.push(document.getElementById(id));
+  });
+  return result;
+}
+
+function testSelectorIdsMatch(selector, ids, testName) {
+  test(function(){
+    var elements = document.querySelectorAll(selector);
+    assert_array_equals([...elements], getElementsByIds(ids));
+  }, testName);
+}
+
+function testSelectorElementsMatch(selector, elements, testName) {
+  test(function(){
+    assert_array_equals([...document.querySelectorAll(selector)], elements);
+  }, testName);
+}

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/valid-invalid-fieldset-disconnected.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:valid, :invalid) on disconnected fieldset element</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-valid">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<fieldset id=fieldset1>
+  <input id=input1>
+</fieldset>
+
+<fieldset id=fieldset2>
+  <select id=select1 required multiple>
+    <option>foo
+  </select>
+</fieldset>
+
+<script>
+test(() => {
+  const fieldset = document.querySelector("#fieldset1");
+  const input = document.querySelector("#input1");
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+
+  fieldset.remove();
+  input.setCustomValidity("foo");
+
+  assert_false(fieldset.matches(":valid"));
+  assert_true(fieldset.matches(":invalid"));
+
+  input.setCustomValidity("");
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+}, "<input> element becomes invalid inside disconnected <fieldset>");
+
+test(() => {
+  const fieldset = document.querySelector("#fieldset2");
+  const select = document.querySelector("#select1");
+
+  assert_false(fieldset.matches(":valid"));
+  assert_true(fieldset.matches(":invalid"));
+
+  fieldset.remove();
+  select.required = false;
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+
+  select.required = true;
+  select.firstElementChild.selected = true;
+
+  assert_true(fieldset.matches(":valid"));
+  assert_false(fieldset.matches(":invalid"));
+}, "<select> element becomes valid inside disconnected <fieldset>");
+</script>

--- a/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/valid-invalid.html
+++ b/Jint.Tests/Wpt/Vendor/html/semantics/selectors/pseudo-classes/valid-invalid.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:valid, :invalid)</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="utils.js"></script>
+<style>
+  #styleTests form, #styleTests fieldset, #failExample { background-color:red; }
+  #styleTests > :valid, #validExample { background-color:green; }
+  #styleTests > :invalid, #invalidExample { background-color:lime; }
+</style>
+</head>
+<body>
+<div id="log"></div>
+<div id='simpleConstraints'>
+  <input type=text id=text1 value="foobar" required>
+  <input type=text id=text2 required>
+</div>
+<div id='FormSelection'>
+  <form id=form1>
+    <input type=text id=text3 value="foobar" required>
+  </form>
+  <form id=form2>
+    <input type=text id=text4 required>
+  </form>
+</div>
+<div id='FieldSetSelection'>
+  <fieldset id=fieldset1>
+    <input type=text id=text5 value="foobar" required>
+  </fieldset>
+  <fieldset id=fieldset2>
+    <input type=text id=text6 required>
+  </fieldset>
+</div>
+<div id='patternConstraints'>
+  <input type=text id=text7 value="AAA" pattern="[0-9][A-Z]{3}">
+  <input type=text id=text8 value="0AAA" pattern="[0-9][A-Z]{3}">
+</div>
+<div id='numberConstraints'>
+  <input type=number id=number1 value=0 min=1>
+  <input type=number id=number2 value=1 min=1>
+</div>
+<div id='styleTests'>
+  <form>
+  </form>
+  <form>
+    <input type=text min=8 value=4>
+  </form>
+  <form>
+    <input type=number min=8 value=4>
+  </form>
+  <fieldset>
+  </fieldset>
+  <fieldset>
+    <input type=text min=8 value=4>
+  </fieldset>
+  <fieldset>
+    <input type=number min=8 value=4>
+  </fieldset>
+  <div id='validExample'></div>
+  <div id='invalidExample'></div>
+  <div id='failExample'></div>
+</div>
+<script>
+  testSelectorIdsMatch("#simpleConstraints :valid", ["text1"], "':valid' matches elements that satisfy their constraints");
+
+  testSelectorIdsMatch("#FormSelection :valid", ["form1", "text3"], "':valid' matches form elements that are not the form owner of any elements that themselves are candidates for constraint validation but do not satisfy their constraints");
+
+  testSelectorIdsMatch("#FieldSetSelection :valid", ["fieldset1", "text5"], "':valid' matches fieldset elements that have no descendant elements that themselves are candidates for constraint validation but do not satisfy their constraints");
+
+  testSelectorIdsMatch("#patternConstraints :valid", [ "text8" ], "':valid' matches elements that satisfy their pattern constraints");
+
+  testSelectorIdsMatch("#numberConstraints :valid", [ "number2" ], "':valid' matches elements that satisfy their number constraints");
+
+
+  testSelectorIdsMatch("#simpleConstraints :invalid", ["text2"], "':invalid' matches elements that do not satisfy their simple text  constraints");
+
+  testSelectorIdsMatch("#FormSelection :invalid", ["form2", "text4"], "':invalid' matches form elements that are the form owner of one or more elements that themselves are candidates for constraint validation but do not satisfy their constraints");
+
+  testSelectorIdsMatch("#FieldSetSelection :invalid", ["fieldset2", "text6"], "':invalid' matches fieldset elements that have of one or more descendant elements that themselves are candidates for constraint validation but do not satisfy their constraints");
+
+  testSelectorIdsMatch("#patternConstraints :invalid", ["text7"], "':invalid' matches elements that do not satisfy their pattern constraints");
+
+  testSelectorIdsMatch("#numberConstraints :invalid", ["number1"], "':invalid' matches elements that do not satisfy their number constraints");
+
+  document.getElementById("text7").value="0BBB";
+  testSelectorIdsMatch("#patternConstraints :valid", [ "text7", "text8" ], "':valid' matches new elements that satisfy their constraints");
+  testSelectorIdsMatch("#patternConstraints :invalid", [], "':invalid' doesn't match new elements that satisfy their constraints");
+
+  document.getElementById("text8").value="BBB";
+  testSelectorIdsMatch("#patternConstraints :valid", ["text7"], "':valid' doesn't match new elements that do not satisfy their constraints");
+  testSelectorIdsMatch("#patternConstraints :invalid", ["text8"], "':invalid' matches new elements that do not satisfy their constraints");
+
+  function getBGColor(elem) {
+    return getComputedStyle(elem).backgroundColor;
+  }
+
+  function testStyles(type) {
+    var elems = document.querySelectorAll("#styleTests " + type),
+        empty = elems[0],
+        valid = elems[1],
+        invalid = elems[2],
+        validInput = valid.querySelector("input"),
+        invalidInput = invalid.querySelector("input"),
+        expectedValidBGColor = getBGColor(document.getElementById("validExample")),
+        expectedInvalidBGColor = getBGColor(document.getElementById("invalidExample")),
+        expectedFailBGColor = getBGColor(document.getElementById("failExample"));
+
+    test(function() {
+      assert_equals(getBGColor(empty), expectedValidBGColor, "wrong background-color");
+    }, 'empty ' + type + ' correctly styled on page-load');
+
+    test(function() {
+      assert_equals(getBGColor(valid), expectedValidBGColor, "wrong background-color");
+    }, 'valid ' + type + ' correctly styled on page-load');
+    test(function() {
+      assert_equals(getBGColor(invalid), expectedInvalidBGColor, "wrong background-color");
+    }, 'invalid ' + type + ' correctly styled on page-load');
+
+    test(function() {
+      empty.appendChild(validInput.cloneNode());
+      assert_equals(getBGColor(empty), expectedValidBGColor, "wrong background-color");
+    }, 'programmatically adding valid to empty ' + type + ' results in correct style');
+    test(function() {
+      empty.appendChild(invalidInput.cloneNode());
+      assert_equals(getBGColor(empty), expectedInvalidBGColor, "wrong background-color");
+    }, 'programmatically adding invalid to empty ' + type + ' results in correct style');
+
+    validInput.type = "number";
+    invalidInput.type = "text";
+    test(function() {
+      assert_equals(getBGColor(valid), expectedInvalidBGColor, "wrong background-color");
+    }, 'programmatically-invalidated ' + type + ' correctly styled');
+    test(function() {
+      assert_equals(getBGColor(invalid), expectedValidBGColor, "wrong background-color");
+    }, 'programmatically-validated ' + type + ' correctly styled');
+  }
+  test(testStyles.bind(undefined, "form"), ":valid/:invalid styling for <form>");
+  test(testStyles.bind(undefined, "fieldset"), ":valid/:invalid styling for <fieldset>");
+</script>
+</body>
+</html>

--- a/Jint.Tests/Wpt/WptCorpus.cs
+++ b/Jint.Tests/Wpt/WptCorpus.cs
@@ -96,6 +96,7 @@ internal static class WptCorpus
         "html/webappapis/scripting/events",
         "html/webappapis/scripting/processing-model-2",
         "html/semantics/embedded-content/the-img-element",
+        "html/semantics/selectors/pseudo-classes",
         "custom-elements",
         "custom-elements/parser",
         "custom-elements/reactions",


### PR DESCRIPTION
## Mechanism

The page registers its own `IPseudoClassSelectorFactory` (`Jint.Browser/Runtime/Parsing/PagePseudoClassSelectorFactory.cs`) and owns the predicate for `:target`, `:link`, `:visited`, `:any-link`, `:enabled`, `:disabled` and `:default`, asking AngleSharp only for each selector's text, specificity and visitor. **Everything it does not own is AngleSharp's `DefaultPseudoClassSelectorFactory`, and until now nothing in either lane measured any of it.** The three vendored Selectors-API documents run a table of *strings* through `matches()` and `querySelectorAll`; they say nothing about what `:in-range` or `:read-write` answers for a real control.

This vendors upstream's own suite for those predicates, so that a fix to one of them has something to be measured against — and so that what is wrong today is written down rather than assumed.

## Spec

HTML §4.16.3, [Pseudo-classes](https://html.spec.whatwg.org/multipage/semantics-other.html#pseudo-classes) — the section every document in the directory links to as its `rel=help`.

## What is vendored

`html/semantics/selectors/pseudo-classes/`, at the corpus pin `6c7127bdd9f2cc6a3668fd9791757843e09d5a9e`, added to `WptCorpus.BrowserSuites` with a `[TestCaseSource]` of its own.

* **29 files**: 28 documents plus `utils.js`, the suite-root helper four of them load.
* **27 cases, 122 tests, 68 not passing.** `focus-iframe.html` is the 28th document and is a **frame body** — `focus.html` loads it to assert that `:focus` does not match a focused element inside a frame — so it is served and never run, which is the `FrameBodies` table's second row.

**Byte-verified.** Every file was read out of `repos/web-platform-tests/wpt/contents/html/semantics/selectors/pseudo-classes?ref=6c7127bdd9f2cc6a3668fd9791757843e09d5a9e` and every blob id upstream reports matches `git hash-object` of what is here — the same comparison the loop in `Vendor/README.md`'s drift recipe makes for one directory. The recipe's two generated figures moved with the files (908 → 937 files, 82 → 83 directories, 374 → 402 documents) and `JINT_WPT_CENSUS=update` rewrote them; the hand-written verification paragraph beneath the block now says which corpus its whole-tree run was a run of, per that file's own rule.

## Premise validation

The brief's premise was that this suite would give the six broken predicates real lane coverage. **It does, for five of the six.** Measured on the unfixed tree, the suite fails on `:in-range` matching an element with no range limitations, `:invalid`/`:valid` on a `<fieldset>`, `:placeholder-shown` ignoring applicability, `:read-only`/`:read-write` reading only mutability, and `:indeterminate` having no radio-button-group rule.

**It gives none for `:open`/`:closed`**, and that is worth saying because the brief assumed otherwise: the directory holds no `open.html`, and `:closed` — which AngleSharp does not register at all, so a page using it gets a `SyntaxError` — is tested nowhere in it. A fix for those two has to bring its own tests.

The suite also found **six causes the brief did not name**, each of them a real AngleSharp behaviour and each recorded rather than fixed: `:active`, `:focus`, `:dir()`, `:checked`, `:required`/`:optional`, and an opaque colour serialized as `rgba()`.

## The eleven causes, and their counts

Every one is a `NeedsTriage` group in `WptBrowserExclusions.Causes`. None gets a row in the README's generated cause table, and that is by construction: that table counts the six DOM suites and every one of these is a failure of this suite alone.

| Tests | Cause |
| ---: | --- |
| 20 | `:read-write` is "mutable" rather than "`readonly` applies **and** the control is mutable", so a checkbox is read-write; and `IsContentEditable` answers false, so an editing host is read-only. Two rows want a form-associated custom element. |
| 10 | `:in-range` matches any validation candidate that is neither overflowing nor underflowing — `<input type=text min=0 max=10>` matches — and a `range` control's value is not clamped to its limits, so it reports an overflow §4.10.5.4 says cannot arise. |
| 9 | `:dir()` compares its argument with `IHtmlElement.Direction`, the `dir` content attribute of that one element. Directionality is inherited and `auto` is resolved from text, so an element declaring none matches neither keyword. |
| 8 | `:valid`/`:invalid` answer from `IValidation.CheckValidity()` and a form's, and skip the `<fieldset>`; the same document's `<form>` rows pass. Two more documents want a constraint state kept across a removal and across a clone. |
| 5 | `:active` is a hyperlink-only flag nothing sets. |
| 5 | `:focus` is `IElement.IsFocused`, which nothing assigns — the page's focus model is `Events/FocusController`, which `document.activeElement` reads. |
| 4 | An opaque colour serializes as `rgba(r, g, b, 1)`. Already recorded in `Dom/divergences.md`; these four rows compare a computed colour with a literal and each already gets the colour the selector should produce. |
| 3 | `:checked` answers for the historical `<menuitem>`, two of which `checked.html` keeps precisely so that they do not match. |
| 2 | `:indeterminate` has no radio-button-group rule. |
| 1 | `:placeholder-shown` ignores whether `placeholder` applies to the type state, and never answers for a `<textarea>`. |
| 1 | `:required`/`:optional` read the attribute on a hidden input, which it does not apply to. |

## Failing-first evidence

There is no new hand-written test here; the vendored documents *are* the evidence, and each of the three tables was written from what they reported rather than the other way round.

* First run with placeholder minimums and no exclusions: **28 cases, 5 passed, 23 failed** — 22 with named failing tests and one (`autofill.html`) with a harness `ERROR`.
* The per-document test counts in `MinimumTests` are exact and were measured (each minimum was set impossibly high once, so every case reported its own count).
* With the eleven cause groups in place: **461/461 green in `Jint.Tests.Browser.Wpt`**, which is the two-sided rule doing its job — every failure named, and no pattern matching a passing test.

## Exclusion delta

**+68 rows, in eleven new cause groups. Nothing removed** — this change vendors a suite and moves no engine.

Census: `html/semantics/selectors/pseudo-classes/` enters at `27 | 0 | 122 | 68`; the totals go `365 → 392` documents, `66,794 → 66,916` tests, `1,077 → 1,145` not passing. Written by `JINT_WPT_BROWSER_CENSUS=update`; **the ceiling was not raised** — the refusal-to-raise check only guards rows the table already had, and no existing suite's figure moved.

Not vendored, four rows, none of them a defect:

* `autofill.html` — its two assertions are `test_valid_selector` from `/css/support/parsing-testcommon.js`, a helper root this corpus does not hold, so the file throws at file scope and reports nothing at all. A harness error covers the whole file and no per-test exclusion can name it.
* `indeterminate-radio-group.html` and `indeterminate-radio-group-ref.html` — a reftest and its reference; neither loads `testharness.js`.
* `*.window.js` — the glob every suite here has.
* `checked-001-manual.html` needs no row: the lane's `-manual.` marker already covers it.

## AngleSharp findings, recorded and not filed

Nine of the eleven causes are AngleSharp behaviours. They are recorded in `WptBrowserExclusions.cs` beside the rows they explain and in `Wpt/README.md`'s new section; **no issue or pull request was opened on any AngleSharp repository.** The `rgba()` serialization already had a row in `Jint.Browser/Dom/divergences.md`, and the exclusion group points at it rather than restating it.

Two of the eleven are this package's rather than AngleSharp's, and both are named as such: `:focus` has a focus model here (`Events/FocusController`) that the selector never consults, and `:active` has no activation state at all.

## Verification

* `dotnet build -c Release Jint.Tests.Browser/Jint.Tests.Browser.csproj` — 0 warnings, 0 errors.
* `JINT_WPT_BROWSER_CENSUS=1 dotnet test Jint.Tests.Browser -c Release -f net8.0` — **2726 passed, 0 failed**, 36 skipped (Playwright).
* `JINT_WPT_BROWSER_CENSUS=1 dotnet test Jint.Tests.Browser -c Release -f net10.0` — **2730 passed, 0 failed**, 36 skipped.
* `dotnet test Jint.Tests -c Release -f net8.0 --filter "FullyQualifiedName~Jint.Tests.Wpt"` — **698 passed, 0 failed.**

Base: `9c585853e49313e9139bbbb05a1f9454c39e3ea0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
