### PR TITLE
Custom elements: a clone is created with the element's is value, and the already-constructed marker is a TypeError

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -257,7 +257,13 @@ that never mentions `customElements` builds no registry at all and pays for none
   is HTML's `HTMLElement` constructor and the only `new` that object ever answers; and a parser-created
   element is **upgraded**. `cloneNode` is re-declared too, so a clone of a custom element is one.
 - **The construction stack is the specification's**, which is what makes `super()` answer the element being
-  upgraded rather than a second one, and a constructor that reaches the base twice an `InvalidStateError`.
+  upgraded rather than a second one, and a constructor that reaches the base twice a `TypeError` — a plain
+  one, not a `DOMException`, which is the only refusal in that constructor a page reaches by constructing its
+  own class from inside its constructor.
+- **A clone carries the element's `is` *value*, not its `is` attribute.** DOM's clone creates the copy with
+  "node's is value", which `createElement(tag, { is })` and `new XY()` set without adding any attribute — so
+  `Cloned` walks the two trees in lockstep and copies the slot before the upgrade, and an element whose `is`
+  attribute says something else is the same rule read from the other side.
 
 **The `[CEReactions]` approximation, which is the one thing to know before changing any of it.** HTML
 processes the element queue when the outermost `[CEReactions]` operation returns to script. Nothing here can

--- a/Jint.Browser/CustomElements/CustomElementCreation.cs
+++ b/Jint.Browser/CustomElements/CustomElementCreation.cs
@@ -81,7 +81,7 @@ internal static class CustomElementCreation
         }
 
         Dom.Files.FileTransferRealm.ResetCopiedInputs(clone);
-        CustomElementRegistry.SubtreeCreated(realm, clone);
+        CustomElementRegistry.Cloned(realm, node, clone);
         return documentDefinition is null ? realm.WrapNodeValue(clone) : realm.Wrap(clone, documentDefinition);
     }
 

--- a/Jint.Browser/CustomElements/CustomElementRegistry.Construction.cs
+++ b/Jint.Browser/CustomElements/CustomElementRegistry.Construction.cs
@@ -46,8 +46,7 @@ internal sealed partial class CustomElementRegistry
         CustomElementDefinition definition,
         ObjectInstance newTarget)
     {
-        var engine = _runtime.Engine;
-        var realm = engine._mainRealm;
+        var realm = _runtime.Engine._mainRealm;
 
         // Step 5, both branches at once: an autonomous element's definition records HTMLElement and a
         // customized built-in's records the interface its local name maps to, so "the interface of the
@@ -77,13 +76,14 @@ internal sealed partial class CustomElementRegistry
         var last = definition.ConstructionStack.Count - 1;
         var wrapper = definition.ConstructionStack[last];
 
+        // "If element is an already constructed marker, then throw a TypeError." A plain TypeError and not a
+        // DOMException: this is the one refusal in the HTML element constructor that a page reaches by
+        // constructing its own class again from inside its constructor, and the corpus asserts the name.
         if (wrapper is null)
         {
-            var error = realm.Intrinsics.DomException.CreateException(
-                DomExceptionNames.InvalidState,
+            Throw.TypeError(
+                realm,
                 "Failed to construct '" + definition.Name + "': the element has already been constructed.");
-            var location = engine._lastSyntaxElement?.Location ?? default;
-            Throw.JavaScriptException(engine, error, in location);
         }
 
         definition.ConstructionStack[last] = null;

--- a/Jint.Browser/CustomElements/CustomElementRegistry.Tree.cs
+++ b/Jint.Browser/CustomElements/CustomElementRegistry.Tree.cs
@@ -166,6 +166,67 @@ internal sealed partial class CustomElementRegistry
         registry.UpgradeSubtree(root);
         registry.Drain();
     }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-node-clone: a copy is created with <b>node's is value</b>, and
+    /// then upgraded the way <see cref="SubtreeCreated"/> upgrades anything else a member just made.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The is value is a slot, not the <c>is</c> content attribute</b>, and the difference is the whole
+    /// of this method. <c>document.createElement('button', { is: 'x-y' })</c> and <c>new XY()</c> set the
+    /// slot and add no attribute, so AngleSharp's clone — which copies attributes and nothing else — handed
+    /// back an element with no way to find its definition, and <c>customized.cloneNode()</c> answered a plain
+    /// built-in. An element whose <c>is</c> attribute says something <i>else</i> is the same rule read from
+    /// the other side: the slot wins, and DOM says so.
+    /// </para>
+    /// <para>
+    /// The two trees are walked in lockstep rather than the copy alone, because only the source knows what
+    /// each element's slot held. An explicit stack for the reason <see cref="Walk"/> has one — the depth is
+    /// a stranger's document — and pairing by index is what AngleSharp's own clone produces.
+    /// </para>
+    /// </remarks>
+    internal static void Cloned(Dom.DomRealm realm, INode source, INode copy)
+    {
+        if (Of(realm.Engine) is not { } registry)
+        {
+            return;
+        }
+
+        registry.CarryIsValues(source, copy);
+
+        if (registry.HasDefinitions)
+        {
+            registry.UpgradeSubtree(copy);
+            registry.Drain();
+        }
+    }
+
+    private void CarryIsValues(INode source, INode copy)
+    {
+        var pending = new Stack<(INode Source, INode Copy)>();
+        pending.Push((source, copy));
+
+        while (pending.Count > 0)
+        {
+            var (from, to) = pending.Pop();
+
+            if (from is IElement element
+                && to is IElement clone
+                && TryGetRecord(element) is { IsValue: { } isValue })
+            {
+                RecordFor(clone).IsValue = isValue;
+            }
+
+            var sources = from.ChildNodes;
+            var copies = to.ChildNodes;
+
+            for (var i = Math.Min(sources.Length, copies.Length) - 1; i >= 0; i--)
+            {
+                pending.Push((sources[i], copies[i]));
+            }
+        }
+    }
 }
 
 /// <summary>

