### PR TITLE
Cache the element wrappers of a static NodeList, per DOM §4.2.6

### DIFF
--- a/Jint.Benchmark/BrowserNodeListBenchmark.cs
+++ b/Jint.Benchmark/BrowserNodeListBenchmark.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Jint.Browser;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The element read of the loop <c>dom/nodes/support/NodeList-static-length-tampered.js</c> compiles —
+/// <c>for (j = 0; j &lt; list.length; j++) if (list[j] === el)</c> — over a <b>real page</b>, so that
+/// <c>list[j]</c> is a DOM projection rather than a host object written for a benchmark.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why it is here and not beside <see cref="HostCollectionLengthBenchmark"/>.</b> That class measures the
+/// same loop's <c>length</c> read with a hand-written <c>ArrayLikeObject</c>, which is the right shape for a
+/// question about the engine. This one is about what the <i>binding</i> does per element — the wrapper lookup
+/// behind <c>DomAccessorNodeList.TryGetIndex</c> — and no host object written here can stand in for it,
+/// because the cost is a <c>ConditionalWeakTable</c> probe against the realm's wrapper table.
+/// <c>Jint.Benchmark</c> already references <c>Jint.Browser</c> for <see cref="BrowserLayoutBenchmark"/>, so
+/// the row lives in the same project as every other row rather than in a browser-side benchmark project of
+/// its own — there is none, and <c>tools/browser-comparison</c> measures other engines rather than this one.
+/// </para>
+/// <para>
+/// <b>What each row is.</b>
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="StaticNodeList"/> — the loop over a <c>querySelectorAll</c> result, which DOM §4.2.6 makes a
+/// static <c>NodeList</c>. This is the row the change is about.
+/// </description></item>
+/// <item><description>
+/// <see cref="StaticNodeListTamperedLength"/> — the same list after the page has defined an own <c>length</c>
+/// accessor answering the same count, which is the half of the wpt documents that makes the pristine-length
+/// lane decline. The loop does the same work, so what is left in the delta is the element read.
+/// </description></item>
+/// <item><description>
+/// <see cref="LiveNodeList"/> — the same loop over <c>childNodes</c>, which is live and deliberately keeps the
+/// accessor-driven wrapper. It is the control that must not move.
+/// </description></item>
+/// <item><description>
+/// <see cref="PlainArray"/> — the floor and the baseline: the identical loop over the
+/// <c>Array.from(list)</c> of the same elements, so the gap is the price of the list being a projection.
+/// </description></item>
+/// </list>
+/// <para>
+/// <b>Engine isolation.</b> One <see cref="Page"/> — and therefore one engine and one document — per row,
+/// built in <c>[GlobalSetup]</c> and given only that row's own fixture, so a row's number never depends on
+/// which sibling warmed which lane first. Page construction and the HTML parse stay outside the measurement;
+/// what the measured call adds over the loop itself is one mailbox round trip per operation, which is the
+/// same term in every row including the baseline.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class BrowserNodeListBenchmark
+{
+    /// <summary>
+    /// 100 elements, which is what the wpt helper builds and the size the profile on
+    /// sebastienros/jint#4013 was taken at.
+    /// </summary>
+    [Params(100)]
+    public int Count { get; set; }
+
+    /// <summary>
+    /// 100 passes of the inner loop per operation. The wpt document runs 50,000 and takes seconds; this is
+    /// the same shape at a size a benchmark can repeat.
+    /// </summary>
+    private const string Passes = "100";
+
+    /// <summary>
+    /// The loop, verbatim in shape from the wpt helper: the match is at index 50, and the <c>break</c> is
+    /// what makes an operation about half the list.
+    /// </summary>
+    private const string Loop = $$"""
+        (function () {
+            var index = -1;
+            for (var i = 0; i < {{Passes}}; i++) {
+                for (var j = 0; j < list.length; j++) {
+                    if (list[j] === el) { index = j; break; }
+                }
+            }
+            return index;
+        })()
+        """;
+
+    private Browser.Browser _browser = null!;
+    private Page _staticList = null!;
+    private Page _staticListTampered = null!;
+    private Page _liveList = null!;
+    private Page _plainArray = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _browser = new Browser.Browser();
+
+        _staticList = await CreatePageAsync("var list = document.getElementById('root').querySelectorAll('span');");
+
+        _staticListTampered = await CreatePageAsync(
+            "var list = document.getElementById('root').querySelectorAll('span');"
+            + $"Object.defineProperty(list, 'length', {{ get: function () {{ return {Count}; }} }});");
+
+        _liveList = await CreatePageAsync("var list = document.getElementById('root').childNodes;");
+
+        _plainArray = await CreatePageAsync(
+            "var list = Array.from(document.getElementById('root').querySelectorAll('span'));");
+    }
+
+    /// <summary>
+    /// One page holding <paramref name="bind"/>'s <c>list</c> and the element the loop looks for, warmed with
+    /// this row's own loop and nothing else.
+    /// </summary>
+    private async Task<Page> CreatePageAsync(string bind)
+    {
+        var page = await _browser.NewPageAsync();
+        await page.SetContentAsync(Document(Count));
+        await page.EvaluateAsync<double>(bind + " var el = list[50]; 0;");
+        await page.EvaluateAsync<double>(Loop);
+        return page;
+    }
+
+    /// <summary>A document of <paramref name="count"/> spans under one parent, and nothing else.</summary>
+    private static string Document(int count)
+    {
+        var html = new StringBuilder("<!doctype html><html><body><div id=\"root\">");
+        for (var i = 0; i < count; i++)
+        {
+            html.Append("<span class=\"foo\"></span>");
+        }
+
+        return html.Append("</div></body></html>").ToString();
+    }
+
+    [Benchmark]
+    public Task<double> StaticNodeList() => _staticList.EvaluateAsync<double>(Loop);
+
+    [Benchmark]
+    public Task<double> StaticNodeListTamperedLength() => _staticListTampered.EvaluateAsync<double>(Loop);
+
+    [Benchmark]
+    public Task<double> LiveNodeList() => _liveList.EvaluateAsync<double>(Loop);
+
+    [Benchmark(Baseline = true)]
+    public Task<double> PlainArray() => _plainArray.EvaluateAsync<double>(Loop);
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _browser.DisposeAsync();
+}

