### PR TITLE
Custom elements: each drain takes the queue the reactions arrived on, which is HTML's reactions stack

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -273,9 +273,12 @@ Two channels deliver those arrivals and both run inline, for the reason
 [the observer section](#the-observers-and-when-each-of-them-delivers) gives: AngleSharp's mutation records
 say what entered and left the document, and its `IAttributeObserver` service says what attribute changed —
 the service and not the records, because a record needs the element to be under the observed document and
-`el.setAttribute` before insertion is the commonest thing a component does. What is deliberately **not**
-drained on arrival is a reaction that arrived on the parser's thread or while the queue was already
-draining: those wait for the enclosing drain, or for the microtask checkpoint. So
+`el.setAttribute` before insertion is the commonest thing a component does. **Each drain takes the queue the
+arrivals landed on and leaves a fresh one behind**, which is the reactions *stack* rather than one flat
+queue: an arrival during a callback is a queue of its own and runs before that callback returns, so a
+callback that writes an attribute on a second element sees that element's callback run *inside* its own. What
+is deliberately **not** drained on arrival is a reaction that arrived on the parser's thread: those wait for
+the microtask checkpoint. So
 `el.setAttribute('x', 1); assert(calls === 1)` holds as it does in a browser, and a reaction from a mutation
 inside a *host* operation — one the page loop makes with no script to return to — runs at the checkpoint
 rather than before that operation returns.

--- a/Jint.Browser/CustomElements/CustomElementRegistry.Reactions.cs
+++ b/Jint.Browser/CustomElements/CustomElementRegistry.Reactions.cs
@@ -12,12 +12,14 @@ namespace Jint.Browser.CustomElements;
 /// <remarks>
 /// <para>
 /// <b>The queue is HTML's and the drain points are this package's approximation of <c>[CEReactions]</c>.</b>
-/// HTML processes the element queue when the outermost <c>[CEReactions]</c> operation returns to script;
-/// nothing here can see a generated member return, so the queue is drained at the moment a reaction
-/// <i>arrives</i> instead — which, for everything a script does, is inside the DOM call that caused it and
-/// therefore before that call returns. What is deliberately not drained there is a reaction that arrived on
-/// the parser thread or while the queue was already draining; those wait for the enclosing drain or for the
-/// checkpoint. <c>Jint.Browser/AGENTS.md</c> states the approximation and what it costs.
+/// HTML pushes an element queue for every <c>[CEReactions]</c> operation and processes it when that
+/// operation returns to script; nothing here can see a generated member return, so the queue is drained at
+/// the moment a reaction <i>arrives</i> instead — which, for everything a script does, is inside the DOM
+/// call that caused it and therefore before that call returns. Each drain takes the queue the arrivals
+/// landed on and leaves a fresh one, so an arrival <i>during</i> a callback is its own queue and runs before
+/// that callback returns, which is what the stack buys. What is deliberately not drained on arrival is a
+/// reaction that arrived on the parser thread, which waits for the checkpoint.
+/// <c>Jint.Browser/AGENTS.md</c> states the approximation and what it costs.
 /// </para>
 /// <para>
 /// The two-level shape — an element queue of elements, each with its own reaction queue — is the
@@ -28,9 +30,8 @@ namespace Jint.Browser.CustomElements;
 /// </remarks>
 internal sealed partial class CustomElementRegistry
 {
-    private readonly List<IElement> _elementQueue = [];
+    private List<IElement> _elementQueue = [];
     private readonly Action _checkpoint;
-    private bool _draining;
     private bool _scheduled;
 
     /// <summary>The record <paramref name="element"/> already has, or <see langword="null"/>.</summary>
@@ -147,11 +148,27 @@ internal sealed partial class CustomElementRegistry
     /// whole element queue.
     /// </summary>
     /// <remarks>
-    /// A reaction that arrives from another thread — the parser's — or while this is already running is left
-    /// on the queue; the enclosing drain picks it up, and if there is none, the checkpoint job does. The
-    /// queue itself needs no lock for that: the parser baton parks one holder while the other works, so the
-    /// parser thread and the loop are never both inside this class, which is the same property
-    /// <c>Observers/MutationObserverLane</c> rests on.
+    /// <para>
+    /// <b>Each drain takes the queue the arrivals landed on and leaves a fresh one behind</b>, which is this
+    /// package's reading of HTML's custom element reactions <i>stack</i>: every <c>[CEReactions]</c>
+    /// operation pushes an element queue and invokes it when that operation returns, so a reaction caused
+    /// from inside a callback belongs to a queue of its own and runs <i>before</i> that callback returns.
+    /// Draining one flat queue instead made a nested reaction wait for the enclosing one, and
+    /// <c>reaction-timing.html</c> is three tests about exactly that difference: a callback that writes an
+    /// attribute on a second element sees that element's callback run inside its own, not after it.
+    /// </para>
+    /// <para>
+    /// An element already on a queue is not added to another — <see cref="CustomElementRecord.Queued"/> is
+    /// what says so — so a reaction that arrives for it while it waits joins its own reaction queue and runs
+    /// when the queue holding it reaches it. That is also what makes a reaction added for the element
+    /// <i>being invoked</i> run before the next element's, which is the specification's own note.
+    /// </para>
+    /// <para>
+    /// A reaction that arrives from another thread — the parser's — is still left on the queue for the
+    /// checkpoint job, because nothing may run script there. The queue itself needs no lock for that: the
+    /// parser baton parks one holder while the other works, so the parser thread and the loop are never both
+    /// inside this class, which is the same property <c>Observers/MutationObserverLane</c> rests on.
+    /// </para>
     /// </remarks>
     internal void Drain()
     {
@@ -160,39 +177,32 @@ internal sealed partial class CustomElementRegistry
             return;
         }
 
-        if (_draining || Environment.CurrentManagedThreadId != _runtime.LoopThreadId)
+        if (Environment.CurrentManagedThreadId != _runtime.LoopThreadId)
         {
             Schedule();
             return;
         }
 
-        _draining = true;
+        var queue = _elementQueue;
+        _elementQueue = [];
 
-        try
+        for (var i = 0; i < queue.Count; i++)
         {
-            while (_elementQueue.Count > 0)
+            var element = queue[i];
+
+            if (!_records.TryGetValue(element, out var record))
             {
-                var element = _elementQueue[0];
-                _elementQueue.RemoveAt(0);
-
-                if (!_records.TryGetValue(element, out var record))
-                {
-                    continue;
-                }
-
-                // Queued stays set for the whole of this element's own queue, so a reaction the callbacks add
-                // for the same element joins the loop below rather than putting it on the queue a second time.
-                while (record.Reactions.Count > 0)
-                {
-                    Invoke(element, record.Reactions.Dequeue());
-                }
-
-                record.Queued = false;
+                continue;
             }
-        }
-        finally
-        {
-            _draining = false;
+
+            // Queued stays set for the whole of this element's own queue, so a reaction the callbacks add
+            // for the same element joins the loop below rather than putting it on a queue a second time.
+            while (record.Reactions.Count > 0)
+            {
+                Invoke(element, record.Reactions.Dequeue());
+            }
+
+            record.Queued = false;
         }
     }
 

--- a/Jint.Tests.Browser/CustomElements/CustomElementReactionTests.cs
+++ b/Jint.Tests.Browser/CustomElements/CustomElementReactionTests.cs
@@ -221,4 +221,83 @@ public sealed class CustomElementReactionTests
         (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("attr:one|sync:1");
         (await page.EvaluateAsync<string>("document.querySelector('x-thing').className")).Should().Be("one");
     }
+
+    /// <summary>
+    /// https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reactions-stack: every
+    /// <c>[CEReactions]</c> operation pushes an element queue of its own, so a reaction a callback causes
+    /// runs <b>inside</b> that callback and not after it.
+    /// </summary>
+    [Test]
+    public async Task AReactionCausedInsideACallbackRunsBeforeThatCallbackReturns()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.order = [];
+              class Thing extends HTMLElement {
+                static get observedAttributes() { return ['data-title', 'title']; }
+                attributeChangedCallback() { this.handler(); }
+                handler() { }
+              }
+              customElements.define('x-thing', Thing);
+
+              const first = document.createElement('x-thing');
+              const second = document.createElement('x-thing');
+              first.id = 'first';
+              second.id = 'second';
+              first.handler = function () {
+                window.order.push(this.id + ':begin');
+                second.setAttribute('data-title', 'x');
+                window.order.push(this.id + ':end');
+              };
+              second.handler = function () {
+                window.order.push(this.id + ':begin');
+                window.order.push(this.id + ':end');
+              };
+              first.setAttribute('title', 'x');
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.order.join('|')"))
+            .Should().Be("first:begin|second:begin|second:end|first:end");
+        page.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The same stack seen through a constructor: a clone made inside a custom element constructor is
+    /// upgraded before the outer constructor returns.
+    /// </summary>
+    [Test]
+    public async Task ACloneMadeInsideAConstructorIsUpgradedBeforeThatConstructorReturns()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              let cloneNext = false;
+              let other;
+              class SelfCloning extends HTMLElement {
+                constructor() {
+                  super();
+                  const mark = window.log.length;
+                  window.log.push(mark + ':begin');
+                  if (cloneNext) { cloneNext = false; other.cloneNode(false); }
+                  window.log.push(mark + ':end');
+                }
+              }
+              customElements.define('x-self-cloning', SelfCloning);
+              const one = document.createElement('x-self-cloning');
+              other = document.createElement('x-self-cloning');
+              window.log = [];
+              cloneNext = true;
+              one.cloneNode(false);
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("0:begin|1:begin|1:end|0:end");
+        page.Errors.Should().BeEmpty();
+    }
 }

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -43,6 +43,11 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
 | **total** | **392** | **9** | **66,916** | **919** |