--- a/Jint.Tests.Browser/CustomElements/CustomElementTests.cs
+++ b/Jint.Tests.Browser/CustomElements/CustomElementTests.cs
@@ -219,7 +219,7 @@ public sealed class CustomElementTests
     }
 
     [Test]
-    public async Task ReachingTheBaseConstructorTwiceDuringAnUpgradeIsAnInvalidStateError()
+    public async Task ReachingTheBaseConstructorTwiceDuringAnUpgradeIsATypeError()
     {
         await using var browser = new Browser();
         var page = await PageWith(browser,
@@ -240,7 +240,7 @@ public sealed class CustomElementTests
         // The upgrade put the element on the construction stack and `super()` replaced it with the
         // already-constructed marker, which is what the second reach finds. A `new Thing()` outside an
         // upgrade has an empty stack and makes a second element instead, exactly as a browser does.
-        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("InvalidStateError");
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("TypeError");
     }
 
     [Test]

--- a/Jint.Tests.Browser/CustomElements/CustomElementUpgradeTests.cs
+++ b/Jint.Tests.Browser/CustomElements/CustomElementUpgradeTests.cs
@@ -182,4 +182,49 @@ public sealed class CustomElementUpgradeTests
         (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("ctor|count:1");
         page.Errors.Should().NotBeEmpty();
     }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors: "if element is an already
+    /// constructed marker, then throw a <b>TypeError</b>" — a plain one, not a <c>DOMException</c>, which is
+    /// what a constructor constructing its own class reaches whichever side of <c>super()</c> it does it on.
+    /// </summary>
+    [TestCase("after")]
+    [TestCase("before")]
+    public async Task AConstructorThatConstructsItsOwnClassGetsATypeError(string side)
+    {
+        await using var browser = new Browser();
+        var body = side == "after"
+            ? """
+              <x-self></x-self>
+              <script>
+                window.name_ = '';
+                window.onerror = function (message, url, line, column, error) { window.name_ = error.name; return true; };
+                class SelfAfter extends HTMLElement {
+                  constructor(doNotCreateItself) {
+                    super();
+                    if (!doNotCreateItself) { new SelfAfter(true); }
+                  }
+                }
+                customElements.define('x-self', SelfAfter);
+              </script>
+              """
+            : """
+              <x-self></x-self>
+              <script>
+                window.name_ = '';
+                window.onerror = function (message, url, line, column, error) { window.name_ = error.name; return true; };
+                class SelfBefore extends HTMLElement {
+                  constructor(doNotCreateItself) {
+                    if (!doNotCreateItself) { new SelfBefore(true); }
+                    super();
+                  }
+                }
+                customElements.define('x-self', SelfBefore);
+              </script>
+              """;
+
+        var page = await PageWith(browser, body);
+
+        (await page.EvaluateAsync<string>("window.name_")).Should().Be("TypeError");
+    }
 }

--- a/Jint.Tests.Browser/CustomElements/CustomizedBuiltInTests.cs
+++ b/Jint.Tests.Browser/CustomElements/CustomizedBuiltInTests.cs
@@ -144,4 +144,61 @@ public sealed class CustomizedBuiltInTests
         (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("attr|ok");
         page.Errors.Should().BeEmpty();
     }