--- a/Jint.Browser/Dom/AGENTS.md
+++ b/Jint.Browser/Dom/AGENTS.md
@@ -231,6 +231,16 @@ The wrappers deliberately do **not** share a base class, and `IDomWrapper` is wh
 - **`Collections/DomCollectionObject : ArrayLikeObject`** — so `list[i]`, `for..of`, spread, `Array.from` and
   the `Array.prototype` generics reach the engine's one-callback-per-element lane with no `Reference`, no key
   object and no descriptor. Its interface-specific half is the generated accessor.
+- **`Collections/DomStaticNodeListObject : DomCollectionBase`** — the one collection that memoizes its
+  elements, and the reason the static/live distinction exists in this package at all. **Nothing about an
+  `INodeList` says whether it is live**: `childNodes` and `labels` are, a selector match is not, and all three
+  used to arrive at the same wrapper. So staticness is a property of a *type* — `DomStaticNodeList`, a
+  snapshot the binding copies for itself, produced only by the `querySelectorAll` hook, which is where DOM
+  §4.2.6's word "static" is. Its wrapper then keeps one element wrapper per index, which is a memo of
+  `DomRealm.WrapNode` and never a second identity: the cached object *is* the one the wrapper table holds, it
+  adds no retention over the snapshot that already names those nodes, and it dies with the list. **A live
+  collection must not get one** — a per-index cache over a membership that moves answers the wrong node, and
+  a removed node it had cached would be pinned for the collection's life.
 - **`Collections/DomIndexedNodeObject : DomNodeObject`** — a node whose interface *also* supports indexed or
   named properties (`form[0]`, `form.username`, `select[0]`). It is a node wrapper with the same generated
   accessor projected on top, and it has to be: the tree-dispatch lane keys on the node wrapper and the cache

--- a/Jint.Browser/Dom/Collections/DomStaticNodeList.cs
+++ b/Jint.Browser/Dom/Collections/DomStaticNodeList.cs
@@ -1,0 +1,85 @@
+using System.Collections;
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Dom.Collections;
+
+/// <summary>
+/// The <b>static</b> <c>NodeList</c> that
+/// <a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall">DOM §4.2.6's
+/// <c>querySelectorAll</c></a> returns: "the static result of running scope-match a selectors string".
+/// </summary>
+/// <remarks>
+/// <para>
+/// It is the mirror image of <see cref="DomLiveHtmlCollection"/>, which exists because AngleSharp answers a
+/// snapshot where DOM wants a live collection. Here the standard wants the snapshot, and the reason the
+/// binding owns one anyway is that <b>nothing about an <see cref="INodeList"/> says whether it is live</b>:
+/// <c>childNodes</c>, <c>labels</c> and a selector match all arrive at the same wrapper through the same
+/// generated accessor, and a wrapper that cached anything per index would be wrong for two of the three. So
+/// staticness is made a property of a <i>type</i> rather than a claim about an instance — this class holds
+/// the matched nodes in an array nothing else can reach, which is what lets
+/// <see cref="DomStaticNodeListObject"/> keep one element wrapper per index.
+/// </para>
+/// <para>
+/// The array is a copy of the collection AngleSharp produced rather than a reference to it. That costs one
+/// array of references per <c>querySelectorAll</c> — beside the <c>List&lt;IElement&gt;</c> the match already
+/// built — and buys the whole safety argument: an <see cref="INodeList"/> handed in from elsewhere can never
+/// become the thing behind a cache merely because it happened to be a snapshot on the day it was written.
+/// </para>
+/// <para>
+/// It holds the nodes strongly, exactly as AngleSharp's own snapshot does, so it adds no retention over the
+/// collection it copies — and the wrapper's per-index cache adds none over <i>this</i>, because a node this
+/// array names is a node whose wrapper the realm's <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey,TValue}"/>
+/// is already keeping alive.
+/// </para>
+/// </remarks>
+internal sealed class DomStaticNodeList : INodeList
+{
+    private readonly INode[] _nodes;
+
+    internal DomStaticNodeList(IHtmlCollection<IElement> matches)
+    {
+        var count = matches.Length;
+        if (count == 0)
+        {
+            _nodes = [];
+            return;
+        }
+
+        var nodes = new INode[count];
+        for (var i = 0; i < count; i++)
+        {
+            nodes[i] = matches[i];
+        }
+
+        _nodes = nodes;
+    }
+
+    /// <summary>The matched nodes, in tree order. Never mutated after the constructor returns.</summary>
+    internal INode[] Nodes => _nodes;
+
+    /// <inheritdoc />
+    public int Length => _nodes.Length;
+
+    /// <summary>
+    /// The CLR indexer, which every caller in this package guards before reaching. It is deliberately a bare
+    /// array index: an out-of-range read is a defect here rather than something a page can ask for, because
+    /// both doors — <c>NodeList.item</c> and <see cref="DomStaticNodeListObject.TryGetIndex"/> — answer
+    /// WebIDL's out-of-range value themselves.
+    /// </summary>
+    public INode this[int index] => _nodes[index];
+
+    /// <inheritdoc />
+    public IEnumerator<INode> GetEnumerator() => ((IEnumerable<INode>) _nodes).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _nodes.GetEnumerator();
+
+    /// <inheritdoc />
+    public void ToHtml(TextWriter writer, IMarkupFormatter formatter)
+    {
+        foreach (var node in _nodes)
+        {
+            node.ToHtml(writer, formatter);
+        }
+    }
+}

