### PR TITLE
Measure an image button's selected coordinate for a tap as well as a click: HTML §4.10.5.1.20

### DIFF
--- a/Jint.Browser/Events/AGENTS.md
+++ b/Jint.Browser/Events/AGENTS.md
@@ -116,11 +116,15 @@ everything else is the fallback submit button's (0, 0) — no `src`, a fetch tha
 `Media/ImageHeader` reads, `element.click()`, a dispatched `MouseEvent`, `requestSubmit`, a keyboard. Those
 are three conditions and `ActivationBehaviors.RunInput`'s image arm asks all three: `Media/PageImages` says
 *completely available*, the click says `isTrusted`, and `BrowserEventRealm.PendingImagePoint` says the
-pointer was measured inside **this** button. **That measurement is `InputDispatcher.DispatchMouse`'s, taken
-from the release's own hit test before `pointerup` fires**, because the activation behaviour that reads it
-runs after `pointerup`, `mouseup` and `click` and any of the three may move, adopt or detach the input first;
-measuring is not selecting, so a canceled click promotes nothing and leaves the coordinate the last
-activation selected. The result lives on the *element* — a weak table on `BrowserEventRealm`, beside the
+pointer was measured inside **this** button. **That measurement is taken from the release's own hit test
+before any listener fires**, because the activation behaviour that reads it runs after `pointerup`, `mouseup`
+and `click` and any of the three may move, adopt or detach the input first; measuring is not selecting, so a
+canceled click promotes nothing and leaves the coordinate the last activation selected. **A tap takes it
+too**, from the same hit test its compatibility mouse events are dispatched at: "activated using a pointing
+device" is the condition, and a finger is one, so `InputDispatcher.DispatchMouse`'s release arm and
+`InputDispatcher.Touch`'s compatibility sequence both park a point and both clear it in a `finally` — a
+coordinate a tap could not select while a click at the same point could would be one input model disagreeing
+with the other. The result lives on the *element* — a weak table on `BrowserEventRealm`, beside the
 mouse press target — rather than on the event, because `new FormData(form, submitter)` reads it arbitrarily
 long afterwards. `Runtime/FormSubmitter` appends x then y, with a name prefix only when nonempty. Its
 inventory is submittable controls, not `form.elements`, which excludes image inputs: AngleSharp's tree
@@ -141,7 +145,8 @@ on the button while the *mouse* events a tap leaves go where the finger really c
 
 **A tap is a click, made of the same parts.** §8's compatibility events — `mousemove`, `mousedown`, `mouseup`,
 `click` — are dispatched through the helpers `DispatchMouse` uses, at the released point, so one activation
-behaviour runs rather than two nearly identical ones. They are owed only by a *single-finger* gesture nothing
+behaviour runs rather than two nearly identical ones — including the image button's selected coordinate,
+which is measured from the released point's hit test the way the mouse's is (above). They are owed only by a *single-finger* gesture nothing
 cancelled: a second contact, a cancelled `touchstart` or first `touchmove`, or a `touchcancel` withdraws them.
 **No pointer event is fired for a touch** — `pointerType: "touch"` with a `pointerId` per contact and its own
 boundary events is a second pointer model over the same contacts, and this package has one.

--- a/Jint.Browser/Events/InputDispatcher.Touch.cs
+++ b/Jint.Browser/Events/InputDispatcher.Touch.cs
@@ -241,6 +241,16 @@ internal static partial class InputDispatcher
     /// <b>No <c>pointerdown</c>, and no boundary events.</b> The first is the class remark's; the second is
     /// <see cref="DispatchMouse"/>'s own limitation, and a tap has no previous position to compute them from.
     /// </para>
+    /// <para>
+    /// <b>An image button's selected coordinate is measured here too</b>, from the same hit test and the same
+    /// layout, and for the same reason the release arm of <see cref="DispatchMouse"/> measures it before its
+    /// listeners: the activation behaviour that reads it runs inside the <c>click</c> below, after the three
+    /// mouse listeners above, and any one of them may move, adopt or detach the input first. HTML asks
+    /// whether "the user activated the button using a pointing device"
+    /// (<a href="https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)">§4.10.5.1.20</a>),
+    /// and a finger is one — without this a tap on an image button submitted <c>(0, 0)</c> where the identical
+    /// click submitted the point it landed on.
+    /// </para>
     /// </remarks>
     private static void CompatibilityMouseEvents(PageRuntime runtime, ActiveTouch released, EventModifiers modifiers)
     {
@@ -250,7 +260,8 @@ internal static partial class InputDispatcher
         }
 
         var dom = runtime.Dom;