+
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-node-clone creates the copy with <b>node's is value</b> — the
+    /// slot <c>createElement(tag, { is })</c> and <c>new XY()</c> set without adding any attribute — so a
+    /// clone of a customized built-in is one, and an <c>is</c> attribute saying something else does not win.
+    /// </summary>
+    [Test]
+    public async Task ACloneOfACustomizedBuiltInFollowsTheIsValueAndNotTheIsAttribute()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              class One extends HTMLButtonElement {}
+              class Two extends HTMLButtonElement {}
+              customElements.define('x-one', One, { extends: 'button' });
+              customElements.define('x-two', Two, { extends: 'button' });
+
+              const created = document.createElement('button', { is: 'x-one' });
+              const constructed = new One();
+              const inconsistent = document.createElement('button', { is: 'x-one' });
+              inconsistent.setAttribute('is', 'x-two');
+
+              window.result = [
+                created.cloneNode() instanceof One,
+                constructed.cloneNode() instanceof One,
+                inconsistent.cloneNode() instanceof One,
+                inconsistent.cloneNode() instanceof Two
+              ].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.result")).Should().Be("true|true|true|false");
+        page.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>A deep clone carries the is value of every element it copies, not just the root.</summary>
+    [Test]
+    public async Task ADeepCloneCarriesTheIsValueOfEveryElementItCopies()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              class Fancy extends HTMLButtonElement {}
+              customElements.define('x-fancy', Fancy, { extends: 'button' });
+              const host = document.getElementById('host');
+              host.appendChild(document.createElement('button', { is: 'x-fancy' }));
+              const copy = host.cloneNode(true);
+              window.result = [copy.firstChild instanceof Fancy, copy.firstChild.localName].join('|');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.result")).Should().Be("true|button");
+        page.Errors.Should().BeEmpty();
+    }
 }

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -37,11 +37,11 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `html/webappapis/scripting/events/` | 12 | 0 | 37 | 2 |
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
 | `html/semantics/embedded-content/the-img-element/` | 4 | 0 | 99 | 0 |