+| `custom-elements/` | 16 | 0 | 513 | 10 |
+| `custom-elements/parser/` | 8 | 0 | 20 | 11 |
+| `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
+| `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
+| **total** | **365** | **9** | **66,794** | **849** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -38,16 +38,11 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
 | `html/semantics/embedded-content/the-img-element/` | 4 | 0 | 99 | 0 |
 | `html/semantics/selectors/pseudo-classes/` | 27 | 0 | 122 | 68 |
-| `custom-elements/` | 16 | 0 | 513 | 13 |
-| `custom-elements/parser/` | 8 | 0 | 20 | 11 |
-| `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
-| `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
-| **total** | **392** | **9** | **66,916** | **919** |
 | `custom-elements/` | 16 | 0 | 513 | 10 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
-| **total** | **365** | **9** | **66,794** | **849** |
+| **total** | **392** | **9** | **66,916** | **916** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -1039,11 +1039,15 @@ internal static class WptBrowserExclusions
     ];
 
     // ---------------------------------------------------------------- the callbacks and when they run
+    // Both rows are the parser's, and they are the same cause README.md's first custom-element cause names:
+    // AngleSharp builds a parser element with no notification to hook, so an element written in the markup is
+    // upgraded at the driver's next boundary instead of constructed with an empty JavaScript stack. The two
+    // things this document asks about are what only that difference can answer -- a microtask checkpoint that
+    // runs inside the constructor, and the HTMLUnknownElement a failed *synchronous* construction leaves.
     private static readonly WptExclusion[] _theCallbacksAndWhenTheyRun =
     [
         new("custom-elements/microtasks-and-constructors.html", "Microtasks evaluate immediately when the stack is empty inside the parser", WptDivergence.NeedsTriage),
         new("custom-elements/microtasks-and-constructors.html", "Microtasks evaluate immediately when the stack is empty inside the parser, causing the checks on no attributes to fail", WptDivergence.NeedsTriage),
-        new("custom-elements/reaction-timing.html", "*", WptDivergence.NeedsTriage),
     ];
 
     // ---------------------------------------------------------------- the parser