-        var hit = runtime.Layout.Current().ElementFromPoint(released.ClientX, released.ClientY) ?? document.DocumentElement;
+        var layout = runtime.Layout.Current();
+        var hit = layout.ElementFromPoint(released.ClientX, released.ClientY) ?? document.DocumentElement;
 
         if (hit is null)
         {
@@ -268,18 +279,30 @@ internal static partial class InputDispatcher
             Detail: 1,
             modifiers);
 
-        Mouse(target, "mousemove", options, cancelable: true);
+        var events = BrowserEventRealm.Of(dom.Engine);
+        events.PendingImagePoint = ImagePointOf(hit, released.ClientX, released.ClientY, layout);
 
-        if (Mouse(target, "mousedown", options with { Buttons = 1 }, cancelable: true)
-            && NearestFocusable(hit) is { } focusTarget)
+        try
         {
-            // https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps — a tap focuses what it
-            // lands on unless the page cancelled the mousedown, which is the rule a press follows too.
-            FocusController.Focus(dom, focusTarget);
-        }
+            Mouse(target, "mousemove", options, cancelable: true);
 
-        Mouse(target, "mouseup", options, cancelable: true);
-        DispatchClickEvent(target, options, trusted: true);
+            if (Mouse(target, "mousedown", options with { Buttons = 1 }, cancelable: true)
+                && NearestFocusable(hit) is { } focusTarget)
+            {
+                // https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps — a tap focuses what
+                // it lands on unless the page cancelled the mousedown, which is the rule a press follows too.
+                FocusController.Focus(dom, focusTarget);
+            }
+
+            Mouse(target, "mouseup", options, cancelable: true);
+            DispatchClickEvent(target, options, trusted: true);
+        }
+        finally
+        {
+            // Nothing is selected by measuring: the activation behaviour promotes it, or nothing does, and
+            // the measurement must not outlive the sequence it was taken for.
+            events.PendingImagePoint = null;
+        }
     }
 
     /// <summary>Builds one <c>TouchEvent</c> over the gesture and dispatches it at the contact's target.</summary>

--- a/Jint.Browser/Events/InputDispatcher.cs
+++ b/Jint.Browser/Events/InputDispatcher.cs
@@ -150,7 +150,7 @@ internal static partial class InputDispatcher
                 // every listener, because the activation behaviour that reads it runs after all three of
                 // them and any one of them may move, adopt or detach the input first. Nothing is selected
                 // by measuring: the activation behaviour promotes it, or nothing does.
-                events.PendingImagePoint = ImagePointOf(hit, input, layout);
+                events.PendingImagePoint = ImagePointOf(hit, input.X, input.Y, layout);
 
                 try
                 {
@@ -222,12 +222,20 @@ internal static partial class InputDispatcher
     /// HTML §4.10.5.1.20</a>'s selected coordinate, "the position of the pointer relative to the image".
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The inclusive ancestors are walked rather than the hit element alone because a click inside an image
     /// button activates the button, and the coordinate is relative to <i>its</i> edge. The component is the
     /// distance truncated to an integer, which HTML's "valid integer" is, and never negative: a descendant's
     /// box is inside its ancestor's in the flat box model, so a point inside one is inside the other.
+    /// </para>
+    /// <para>
+    /// It takes the two coordinates rather than a <see cref="MouseInput"/> because a <b>tap</b> selects one
+    /// too: HTML asks whether "the user activated the button using a pointing device", and a touch is one.
+    /// The point a tap measures from is where the finger came off, which is also the point its compatibility
+    /// mouse events are dispatched at.
+    /// </para>
     /// </remarks>
-    private static (IElement Image, int X, int Y)? ImagePointOf(IElement hit, in MouseInput input, FlatLayout layout)
+    private static (IElement Image, int X, int Y)? ImagePointOf(IElement hit, double x, double y, FlatLayout layout)
     {
         for (var element = hit; element is not null; element = element.ParentElement)
         {
@@ -241,7 +249,7 @@ internal static partial class InputDispatcher
                 return null;
             }
 
-            return (image, Component(input.X - box.X), Component(input.Y - box.Y));
+            return (image, Component(x - box.X), Component(y - box.Y));
         }
 
         return null;

--- a/Jint.Tests.Browser/Forms/ImageSubmitTests.cs
+++ b/Jint.Tests.Browser/Forms/ImageSubmitTests.cs
@@ -69,6 +69,137 @@ public sealed class ImageSubmitTests
         page.Errors.Should().BeEmpty();
     }
 