-| `custom-elements/` | 16 | 0 | 513 | 235 |
+| `custom-elements/` | 16 | 0 | 513 | 13 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
-| `custom-elements/upgrading/` | 2 | 0 | 7 | 3 |
-| **total** | **365** | **9** | **66,794** | **1,077** |
+| `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
+| **total** | **365** | **9** | **66,794** | **852** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes
@@ -157,7 +157,7 @@ table, now for the narrower reason: they are the ones about adoption, cross-real
 reaction queue. Re-vendoring against the window is a change of its own, because it moves the census's
 Documents and Tests columns.
 
-What the rest found is six causes, and every exclusion in the four new suites is one of them:
+What the rest found is five causes, and every exclusion in the four new suites is one of them:
 
 1. **The parser upgrades a custom element where HTML constructs one.** AngleSharp creates a parser element
    with no notification to hook, so `<my-el>` in the markup is undefined until the driver's next script
@@ -190,9 +190,16 @@ What the rest found is six causes, and every exclusion in the four new suites is
 5. **AngleSharp's CSS serialization**, already recorded as a divergence: `reactions/CSSStyleDeclaration.html`
    compares the style attribute the reaction reported against `"color: blue;"` and gets
    `"color: rgba(0, 0, 255, 1)"`. The reaction fired; the value did not match.
-6. **`builtin-coverage.html`'s two hundred and twenty rows** are the `'new'` and `createElement` halves of a
-   table over every HTML local name. Its `innerHTML` and parser halves pass for all one hundred and eight
-   tags, which is what says the customized-built-in path itself works.
+
+**`builtin-coverage.html` is green now**, all four hundred and forty-four rows of it. Its `'new'` and
+`createElement` halves were two hundred and twenty-two rows of one defect, and the defect was not the
+customized-built-in path at all — its `innerHTML` and parser halves always passed. Every one of those rows
+failed on `customized.cloneNode().constructor`: DOM creates a clone with the element's **is value**, which is
+a slot that `createElement(tag, { is })` and `new XY()` set without adding an attribute, and AngleSharp's
+clone copies attributes and nothing else. So the two halves that set the slot cloned into a plain built-in
+and the two that write the `is` attribute in markup did not. `custom-elements/upgrading/`'s own row was the
+same rule read from the other side — a clone must follow the slot even when the `is` attribute says
+something else — and it went with it.
 
 Two more things the corpus found are **not** defects and are recorded where they belong instead.
 `Element.insertAdjacentText` is missing, which upstream's own result renderer calls — the overlay turns the

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -1012,13 +1012,6 @@ internal static class WptBrowserExclusions
         new("custom-elements/reaction-timing.html", "*", WptDivergence.NeedsTriage),
     ];
 
-    // ---------------------------------------------------------------- the customized built-in table
-    private static readonly WptExclusion[] _theCustomizedBuiltInTable =
-    [
-        new("custom-elements/builtin-coverage.html", "*: Operator 'new' should instantiate a customized built-in element", WptDivergence.NeedsTriage),
-        new("custom-elements/builtin-coverage.html", "*: document.createElement() should instantiate a customized built-in element", WptDivergence.NeedsTriage),
-    ];
-
     // ---------------------------------------------------------------- the parser
     private static readonly WptExclusion[] _theParser =
     [
@@ -1030,14 +1023,6 @@ internal static class WptBrowserExclusions
         new("custom-elements/parser/parser-sets-attributes-and-children.html", "HTML parser should call connectedCallback before appending child nodes.", WptDivergence.NeedsTriage),
         new("custom-elements/parser/serializing-html-fragments-customized-builtins.html", "\"is\" value should be serialized even for an undefined element", WptDivergence.NeedsTriage),
         new("custom-elements/parser/serializing-html-fragments-customized-builtins.html", "\"is\" value should be serialized if the custom element has no \"is\" content attribute", WptDivergence.NeedsTriage),
-    ];
-
-    // ---------------------------------------------------------------- the upgrade
-    private static readonly WptExclusion[] _theUpgrade =
-    [
-        new("custom-elements/upgrading/Node-cloneNode-customized-builtins.html", "*", WptDivergence.NeedsTriage),
-        new("custom-elements/upgrading/upgrading-parser-created-element.html", "HTMLElement constructor must throw an TypeError when the top of the construction stack is marked AlreadyConstructed due to a custom element constructor constructing itself after super() call", WptDivergence.NeedsTriage),
-        new("custom-elements/upgrading/upgrading-parser-created-element.html", "HTMLElement constructor must throw an TypeError when the top of the construction stack is marked AlreadyConstructed due to a custom element constructor constructing itself before super() call", WptDivergence.NeedsTriage),
     ];
 
     // ---------------------------------------------------------------- one [CEReactions] member per file
@@ -1431,9 +1416,7 @@ internal static class WptBrowserExclusions
         new("a rendering", _aRendering),
         new("the registry, the constructor and the two creation members", _theRegistryTheConstructorAndTheTwoCreationMembers),
         new("the callbacks and when they run", _theCallbacksAndWhenTheyRun),
-        new("the customized built-in table", _theCustomizedBuiltInTable),
         new("the parser", _theParser),
-        new("the upgrade", _theUpgrade),
         new("one [CEReactions] member per file", _oneCEReactionsMemberPerFile),
         new("a frame that runs script", _aFrameThatRunsScript),
         new("relList on an element AngleSharp gives no interface", _relListOnAnElementAngleSharpGivesNoInterface),


### PR DESCRIPTION
Stacked on #4026 (`feat/custom-elements-registry`); the boundary commit is `8f14e685d`, and everything below is the second commit alone. Two mechanisms, and between them **two whole exclusion groups disappear** — `the upgrade` and `the customized built-in table`.

## The mechanisms

**1. A clone is created with the element's *is value*.** [DOM's clone-a-node](https://dom.spec.whatwg.org/#concept-node-clone) creates the copy given the node's local name, its namespace, its namespace prefix and **node's is value** — the internal slot, not the `is` content attribute. `document.createElement('button', { is: 'x-y' })` and `new XY()` set that slot and add no attribute, and AngleSharp's clone copies attributes and nothing else, so the copy had nothing a definition lookup could find and `customized.cloneNode()` answered a plain built-in. `CustomElementRegistry.Cloned` walks the source and the copy in lockstep (an explicit stack, for the reason `Walk` has one), copies the slot, and then upgrades the copy the way every other freshly created subtree is upgraded.

Read from the other side it is the same rule, and it is what `upgrading/Node-cloneNode-customized-builtins.html` is about: an element whose `is` **attribute** says something else still clones as what its **slot** says.

**2. The already-constructed marker is a `TypeError`.** [HTML's HTML element constructor steps](https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors): "if element is an already constructed marker, then throw a **TypeError**" — a plain one, not a `DOMException`. Jint threw `InvalidStateError`. That is the refusal a constructor reaches by constructing its own class from inside itself, on either side of `super()`, and the spec spells out both shapes in its own examples.

## Premise validation

Both rows of `the upgrade` and both globs of `the customized built-in table` were run on the unfixed tree first. Neither needed a parser notification and neither needed a second realm — and the customized built-in table turned out **not** to be about the customized built-in path at all. `builtin-coverage.html` is four subtests per HTML local name; its `innerHTML` and parser halves already passed for every one of the 111 tags, because markup writes the `is` attribute. What failed was the *same single assertion* in the `'new'` and `createElement` halves — `assert_equals(customized.cloneNode().constructor, klass, 'Cloning a customized built-in element should succeed.')` — for all 222 of them, because those two halves set the slot and no attribute. One defect, 222 rows.

## Failing-first evidence

Five new/changed test cases, run against the unfixed `Jint.Browser/CustomElements/` with the tests in place:

```
Failed!  - Failed: 5, Passed: 14, Skipped: 0, Total: 19
  Failed ACloneOfACustomizedBuiltInFollowsTheIsValueAndNotTheIsAttribute
  Failed ADeepCloneCarriesTheIsValueOfEveryElementItCopies
  Failed AConstructorThatConstructsItsOwnClassGetsATypeError("after")
  Failed AConstructorThatConstructsItsOwnClassGetsATypeError("before")
  Failed ReachingTheBaseConstructorTwiceDuringAnUpgradeIsATypeError