--- a/Jint.Browser/Dom/Collections/DomStaticNodeListObject.cs
+++ b/Jint.Browser/Dom/Collections/DomStaticNodeListObject.cs
@@ -1,0 +1,92 @@
+using AngleSharp.Dom;
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.Browser.Dom.Collections;
+
+/// <summary>
+/// The wrapper for a <see cref="DomStaticNodeList"/>: a <c>NodeList</c> whose membership cannot change, and
+/// which therefore keeps the one element wrapper each of its indices answers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What it caches, and why that is not a second identity.</b> The cached value <i>is</i> the canonical
+/// wrapper — the one <c>DomRealm.WrapNode</c> answers, which is the one the realm's
+/// <c>ConditionalWeakTable</c> holds for that node and the one every other route to the node returns. So
+/// <c>list[0] === document.querySelector(…)</c> and <c>list[0] === otherList[0]</c> stay true by
+/// construction: the array is a memo of a lookup, never a source of objects. What it removes is the lookup —
+/// the weak-table probe (<c>FindEntry</c>) the profile in
+/// <a href="https://github.com/sebastienros/jint/issues/4013">sebastienros/jint#4013</a> measured on the
+/// element read of <c>for (j = 0; j &lt; list.length; j++) if (list[j] === el)</c>.
+/// </para>
+/// <para>
+/// <b>Why it adds no retention.</b> The snapshot holds its nodes strongly, and a live node's wrapper is
+/// already kept alive by the weak table keyed on it. The cache therefore names objects the wrapper's own
+/// <c>DomTarget</c> was keeping alive anyway, and it dies with the wrapper — which dies when the page and the
+/// script both let go of the list. Removing a cached node from the document changes nothing: the node is
+/// still in this static list, which is precisely what "static" means, and it still has one wrapper.
+/// </para>
+/// <para>
+/// <b>Why it is per wrapper rather than per snapshot.</b> An <see cref="ObjectInstance"/> belongs to one
+/// engine and one realm, so a cache of them cannot live on the AngleSharp-side object the way the node array
+/// does. This class is that per-engine half.
+/// </para>
+/// <para>
+/// It also answers the other half of the read cost the same profile names: the target is a typed
+/// <c>INode[]</c> field rather than <c>object</c> + a per-read interface cast, and there is no
+/// <c>DomCollectionAccessor</c> virtual call, because this shape has exactly one interface behind it.
+/// <see cref="DomCollectionAccessor"/>'s own <c>object</c> parameter is unchanged and must stay: one
+/// process-shared singleton serves every engine and every CLR target type of its interface.
+/// </para>
+/// </remarks>
+internal sealed class DomStaticNodeListObject : DomCollectionBase
+{
+    private readonly INode[] _nodes;
+
+    /// <summary>
+    /// One slot per index, filled on that index's first read. A <see langword="null"/> slot means "not read
+    /// yet", never "no element": every index below <see cref="Length"/> has a node. The array itself is
+    /// allocated on the first indexed read, so a match a page only takes the <c>length</c> of — or never
+    /// touches at all — costs nothing for it.
+    /// </summary>
+    private ObjectInstance?[]? _elements;
+
+    internal DomStaticNodeListObject(DomRealm realm, DomStaticNodeList snapshot)
+        : base(realm, DomInterfaces.NodeList, snapshot)
+    {
+        _nodes = snapshot.Nodes;
+    }
+
+    /// <inheritdoc />
+    public override uint Length => (uint) _nodes.Length;
+
+    /// <inheritdoc />
+    public override bool TryGetIndex(uint index, out JsValue value)
+    {
+        var nodes = _nodes;
+
+        if (index >= (uint) nodes.Length)
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        var elements = _elements ??= new ObjectInstance?[nodes.Length];
+        var wrapper = elements[index];
+
+        if (wrapper is null)
+        {
+            // Not memoized before the wrap returns, so a projection the node budget refused leaves the slot
+            // empty and the next read asks again -- and gets the same wrapper, because the realm's table took
+            // it before the RangeError was raised.
+            wrapper = DomRealm.WrapNode(nodes[index]);
+            elements[index] = wrapper;
+        }
+
+        value = wrapper;
+        return true;
+    }
+
+    /// <inheritdoc />
+    protected override bool HasIndex(uint index) => index < (uint) _nodes.Length;
+}

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -266,6 +266,24 @@ internal class DomHostHooks
         return realm.WrapCollection<IElement>(new DomLiveHtmlCollection(Current));
     }
 
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall — "the <b>static</b> result of running
+    /// scope-match a selectors string".
+    /// </summary>
+    /// <remarks>
+    /// AngleSharp's answer is already a snapshot, so this hook corrects no behaviour. What it does is put the
+    /// standard's word "static" where the binding can act on it: the result is projected through
+    /// <c>DomRealm.WrapStaticNodeList</c>, whose <see cref="Collections.DomStaticNodeList"/> makes staticness
+    /// a property of the type rather than a guess about an <c>INodeList</c> — which is what lets that
+    /// wrapper keep one element wrapper per index. Every other <c>NodeList</c> in the surface
+    /// (<c>childNodes</c>, <c>labels</c>) is live and keeps the ordinary accessor-driven wrapper.
+    /// </remarks>
+    internal virtual JsValue QuerySelectorAll(DomRealm realm, INode root, JsValue[] arguments)
+    {
+        var selectors = DomConvert.RequiredText(arguments, 0, Member(root, "querySelectorAll"));
+        return realm.WrapStaticNodeList(((IParentNode) root).QuerySelectorAll(selectors));
+    }
+
     private static string Member(INode root, string operation)
         => root switch
         {

--- a/Jint.Browser/Dom/DomRealm.cs
+++ b/Jint.Browser/Dom/DomRealm.cs
@@ -341,6 +341,25 @@ internal sealed class DomRealm
         return Cache(collection, new DomHtmlCollectionObject<T>(this, definition, collection));
     }
 