+    /// <summary>
+    /// A single-finger tap on the image, driven through the same dispatcher <c>Input.dispatchTouchEvent</c>
+    /// reaches: down at the point, then up, which is what leaves Touch Events §8's compatibility mouse
+    /// events behind.
+    /// </summary>
+    private static Task<bool> Tap(Page page, double x, double y)
+        => page.RunOnLoopAsync(engine =>
+        {
+            var runtime = PageRuntime.Find(engine)!;
+            var input = (IHtmlInputElement) runtime.Document!.GetElementById("image")!;
+            var box = runtime.Layout.Current().ClientBoxOf(input)!.Value;
+            InputDispatcher.DispatchTouch(runtime, new TouchInput(
+                TouchInputKind.Start, [TouchPointInput.At(box.X + x, box.Y + y)], EventModifiers.None));
+            InputDispatcher.DispatchTouch(runtime, TouchInput.Of(TouchInputKind.End));
+            return true;
+        });
+
+    [TestCase("name='go'", "go.x", "go.y")]
+    [TestCase("name=''", "x", "y")]
+    [TestCase("", "x", "y")]
+    public async Task ATapInsideAnAvailableImageSelectsTheCoordinateItLandedOn(string nameAttribute, string x, string y)
+    {
+        // https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image) asks whether
+        // "the user activated the button using a pointing device", and a finger is one: Touch Events §8's
+        // compatibility `click` is the activation, so the tap selects the point it came off at exactly as
+        // the identical mouse release does.
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync($"<form id=f><input id=image type=image {nameAttribute} {AvailableImage}></form>");
+        await page.EvaluateAsync("f.onsubmit = e => e.preventDefault()");
+        await Tap(page, 7.75, 5.5);
+
+        (await Entries(page)).Should().Be(JsonSerializer.Serialize(new[] { new[] { x, "7" }, new[] { y, "5" } }));
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ATapAndAClickAtOnePointSelectTheSameCoordinate()
+    {
+        // The two paths reach one activation behaviour, so they cannot disagree about the coordinate; this
+        // is the assertion that would have failed silently while only the mouse path measured.
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync($"<form id=f><input id=image type=image name=go {AvailableImage}></form>");
+        await page.EvaluateAsync("f.onsubmit = e => e.preventDefault()");
+
+        await PointerClick(page, 12, 3);
+        var clicked = await Entries(page);
+
+        await page.EvaluateAsync("window.tapped = null");
+        await Tap(page, 12, 3);
+
+        (await Entries(page)).Should().Be(clicked).And.Be("""[["go.x","12"],["go.y","3"]]""");
+    }
+
+    [Test]
+    public async Task ATapTheDocumentCancelledSelectsNothingBecauseItActivatesNothing()
+    {
+        // §8: `preventDefault()` on the `touchstart` means no compatibility mouse events at all, so there is
+        // no click, no activation behaviour and nothing to select — the button keeps the (0, 0) every
+        // unactivated image button has. The listener has to say `passive: false`, because HTML makes a
+        // `touchstart` listener on the window, the document or the body passive by default and a passive
+        // listener's `preventDefault()` does nothing.
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync($"<form id=f><input id=image type=image name=go {AvailableImage}></form>");
+        await page.EvaluateAsync("""
+            window.submitted = false;
+            f.onsubmit = e => { window.submitted = true; e.preventDefault(); };
+            document.addEventListener('touchstart', e => e.preventDefault(), { passive: false });
+            """);
+        await Tap(page, 7.75, 5.5);
+
+        (await page.EvaluateAsync<bool>("window.submitted")).Should().BeFalse();
+        (await Entries(page)).Should().Be("""[["go.x","0"],["go.y","0"]]""");
+    }
+
+    [Test]
+    public async Task ATapThatLiftsOffTheImageSelectsNothingForIt()
+    {
+        // The compatibility events are dispatched where the finger came off, not where it went down, so a
+        // finger that slid off the button before lifting activates nothing and the button stays at (0, 0).
+        await using var browser = new global::Jint.Browser.Browser();
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(
+            $"<form id=f><input id=image type=image name=go {AvailableImage}></form><p id=elsewhere>elsewhere</p>");
+        await page.EvaluateAsync("""
+            window.submitted = false;
+            window.clicked = '';
+            f.onsubmit = e => { window.submitted = true; e.preventDefault(); };
+            document.addEventListener('click', e => { window.clicked = e.target.id; });
+            """);
+
+        await page.RunOnLoopAsync(engine =>
+        {
+            var runtime = PageRuntime.Find(engine)!;
+            var layout = runtime.Layout.Current();
+            var image = (IHtmlInputElement) runtime.Document!.GetElementById("image")!;
+            var elsewhere = runtime.Document.GetElementById("elsewhere")!;
+            var from = layout.ClientBoxOf(image)!.Value;
+            var to = layout.ClientBoxOf(elsewhere)!.Value;
+
+            InputDispatcher.DispatchTouch(runtime, new TouchInput(
+                TouchInputKind.Start, [TouchPointInput.At(from.X + 7, from.Y + 5)], EventModifiers.None));
+            InputDispatcher.DispatchTouch(runtime, new TouchInput(
+                TouchInputKind.Move, [TouchPointInput.At(to.X + 2, to.Y + 2)], EventModifiers.None));
+            InputDispatcher.DispatchTouch(runtime, TouchInput.Of(TouchInputKind.End));
+            return true;
+        });
+
+        (await page.EvaluateAsync<string>("window.clicked")).Should().Be("elsewhere");
+        (await page.EvaluateAsync<bool>("window.submitted")).Should().BeFalse();
+        (await Entries(page)).Should().Be("""[["go.x","0"],["go.y","0"]]""");
+    }
+
+    [Test]
+    public async Task TheCoordinateATapSelectedReachesAnActualSubmission()
+    {
+        await using var fixture = await LoopbackPage.CreateAsync(server => server
+            .MapHtml("/form", $"<form id=f action=/echo><input name=a value=1>"
+                + $"<input id=image type=image name=go {AvailableImage}></form>")
+            .MapHtml("/echo", "<p>echoed</p>"));
+        await fixture.Page.NavigateAsync(fixture.Url("/form"));
+
+        var navigated = fixture.Page.WaitForNavigationAsync(TimeSpan.FromSeconds(10));
+        await Tap(fixture.Page, 7.75, 5.5);
+        (await navigated).Should().BeTrue("a tap's compatibility click runs the image button's activation behaviour");
+
+        fixture.Server.Received.Single(request => request.Path == "/echo").Query.Should().Be("a=1&go.x=7&go.y=5");
+    }
+
     [Test]
     public async Task TheFormdataEventCarriesTheSelectedCoordinateLongAfterTheClick()
     {


### PR DESCRIPTION
## Mechanism

[HTML §4.10.5.1.20](https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)) gives an
image button a real *selected coordinate* only when "the user activated the button using a pointing device".
A finger is one: [Touch Events §8](https://w3c.github.io/touch-events/#mouse-events)'s compatibility mouse
events are what a single-finger tap that nothing cancelled leaves behind, and their `click` is the activation
that runs the button's behaviour.

[#4017](https://github.com/sebastienros/jint/pull/4017) parks the measurement
(`BrowserEventRealm.PendingImagePoint`, promoted by `ActivationBehaviors.RunInput`) in
`InputDispatcher.DispatchMouse`'s **released** arm only. `InputDispatcher.Touch`'s
`CompatibilityMouseEvents` dispatches through the same `Mouse`/`DispatchClickEvent` helpers and parked
nothing, so `SelectCoordinate` found no pending point and fell through to `(0, 0)`.

`CompatibilityMouseEvents` now measures from the hit test and the `FlatLayout` it already dispatches at,
**before its own three mouse listeners** — the same reason the mouse arm measures before its three: the
activation behaviour runs inside the `click` below them, and any listener may move, adopt or detach the input
first. The point is cleared in a `finally`, so it cannot outlive the sequence it was taken for.
`ImagePointOf` takes two coordinates rather than a `MouseInput`, because there are two callers now.

Measuring is still not selecting. A gesture whose compatibility events are withdrawn — a second contact, a
cancelled `touchstart` or first `touchmove`, a `touchcancel` — dispatches no click, runs no activation
behaviour and promotes nothing, so the button keeps whatever the last activation selected.

## Premise validation

The premise held exactly as written. On the unfixed tree, `Page.TapAsync`-shaped input on
`<input type=image name=go>` inside a form posting to a loopback server:

```
tap    a=1&go.x=0&go.y=0
click  a=1&go.x=7&go.y=5      (the identical point, through Input.dispatchMouseEvent)
```

Two things the brief did not say, found while checking it:

- **The `finally` matters for the same reason as in the mouse arm** and is not decoration: a `click`
  listener that calls `image.click()` would otherwise reach `SelectCoordinate` with a point still parked.
  It is excluded anyway by `ev.IsTrusted`, but the parked point is sequence state and clearing it is what
  keeps that true of any future caller.
- **A `touchstart` listener on `document` cannot cancel a tap without `{ passive: false }`.** HTML makes a
  `touchstart` listener on the window, the document or the body passive by default, so the obvious
  `document.addEventListener('touchstart', e => e.preventDefault())` does nothing and the compatibility
  events still fire. That is correct behaviour and the engine already implements it (#3695's default passive
  value); it cost one test a wrong expectation, and the test now says so in a comment.

## Failing-first evidence

Five new cases in `Jint.Tests.Browser/Forms/ImageSubmitTests.cs` (six with the three-way `TestCase`),
driving `InputDispatcher.DispatchTouch` the way `Jint.Tests.Browser/Events/TouchDispatcherTests` does:

| Case | What it holds |
| --- | --- |
| `ATapInsideAnAvailableImageSelectsTheCoordinateItLandedOn` (×3 names) | the point, over `name='go'`, `name=''` and no name |
| `ATapAndAClickAtOnePointSelectTheSameCoordinate` | the two input paths cannot disagree |
| `ATapTheDocumentCancelledSelectsNothingBecauseItActivatesNothing` | §8's withdrawal, with `{ passive: false }` |
| `ATapThatLiftsOffTheImageSelectsNothingForIt` | the compatibility click goes where the finger came off |
| `TheCoordinateATapSelectedReachesAnActualSubmission` | end to end, over the wire |

Run with only the measurement removed from `CompatibilityMouseEvents` (the tests and everything else left in
place):

```
unfixed   Failed: 5, Passed: 37, Total: 42
          ATapInsideAnAvailableImageSelectsTheCoordinateItLandedOn  ×3
          ATapAndAClickAtOnePointSelectTheSameCoordinate            "[["go.x","0"],["go.y","0"]]" vs "[["go.x","12"],["go.y","3"]]"
          TheCoordinateATapSelectedReachesAnActualSubmission        "a=1&go.x=0&go.y=0"           vs "a=1&go.x=7&go.y=5"
fixed     Failed: 0, Passed: 42, Total: 42
```

The two that pass either way are the two that assert the coordinate stays `(0, 0)` — the cancelled tap and
the finger that lifted elsewhere — which is what they are for: they hold the fix to *not* selecting where
nothing was activated.

## Exclusion delta

**None.** No `WptBrowserExclusions` row and no census figure moves; no vendored document taps an image button.

```
JINT_WPT_BROWSER_CENSUS=1 dotnet test Jint.Tests.Browser -c Release -f net10.0 \
  --filter "FullyQualifiedName~Jint.Tests.Browser.Wpt"
Passed! - Failed: 0, Passed: 434, Total: 434
```

## AngleSharp findings, recorded not filed

None. This is entirely in the events bridge, which is Jint's own; AngleSharp has no part in the input model.
`Jint.Browser/Events/AGENTS.md` is updated in both places that describe the measurement, so the two input
paths are documented as one rule rather than as the mouse's rule plus an omission.

## Verification

- `dotnet build -c Release Jint.Browser` and `Jint.Tests.Browser` — 0 warnings, 0 errors.
- `dotnet test Jint.Tests.Browser -c Release -f net10.0` — `Failed: 0, Passed: 2693, Skipped: 38`.
- `dotnet test Jint.Tests.Browser -c Release -f net8.0` — `Failed: 0, Passed: 2689, Skipped: 38`.
- `--filter "…Jint.Tests.Browser.Events|…ImageSubmitTests"` — `Failed: 0, Passed: 191`, so
  `TouchDispatcherTests`, `InputDispatcherTests`, `ActivationBehaviorTests` and `PageInputTests` are green
  alongside.
- `dotnet test Jint.Tests -c Release --filter "…AgentInstructionFileTests"` — green on all three TFMs.

Base SHA: `dd9b59102890863d1683d7c43fb068ebbf777fe0`

Refs #4017

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