```

The last one is an existing test whose expectation was wrong: it asserted `InvalidStateError`, which is what the code did and not what HTML says. It is renamed and corrected here rather than left as a check that pins the defect.

The corpus, unfixed → fixed:

| document | before | after |
| --- | --- | --- |
| `custom-elements/builtin-coverage.html` | 222 FAIL, 222 PASS | **444 PASS** |
| `custom-elements/upgrading/Node-cloneNode-customized-builtins.html` | 1 FAIL | 1 PASS |
| `custom-elements/upgrading/upgrading-parser-created-element.html` | 2 FAIL, 4 PASS | 6 PASS |

## Exact exclusion delta

Two arrays are deleted outright, along with their two entries in `WptBrowserExclusions.Causes` (an empty cause is a failure of its own — `EveryRowNamesACauseAndEveryCauseIsNamedOnce` refuses one that holds no exclusion):

```
- the upgrade                      (3 rows)
    upgrading/Node-cloneNode-customized-builtins.html  "*"
    upgrading/upgrading-parser-created-element.html    "…AlreadyConstructed …after super() call"
    upgrading/upgrading-parser-created-element.html    "…AlreadyConstructed …before super() call"
- the customized built-in table    (2 globs, 222 tests)
    builtin-coverage.html  "*: Operator 'new' should instantiate a customized built-in element"
    builtin-coverage.html  "*: document.createElement() should instantiate a customized built-in element"
```

Nothing else in the table moves, and no row is added.

Census, re-run over the full `FullyQualifiedName~Jint.Tests.Browser.Wpt` filter with `JINT_WPT_BROWSER_CENSUS=update` and then checked: `custom-elements/` not passing **235 → 13**, `custom-elements/upgrading/` **3 → 0**, total **1,077 → 852**.

`Wpt/README.md`'s hand-written "What the custom element corpus says" section goes from six causes to five: cause 6 was `builtin-coverage.html`'s 220 rows, and the paragraph that replaces it says what those rows really were. The generated cause table is about the six DOM suites and is untouched.

## AngleSharp findings, recorded and not filed

None new. The one this leans on is already stated: AngleSharp's element carries no custom element state, which is why the is value lives in this package's `ConditionalWeakTable` side table and why a clone has to be told about it.

## A lead this turned up, not fixed here

`document.importNode` never upgrades. `DomHostHooks.ImportNode` clones through AngleSharp and adopts, but calls neither `SubtreeCreated` nor `Cloned`, so an imported custom element is not constructed and an imported customized built-in loses its is value — the same defect this pull request fixes for `cloneNode`, on the member DOM defines as "the result of cloning a node given node with document set to this". No vendored document currently fails on it, which is why it is a lead in the report rather than a change here.

## Verification

* `Jint.Tests.Browser` `-f net8.0`: 2,687 passed, 0 failed.
* `Jint.Tests.Browser` `-f net10.0`: 2,691 passed, 0 failed.
* `Jint.Tests.Browser` `-f net8.0` with `JINT_HOST_CONTRACT_VERIFICATION=1`: 2,687 passed, 0 failed.
* Census update and check runs over the full Wpt filter: both green.

Base: dd9b59102890863d1683d7c43fb068ebbf777fe0 (stacked on 8f14e685d)

Refs #3771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