+    /// <summary>
+    /// Projects the <b>static</b> <c>NodeList</c> a selector match produced, as
+    /// <a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall">DOM §4.2.6</a> defines it:
+    /// "the static result of running scope-match a selectors string".
+    /// </summary>
+    /// <remarks>
+    /// The snapshot is the binding's own (<see cref="DomStaticNodeList"/>) rather than AngleSharp's, because
+    /// nothing about an <see cref="INodeList"/> says whether it is live and this wrapper keeps one element
+    /// wrapper per index. It is cached like every other wrapper, so <c>Hooks.WrapperCreated</c> fires once
+    /// for it; the snapshot is new on every call, which keeps
+    /// <c>el.querySelectorAll('x') !== el.querySelectorAll('x')</c> — DOM's answer, and the one the binding
+    /// already gave.
+    /// </remarks>
+    internal JsValue WrapStaticNodeList(IHtmlCollection<IElement> matches)
+    {
+        var snapshot = new DomStaticNodeList(matches);
+        return Cache(snapshot, new DomStaticNodeListObject(this, snapshot));
+    }
+
     /// <summary>Projects the live <c>NodeList</c> of labels associated with a labelable element.</summary>
     internal JsValue WrapLabels(IHtmlElement control)
     {

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -1250,7 +1250,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.querySelectorAll", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.querySelectorAll");
-                    return self.Realm.Wrap((global::AngleSharp.Dom.INodeList) (self.Target.QuerySelectorAll(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Document.querySelectorAll"))), global::Jint.Browser.Dom.DomInterfaces.NodeList);
+                    return self.Realm.Hooks.QuerySelectorAll(self.Realm, self.Target, args);
                 }),
                 length: 1)
             .Accessor("readyState",
@@ -1419,7 +1419,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("DocumentFragment.querySelectorAll", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocumentFragment>(thisObj, "DocumentFragment.querySelectorAll");
-                    return self.Realm.Wrap((global::AngleSharp.Dom.INodeList) (self.Target.QuerySelectorAll(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "DocumentFragment.querySelectorAll"))), global::Jint.Browser.Dom.DomInterfaces.NodeList);
+                    return self.Realm.Hooks.QuerySelectorAll(self.Realm, self.Target, args);
                 }),
                 length: 1)
             .Method("replaceChildren",
@@ -1826,7 +1826,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Element.querySelectorAll", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IElement>(thisObj, "Element.querySelectorAll");
-                    return self.Realm.Wrap((global::AngleSharp.Dom.INodeList) (self.Target.QuerySelectorAll(global::Jint.Browser.Dom.DomConvert.RequiredText(args, 0, "Element.querySelectorAll"))), global::Jint.Browser.Dom.DomInterfaces.NodeList);
+                    return self.Realm.Hooks.QuerySelectorAll(self.Realm, self.Target, args);
                 }),
                 length: 1)
             .Method("remove",

--- a/Jint.Tests.Browser/Dom/StaticNodeListTests.cs
+++ b/Jint.Tests.Browser/Dom/StaticNodeListTests.cs
@@ -1,0 +1,341 @@
+using System.Runtime.CompilerServices;
+using Jint.Browser.Dom.Collections;
+using Jint.Native;
+
+namespace Jint.Tests.Browser;
+
+/// <summary>
+/// The static <c>NodeList</c> <c>querySelectorAll</c> returns, and the per-index element-wrapper cache on it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache is a memo of <c>DomRealm.WrapNode</c>, so every assertion here about identity is an assertion
+/// that it stayed one: the cached object <i>is</i> the canonical wrapper the realm's weak table holds, and a
+/// second list over the same node, a fresh <c>querySelector</c> and the tree all have to keep answering it.
+/// Most of these therefore pass on both sides of the change — deliberately, because "nothing observable moved"
+/// is the whole claim. What only passes after it is
+/// <see cref="OnlyASelectorMatchTakesTheStaticLane"/>, which pins the seam itself.
+/// </para>
+/// <para>
+/// The retention tests are the other half, and they are reachability questions rather than heap readings, for
+/// the reasons <c>Jint.Tests.Runtime.GarbageCollectionTests</c> records: a weak reference names the object
+/// rather than an amount of bytes that resembles it.
+/// </para>
+/// </remarks>
+public sealed class StaticNodeListTests
+{
+    private const string Page = "<div id='root'><span class='foo' id='s0'>a</span><span class='foo' id='s1'>b</span></div>";
+
+    /// <summary>
+    /// 100 elements, which is what <c>dom/nodes/support/NodeList-static-length-tampered.js</c> builds and the
+    /// size the profile in <a href="https://github.com/sebastienros/jint/issues/4013">#4013</a> was taken on.
+    /// </summary>
+    private const string HundredSpans = """
+        var root = document.getElementById('root');
+        root.innerHTML = '';
+        for (var i = 0; i < 100; i++) {
+            var el = document.createElement('span');
+            el.className = 'foo';
+            root.appendChild(el);
+        }
+        """;
+
+    [Test]
+    public void TheSameIndexAnswersOneObjectHoweverOftenItIsRead()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Bool("var l = document.querySelectorAll('.foo'); l[0] === l[0]").Should().BeTrue();
+        fixture.Bool("l[1] === l[1]").Should().BeTrue();
+        fixture.Bool("l[0] === l[1]").Should().BeFalse();
+
+        // The expando is the reason identity matters at all, and it survives the cache being the thing that
+        // answered the second read.
+        fixture.Evaluate("l[0].__state = 7;");
+        fixture.Number("l[0].__state").Should().Be(7);
+    }
+
+    [Test]
+    public void ACachedElementIsTheSameObjectEveryOtherRouteToTheNodeAnswers()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Execute("var l = document.querySelectorAll('.foo'); var first = l[0];");
+
+        fixture.Bool("first === document.querySelector('.foo')").Should().BeTrue();
+        fixture.Bool("first === document.getElementById('s0')").Should().BeTrue();
+        fixture.Bool("first === document.getElementById('root').firstElementChild").Should().BeTrue();
+        fixture.Bool("first === document.getElementById('root').childNodes[0]").Should().BeTrue();
+
+        // And the other way round: a wrapper the tree handed out first is what the list answers afterwards.
+        fixture.Execute("var second = document.getElementById('s1'); var l2 = document.querySelectorAll('.foo');");
+        fixture.Bool("l2[1] === second").Should().BeTrue();
+    }
+
+    [Test]
+    public void TwoListsOverTheSameNodesAnswerTheSameObjects()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Execute("var a = document.querySelectorAll('.foo'); var b = document.querySelectorAll('.foo');");
+
+        // DOM makes each call a new static NodeList, so the two lists are different objects...
+        fixture.Bool("a === b").Should().BeFalse();
+        // ...while every element they answer is the one wrapper its node has.
+        fixture.Bool("a[0] === b[0]").Should().BeTrue();
+        fixture.Bool("a[1] === b[1]").Should().BeTrue();
+
+        // Filling one list's cache first must not change what the other one answers, in either order.
+        fixture.Execute("var c = document.querySelectorAll('.foo'); var seen = c[0]; var d = document.querySelectorAll('.foo');");
+        fixture.Bool("d[0] === seen").Should().BeTrue();
+    }
+
+    [Test]
+    public void ARemovedNodeStillAnswersTheSameWrapperFromTheListThatMatchedIt()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Execute("var l = document.querySelectorAll('.foo'); var first = l[0];");
+        fixture.Execute("first.__state = 'kept'; first.remove();");
+
+        // "Static" means the membership does not change, so a removed node is still element 0...
+        fixture.Number("l.length").Should().Be(2);
+        fixture.Bool("l[0] === first").Should().BeTrue();
+        fixture.Text("l[0].__state").Should().Be("kept");
+        fixture.Bool("l[0].isConnected").Should().BeFalse();
+
+        // ...and the live NodeList beside it does change, which is what says the two lanes stayed apart.
+        fixture.Number("document.getElementById('root').childNodes.length").Should().Be(1);
+
+        // A fresh match no longer finds it, and the wrapper the removed node keeps is still the only one.
+        fixture.Number("document.querySelectorAll('.foo').length").Should().Be(1);
+        fixture.Bool("document.querySelectorAll('.foo')[0] === l[1]").Should().BeTrue();
+    }
+
+    [Test]
+    public void AnIndexPastTheEndIsUndefinedAndItemIsNull()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Execute("var l = document.querySelectorAll('.foo');");
+
+        // dom/nodes/Node-childNodes.html asserts these two answers are different on purpose.
+        fixture.Evaluate("l[2]").IsUndefined().Should().BeTrue();
+        fixture.Evaluate("l[99]").IsUndefined().Should().BeTrue();
+        fixture.Evaluate("l.item(2)").IsNull().Should().BeTrue();
+        fixture.Evaluate("l.item(-1)").IsNull().Should().BeTrue();
+
+        fixture.Bool("2 in l").Should().BeFalse();
+        fixture.Bool("1 in l").Should().BeTrue();
+        fixture.Bool("l.hasOwnProperty('0')").Should().BeTrue();
+        fixture.Bool("l.hasOwnProperty('2')").Should().BeFalse();
+        fixture.Text("Object.keys(l).join(',')").Should().Be("0,1");
+
+        // An empty match keeps the same shape, with no array to allocate at all.
+        fixture.Number("document.querySelectorAll('.nothing').length").Should().Be(0);
+        fixture.Evaluate("document.querySelectorAll('.nothing')[0]").IsUndefined().Should().BeTrue();
+    }
+
+    [Test]
+    public void TheWrapperIsStillANodeListInEveryWayAPageCanSee()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Execute("var l = document.querySelectorAll('.foo');");
+
+        fixture.Bool("l instanceof NodeList").Should().BeTrue();
+        fixture.Bool("Object.getPrototypeOf(l) === NodeList.prototype").Should().BeTrue();
+        fixture.Text("Object.prototype.toString.call(l)").Should().Be("[object NodeList]");
+        fixture.Bool("Array.isArray(l)").Should().BeFalse();
+        fixture.Bool("l[Symbol.iterator] === Array.prototype[Symbol.iterator]").Should().BeTrue();
+        fixture.Text("Array.from(l).map(function (e) { return e.id; }).join(',')").Should().Be("s0,s1");
+        fixture.Text("[...l].map(function (e) { return e.id; }).join(',')").Should().Be("s0,s1");
+        fixture.Number("Array.prototype.indexOf.call(l, l[1])").Should().Be(1);
+        fixture.Text("JSON.stringify(Array.prototype.map.call(l, function (e) { return e.id; }))")
+            .Should().Be("[\"s0\",\"s1\"]");
+
+        var forEach = "var ids = []; l.forEach(function (e) { ids.push(e.id); }); ids.join(',')";
+        fixture.Text(forEach).Should().Be("s0,s1");
+    }
+
+    /// <summary>
+    /// The three <c>NodeList-static-length-getter-tampered-*.html</c> shapes, in miniature: an own
+    /// <c>length</c> a page defines over the list must decide what a loop and <c>Array.prototype.indexOf</c>
+    /// see, and the element reads must keep answering the elements they always did.
+    /// </summary>
+    [Test]
+    public void ATamperedLengthDecidesWhatALoopSeesAndTheElementsDoNotMove()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+
+        fixture.Execute(HundredSpans);
+        fixture.Execute("var l = document.querySelectorAll('.foo'); var el = l[50];");
+
+        const string Loop = """
+            (function () {
+                for (var j = 0; j < l.length; j++) {
+                    if (l[j] === el) { return j; }
+                }
+                return -1;
+            })()
+            """;
+
+        fixture.Number(Loop).Should().Be(50);
+        fixture.Number("Array.prototype.indexOf.call(l, el)").Should().Be(50);
+
+        // Exactly what the wpt documents do half way through their loop.
+        fixture.Execute("Object.defineProperty(l, 'length', { get: function () { return 10; } });");
+
+        fixture.Number("l.length").Should().Be(10);
+        fixture.Number(Loop).Should().Be(-1);
+        fixture.Number("Array.prototype.indexOf.call(l, el)").Should().Be(-1);
+
+        // The tampered length shortens what a length-driven walk sees; it does not change an element read,
+        // and index 50 is still the object it was before the redefinition.
+        fixture.Bool("l[50] === el").Should().BeTrue();
+        fixture.Bool("l[99] === undefined").Should().BeFalse();
+        fixture.Number("l.item(50) === el ? 1 : 0").Should().Be(1);
+    }
+
+    /// <summary>
+    /// The seam: only a selector match takes the static lane. A live <c>NodeList</c> — <c>childNodes</c>, and
+    /// a labelable element's <c>labels</c> — must keep the accessor-driven wrapper, because a per-index cache
+    /// over a list whose membership moves would answer the wrong node.
+    /// </summary>
+    /// <remarks>This is the one test here that fails against the unfixed code.</remarks>
+    [Test]
+    public void OnlyASelectorMatchTakesTheStaticLane()
+    {
+        using var fixture = DomTestFixture.Create(
+            "<div id='root'><span class='foo' id='s0'>a</span></div><label for='c'>l</label><input id='c'>");
+
+        fixture.Evaluate("document.querySelectorAll('.foo')").Should().BeOfType<DomStaticNodeListObject>();
+        fixture.Evaluate("document.getElementById('root').querySelectorAll('span')").Should().BeOfType<DomStaticNodeListObject>();
+        fixture.Evaluate("document.createDocumentFragment().querySelectorAll('span')").Should().BeOfType<DomStaticNodeListObject>();
+
+        fixture.Evaluate("document.getElementById('root').childNodes").Should().BeOfType<DomCollectionObject>();
+        fixture.Evaluate("document.getElementById('c').labels").Should().BeOfType<DomCollectionObject>();
+
+        // A live NodeList reports the tree it currently has, which is the property a cache would have broken.
+        fixture.Execute("var live = document.getElementById('root').childNodes;");
+        fixture.Number("live.length").Should().Be(1);
+        fixture.Execute("document.getElementById('root').appendChild(document.createElement('b'));");
+        fixture.Number("live.length").Should().Be(2);
+        fixture.Text("live[1].tagName").Should().Be("B");
+        fixture.Execute("document.getElementById('root').removeChild(document.getElementById('s0'));");
+        fixture.Text("live[0].tagName").Should().Be("B");
+    }
+
+    /// <summary>
+    /// Dropping the page and the list lets the nodes and their wrappers go — the cache adds no retention over
+    /// the snapshot, which adds none over the collection AngleSharp already built.
+    /// </summary>
+    [Test]
+    [NonParallelizable]
+    public void DroppingTheListAndThePageCollectsTheNodesAndTheirWrappers()
+    {
+        var (node, wrapper, list) = BuildAndDropAPageWithAStaticNodeList();
+
+        Collect();
+
+        list.IsAlive.Should().BeFalse("nothing names the NodeList wrapper any more");
+        wrapper.IsAlive.Should().BeFalse("the element wrapper was only reachable through the list's cache and the realm's weak table");
+        node.IsAlive.Should().BeFalse("the AngleSharp element was only reachable through the document and the snapshot");
+    }
+
+    /// <summary>
+    /// The control, and the reason the test above can be trusted: the same three objects, with the page and
+    /// the list still held, must survive. Without it a harness that failed to build anything would satisfy
+    /// the assertions above for the wrong reason.
+    /// </summary>
+    [Test]
+    [NonParallelizable]
+    public void APageThatStillHoldsItsListKeepsTheNodesAndTheirWrappers()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+        var (node, wrapper, list) = ReadAStaticNodeList(fixture, keepInAGlobal: true);
+
+        Collect();
+
+        list.IsAlive.Should().BeTrue("a global still names the NodeList");
+        wrapper.IsAlive.Should().BeTrue("the list still names the element wrapper");
+        node.IsAlive.Should().BeTrue("the document still holds the element");
+
+        GC.KeepAlive(fixture);
+    }
+
+    /// <summary>
+    /// The sharper half: within a page that is still alive, a static list script has dropped must not go on
+    /// holding the wrappers it cached. This is what fails if the cache is ever moved off the wrapper — onto
+    /// the realm, or onto a table keyed by anything the engine outlives.
+    /// </summary>
+    [Test]
+    [NonParallelizable]
+    public void ACacheDoesNotOutliveTheListInsideALivePage()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+        var (node, wrapper, _) = ReadAStaticNodeList(fixture, keepInAGlobal: false);
+
+        // The nodes leave the tree too: while the document holds them, their wrappers are reachable through
+        // the realm's table whatever this cache does, so detaching them is what makes the question about the
+        // cache.
+        fixture.Execute("document.getElementById('root').innerHTML = '';");
+
+        Collect();
+
+        wrapper.IsAlive.Should().BeFalse("the list that cached the wrapper is unreachable and the node has left the tree");
+        node.IsAlive.Should().BeFalse("nothing reaches the detached element any more");
+
+        GC.KeepAlive(fixture);
+    }
+
+    /// <summary>
+    /// Builds a whole page, reads one element out of a static <c>NodeList</c>, and hands back weak references
+    /// to the AngleSharp element, its wrapper and the list — keeping no strong reference to any of them, nor
+    /// to the fixture. <c>NoInlining</c> so nothing stays rooted in the caller's frame.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Node, WeakReference Wrapper, WeakReference List) BuildAndDropAPageWithAStaticNodeList()
+    {
+        using var fixture = DomTestFixture.Create(Page);
+        return ReadAStaticNodeList(fixture, keepInAGlobal: false);
+    }
+
+    /// <summary>
+    /// Reads <c>querySelectorAll('.foo')[0]</c> on <paramref name="fixture"/> and weakly observes the element,
+    /// its wrapper and the list.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Node, WeakReference Wrapper, WeakReference List) ReadAStaticNodeList(
+        DomTestFixture fixture,
+        bool keepInAGlobal)
+    {
+        WeakReference? wrapper = null;
+        WeakReference? list = null;
+
+        fixture.Engine.SetValue("observe", new Action<JsValue, JsValue>((element, nodeList) =>
+        {
+            wrapper ??= new WeakReference(element);
+            list ??= new WeakReference(nodeList);
+        }));
+
+        fixture.Execute($$"""
+            var kept = null;
+            (function () {
+                var l = document.querySelectorAll('.foo');
+                observe(l[0], l);
+                {{(keepInAGlobal ? "kept = l;" : "")}}
+            })();
+            """);
+
+        var node = new WeakReference(fixture.Document.QuerySelector(".foo")!);
+        return (node, wrapper!, list!);
+    }
+
+    private static void Collect()
+    {
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+    }
+}

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -1542,6 +1542,30 @@
       "reason": "The Element spelling invokes the same live namespace/local-name collection algorithm as Document."
     },
     {
+      "interface": "Document",
+      "member": "querySelectorAll",
+      "half": "operation",
+      "hook": "QuerySelectorAll",
+      "returns": true,
+      "reason": "DOM 4.2.6 makes the result the STATIC result of scope-match, and AngleSharp's QueryCollection already is a snapshot -- so this hook corrects no behaviour and exists to put the standard's word where the binding can act on it. Nothing about an INodeList says whether it is live (childNodes and labels are, this is not), so the hook wraps the match in DomStaticNodeList, whose staticness is a property of the type; that is what lets DomStaticNodeListObject keep one element wrapper per index instead of probing the realm's wrapper table on every list[j]. See sebastienros/jint#4013."
+    },
+    {
+      "interface": "DocumentFragment",
+      "member": "querySelectorAll",
+      "half": "operation",
+      "hook": "QuerySelectorAll",
+      "returns": true,
+      "reason": "The fragment spelling of the same ParentNode operation, and the same static result."
+    },
+    {
+      "interface": "Element",
+      "member": "querySelectorAll",
+      "half": "operation",
+      "hook": "QuerySelectorAll",
+      "returns": true,
+      "reason": "The element spelling of the same ParentNode operation, and the same static result."
+    },
+    {
       "interface": "HTMLImageElement",
       "member": "complete",
       "half": "getter",


### PR DESCRIPTION
A per-collection cache of element wrappers for **static** node lists, so a repeated `list[j]` answers from an array instead of the realm's weak table.

The lead's ultra profile on [#4013](https://github.com/sebastienros/jint/issues/4013) measured the loop `for (j = 0; j < nodeList.length; j++) if (nodeList[j] === el)` over a 100-element `querySelectorAll` result — the shape `dom/nodes/support/NodeList-static-length-tampered.js` compiles. On net8.0, `DomAccessorNodeList.TryGetIndex` was **14.2 % of the page-loop thread** inclusive: `ConditionalWeakTable.FindEntry` 8.9 %, `ChkCastInterface` 0.7 %, its own body 4.4 %. [#4002](https://github.com/sebastienros/jint/pull/4002) removed the `length` read's cost; this is the element read.

## Mechanism

`nodeList[j]` went `DomCollectionObject.TryGetIndex` → `DomAccessorNodeList.TryGetIndex` → `DomRealm.WrapNodeValue` → `WrapNode` → `ConditionalWeakTable.TryGetValue` on `DomRealm._wrappers`, **on every read of every index**, so a 100-element scan re-derived a hundred wrappers it had already derived on the previous pass.

Three pieces:

* **`DomStaticNodeList`** (`Jint.Browser/Dom/Collections/`) — an `INodeList` that holds the matched nodes in an `INode[]` copied at construction. It is the mirror image of the existing `DomLiveHtmlCollection`, which exists because AngleSharp answers a snapshot where DOM wants a live collection; here the standard wants the snapshot, and the binding owns one anyway so that *staticness is a property of a type*.
* **`DomStaticNodeListObject : DomCollectionBase`** — its wrapper, with an `ObjectInstance?[]` filled lazily from `DomRealm.WrapNode` on each index's first read. The array itself is allocated on the first indexed read, so a match a page only takes the `length` of costs nothing for it.
* **A `querySelectorAll` hook** (`overrides.json` → `DomHostHooks.QuerySelectorAll`), on `Document`, `DocumentFragment` and `Element`. It corrects no behaviour — AngleSharp's `QueryCollection` already is a snapshot. It exists to put DOM §4.2.6's word *"static"* where the binding can act on it. Regenerated with `JINT_DOM_BINDINGS=update`; the generated diff is three lines.

## Where static and live are known — the seam

They were **not** distinguished before this change, and that is the whole difficulty: **nothing about an `INodeList` says whether it is live.** All three of these reached `DomCollectionObject` + `DomAccessorNodeList`:

| producer | AngleSharp type | live? |
| --- | --- | --- |
| `node.childNodes` | `AngleSharp.Dom.NodeList` | **live** |
| `control.labels` | `DomLabelNodeList` (ours) | **live** |
| `x.querySelectorAll(s)` | `AngleSharp.Dom.QueryCollection` | static |

Deciding it from the target's CLR type was the tempting shortcut and is a cliff: `QueryCollection` is `internal sealed`, and the only public fact separating it from the live `NodeList` is that it also implements `IHtmlCollection<IElement>` — a coincidence of AngleSharp's class hierarchy, not a promise about liveness, and one a future AngleSharp could break in silence. So the seam is expressed the other way round: the binding constructs the snapshot itself, from the one operation whose specification says the result is static, and the type it constructs is what the cache keys on.

**Live collections are deliberately untouched by this PR**, and `OnlyASelectorMatchTakesTheStaticLane` pins that: `childNodes` and `labels` keep the accessor-driven wrapper and keep reporting the tree they currently have. A per-index memo over a membership that moves would answer the wrong node, and a removed node it had cached would be pinned for the collection's life. Caching a live collection would need a membership version to key on, and that is a separate change.

## Why it is safe

Each claim is verifiable in the code:

* **Identity cannot move.** The cached value *is* the canonical wrapper: it comes from `DomRealm.WrapNode`, which is the one door onto `DomRealm._wrappers` (`Jint.Browser/Dom/DomRealm.cs`), so the array is a memo of a lookup and never a source of objects. `list[0] === list[0]`, `list[0] === document.querySelector(…)` and `listA[0] === listB[0]` hold by construction.
* **It adds no retention.** A static `NodeList` holds strong references to its nodes — `QueryCollection` holds a `List<IElement>`, `DomStaticNodeList` holds the `INode[]` copied from it — and the wrapper reaches them through its own `DomTarget`. `DomRealm._wrappers` is a `ConditionalWeakTable` keyed on the node, so **a node's wrapper is already kept alive exactly as long as the node is**. The cache therefore names only objects the list was keeping reachable anyway, and the array dies with the wrapper.
* **It is per collection-wrapper instance.** An `ObjectInstance` belongs to one engine and one realm, so the cache lives on the wrapper (per engine) while the node array lives on the snapshot (engine-free). Nothing is shared between engines.
* **`Delete`, `DefineOwnProperty`, `Set`, both key enumerations and the probe are still `ArrayLikeObject`'s**, derived from `Length` and `TryGetIndex`, and `HasIndex` is overridden to agree with `TryGetIndex` at the same instant. Verified on every read under `JINT_HOST_CONTRACT_VERIFICATION=1`.

The wrapper also answers the other half of the profile: the target is a typed `INode[]` field rather than `object` + a per-read interface cast, and there is no `DomCollectionAccessor` virtual call, because this shape has exactly one interface behind it. `DomCollectionAccessor`'s own `object` parameter is unchanged and has to stay — one process-shared singleton serves every engine and every CLR target type of its interface, which is why there is one collection wrapper class rather than twenty.

## Tests

`Jint.Tests.Browser/Dom/StaticNodeListTests.cs`, 11 cases. Green on **net8.0 and net10.0**, and again under **`JINT_HOST_CONTRACT_VERIFICATION=1`** (2688 / 2684 passing, 0 failed, on each leg in each configuration).

**Failing-first.** Only one of them fails against the unfixed code, and that is the honest result rather than a gap: the change is meant to move nothing observable, so the identity, removal, out-of-range and tampered-length tests are regression guards that pass on both sides. Verified by reverting the three generated call sites and re-running: `OnlyASelectorMatchTakesTheStaticLane` failed, the other ten passed.

The two retention tests were checked the other way, since they also pass on both sides. A deliberate leak — a `static List<object>` holding each cache array, introduced, run and reverted — failed `DroppingTheListAndThePageCollectsTheNodesAndTheirWrappers` **and** `ACacheDoesNotOutliveTheListInsideALivePage`, so both have teeth against exactly the mistake they are there to catch. They are reachability questions rather than heap readings, for the reason `Jint.Tests.Runtime.GarbageCollectionTests` records, and each has a control that keeps the page and the list and requires the same objects to survive.

What they cover: identity across repeated reads and expandos; a cached element against `querySelector`, `getElementById`, the tree and a second list; a removed node still answering the same wrapper from the list that matched it, beside the live `childNodes` that does change; out-of-range (`undefined` from an index, `null` from `item()`, `in`/`hasOwnProperty`/`Object.keys`); `instanceof NodeList`, `@@toStringTag`, `Symbol.iterator`, spread, `Array.from`, `forEach` and `Array.prototype.indexOf`; and the tampered-`length` shape of the six wpt documents in miniature, in both the hand-written-loop and the `Array.prototype.indexOf` spellings.

The six `dom/nodes/NodeList-static-length-getter-tampered*.html` documents were run before and after through the browser lane and pass in both. **Their wall-clock times are not a measurement** and are not quoted here: they are a test-runner figure from a machine that was also compiling, on a document whose work is dominated by a harness. The lead owns measurement.

## Benchmark row — written, not run

`Jint.Benchmark/BrowserNodeListBenchmark.cs`. `Jint.Benchmark` **can** reference `Jint.Browser` — it already does, for `BrowserLayoutBenchmark` — so the row lives in the same project as every other row rather than in a browser-side benchmark project (there is none; `tools/browser-comparison` measures other engines).

It runs the wpt loop shape over a real `Page`: 100 spans, the match at index 50, `break` on the match, 100 passes an operation. Four rows, one `Page` and therefore one engine and one document each, warmed with that row's own loop and nothing else, page construction and the HTML parse outside the measurement:

* `StaticNodeList` — the row the change is about.
* `StaticNodeListTamperedLength` — the same list after the page defines an own `length` accessor answering the same count, so the pristine-length lane must decline and the loop still does the same work. What is left in the delta is the element read.
* `LiveNodeList` — the same loop over `childNodes`; the control that must not move.
* `PlainArray` — the baseline and the floor, over `Array.from(list)`.

**No benchmark and no profiler was run.** The four row scripts were each checked for correct answers (index 50, length 100) by evaluating them once on a real page through `jint-browser eval`, which is a correctness check and not a timing.

## Doubts

* The row sizes (`Passes = 100`, 100 elements) are a guess at "long enough to measure, short enough to repeat" and may want adjusting once the lead sees the first table.
* `DomStaticNodeList` copies the match into an `INode[]` rather than holding AngleSharp's collection. That is a deliberate second array per `querySelectorAll` — beside the `List<IElement>` the match already built — bought because holding the collection would make the staticness claim rest on the hook being its only caller, and `DomLiveHtmlCollection` is itself an `IHtmlCollection<IElement>` that would compile there.
* `MutationRecord.addedNodes` / `removedNodes` are static per DOM too and are **not** covered here; they keep the accessor-driven wrapper.
* The live lane still pays the `object` + interface cast per read. Making `DomCollectionAccessor` typed would touch twenty generated classes and is not attempted here.
* `Jint.Tests.Browser/Wpt/README.md` still says the six tampered documents "are not vendored"; they are vendored and are cases (`MinimumTests`) since #3875. Not touched — it is someone else's sentence to correct.

Refs #4013 and #3947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