### PR DESCRIPTION
Stacked on #4029 (`feat/custom-elements-upgrade`), which is itself stacked on #4026; the boundary commit is `29cee868c` and everything below is the third commit alone.

## The mechanism

[HTML's custom element reactions stack](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reactions-stack) pushes a **new element queue** for every `[CEReactions]` operation and invokes that queue when the operation returns, so a reaction a callback causes belongs to a queue of its own and runs *before* that callback returns.

This package cannot see a generated member return, so it drains at the moment a reaction **arrives** — which for everything a script does is inside the DOM call that caused it. That approximation was right; the queue under it was not. One flat `List<IElement>` plus a `_draining` re-entrancy guard meant a nested arrival was *left* for the enclosing drain, so:

```js
first.handler  = function () { order.push('first:begin');  second.setAttribute('data-title','x'); order.push('first:end'); };
second.handler = function () { order.push('second:begin'); order.push('second:end'); };
first.setAttribute('title', 'x');
```

gave `first:begin | first:end | second:begin | second:end` where a browser gives `first:begin | second:begin | second:end | first:end`.

Each drain now **takes** the queue the arrivals landed on and leaves a fresh one behind, so the nested arrival's own `Drain()` runs it immediately and the guard is gone. Two properties are kept deliberately:

* An element already on a queue is never added to a second one (`CustomElementRecord.Queued`), so a reaction that arrives for an element still waiting joins that element's own reaction queue — which is what keeps [the specification's own note](https://html.spec.whatwg.org/multipage/custom-elements.html#invoke-custom-element-reactions) true, that an element gaining a second reaction while its first runs runs both before the next element's.
* A reaction arriving on the **parser's** thread still waits for the microtask checkpoint, because nothing may run script there. Only the "already draining" half of the old condition is removed.

## Premise validation

The group is called "the callbacks and when they run" and had three rows. Run on the unfixed tree, they are **two different causes**, and only one of them is Jint's own §4.13:

* `reaction-timing.html` (`*`, 3 tests) is the reactions stack — this change. All three of its tests failed on the ordering, including the third, which is the same thing seen through a constructor: a clone made inside a custom element constructor must be upgraded before the outer constructor returns.
* `microtasks-and-constructors.html`'s two rows are **the parser's**, and stay. They are the cause `Wpt/README.md` already names first: AngleSharp builds a parser element with no notification to hook, so `<x-0>` in the markup is *upgraded at the driver's next boundary* rather than *constructed* with an empty JavaScript stack. The two things this document asks about are exactly what only that difference can answer — a microtask checkpoint that runs inside the constructor because the stack is empty, and the `HTMLUnknownElement` that [DOM's create-an-element](https://dom.spec.whatwg.org/#concept-create-element) step 6.1.3 leaves behind when a *synchronous* construction throws. Neither is reachable without a parser hook, so both rows now carry a comment saying so rather than sitting unexplained under `NeedsTriage`.

## Failing-first evidence

Two new `CustomElementReactionTests` cases, run against the unfixed `CustomElementRegistry.Reactions.cs` with the tests in place:

```
Failed!  - Failed: 2, Passed: 9, Skipped: 0, Total: 11
  Failed AReactionCausedInsideACallbackRunsBeforeThatCallbackReturns
  Failed ACloneMadeInsideAConstructorIsUpgradedBeforeThatConstructorReturns
```

The corpus, unfixed → fixed:

| document | before | after |
| --- | --- | --- |
| `custom-elements/reaction-timing.html` | 3 FAIL | 3 PASS |
| `custom-elements/microtasks-and-constructors.html` | 2 FAIL, 3 PASS | 2 FAIL, 3 PASS (unchanged, and now explained in the table) |

## Exact exclusion delta

One row removed from `_theCallbacksAndWhenTheyRun`, which keeps its name and its two remaining rows:

```
- custom-elements/reaction-timing.html  "*"
```

Nothing else moves. The comment added above the two survivors is the only other change to the table.

Census, re-run over the full `FullyQualifiedName~Jint.Tests.Browser.Wpt` filter with `JINT_WPT_BROWSER_CENSUS=update` and then checked: `custom-elements/` not passing **13 → 10**, total **852 → 849**.

## AngleSharp findings, recorded and not filed

None new. The one the two surviving rows rest on is already the first cause in `Wpt/README.md`'s custom-element section and already in `Jint.Browser/AGENTS.md`: AngleSharp's parser creates an element with no notification this package can hook.

## A note on re-entrancy

Removing the `_draining` guard makes the drain genuinely re-entrant, which is what a browser does — a callback that mutates the DOM runs the resulting callback inside itself, on the stack. A runaway page recursing that way meets the engine's own stack guard, the same one a runaway plain JavaScript recursion meets; nothing here converts it into a silent deferral any more, which was the previous behaviour and the defect.

## Verification

* `Jint.Tests.Browser` `-f net8.0`: 2,698 passed, 0 failed.
* `Jint.Tests.Browser` `-f net10.0`: 2,702 passed, 0 failed.
* `Jint.Tests.Browser` `-f net8.0` with `JINT_HOST_CONTRACT_VERIFICATION=1`: 2,698 passed, 0 failed.
* Census update and check runs over the full Wpt filter: both green.
* `Jint.Tests` `AgentInstructionFileTests`: green — `Jint.Browser/AGENTS.md` is 30,821 bytes against the 32 KiB cap.

Base: dd9b59102890863d1683d7c43fb068ebbf777fe0 (stacked on 29cee868c)

Refs #3771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
