### PR TITLE
An imported node is upgraded in this document: DOM §4.5's importNode

### DIFF
--- a/Jint.Browser/AGENTS.md
+++ b/Jint.Browser/AGENTS.md
@@ -255,7 +255,8 @@ that never mentions `customElements` builds no registry at all and pays for none
   `skip`ped in the override table and re-declared, because for a defined name the element is the
   *constructor's* rather than AngleSharp's; `new MyElement()` reaches `DomInterfaceObject.Construct`, which
   is HTML's `HTMLElement` constructor and the only `new` that object ever answers; and a parser-created
-  element is **upgraded**. `cloneNode` is re-declared too, so a clone of a custom element is one.
+  element is **upgraded**. `cloneNode` and `importNode` are hooked too, so a copy of a custom element is
+  one, and an imported customized built-in keeps its is value.
 - **The construction stack is the specification's**, which is what makes `super()` answer the element being
   upgraded rather than a second one, and a constructor that reaches the base twice a `TypeError` — a plain
   one, not a `DOMException`, which is the only refusal in that constructor a page reaches by constructing its

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -569,24 +569,38 @@ internal class DomHostHooks
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#dom-document-importnode — "return the result of cloning a node given
-    /// node with <b>document set to this</b>". Three things AngleSharp's <c>Import</c> leaves out: DOM's
+    /// node with <b>document set to this</b>". Four things AngleSharp's <c>Import</c> leaves out: DOM's
     /// import steps do not copy a file input's selected files, the clone's node document is the
-    /// <i>source</i> document rather than this one, and the IDL default for <c>deep</c> is
-    /// <see langword="false"/> where <c>Import</c>'s own is <see langword="true"/>.
+    /// <i>source</i> document rather than this one, the IDL default for <c>deep</c> is
+    /// <see langword="false"/> where <c>Import</c>'s own is <see langword="true"/>, and a copy is never
+    /// upgraded.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The second one is why the clone is adopted afterwards, which is the step DOM folds into "cloning a
     /// node given a document": an imported element went on belonging to the document it came from, so
     /// <c>importNode(x).ownerDocument === document</c> was false and every member that asks its node
     /// document a question — <c>tagName</c> among them — answered about the wrong document. AngleSharp
     /// refuses to adopt an <c>IAttr</c> where DOM adopts any node, so an imported attribute is the one node
     /// this cannot correct; the divergence table records both halves.
+    /// </para>
+    /// <para>
+    /// <b>The fourth is <see cref="CloneNode"/>'s defect on this member.</b> "Cloning a node" creates each
+    /// copy through DOM's create-an-element given <b>node's is value</b> with the synchronous custom
+    /// elements flag unset, which enqueues an upgrade reaction — so an imported autonomous element was never
+    /// constructed, and an imported customized built-in, whose is value is a slot and not the <c>is</c>
+    /// content attribute AngleSharp copies, came back a plain built-in.
+    /// <see cref="CustomElements.CustomElementRegistry.Cloned"/> is what carries the slot and upgrades, and
+    /// it runs <i>after</i> the adopt because DOM creates the copy in <b>this</b> document: the constructor
+    /// has to see <c>ownerDocument</c> already answering this one. That order is also what keeps the adopt
+    /// silent — the copy is not custom yet, so it enqueues no <c>adoptedCallback</c>, which is the answer
+    /// DOM gives for a member that clones rather than moves.
+    /// </para>
     /// </remarks>
     internal virtual JsValue ImportNode(DomRealm realm, IDocument document, JsValue[] arguments)
     {
-        var imported = document.Import(
-            DomBindings.Argument<INode>(arguments, 0, "Document.importNode"),
-            DomConvert.OptionalBool(arguments, 1, false));
+        var source = DomBindings.Argument<INode>(arguments, 0, "Document.importNode");
+        var imported = document.Import(source, DomConvert.OptionalBool(arguments, 1, false));
 
         if (imported is not IAttr && !ReferenceEquals(imported.Owner, document))
         {
@@ -594,6 +608,7 @@ internal class DomHostHooks
         }
 
         Files.FileTransferRealm.ResetCopiedInputs(imported);
+        CustomElements.CustomElementRegistry.Cloned(realm, source, imported);
         return realm.WrapNodeValue(imported);
     }
 

--- a/Jint.Tests.Browser/CustomElements/CustomElementImportTests.cs
+++ b/Jint.Tests.Browser/CustomElements/CustomElementImportTests.cs
@@ -1,0 +1,152 @@
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.CustomElements;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>document.importNode</c>, which https://dom.spec.whatwg.org/#dom-document-importnode defines as "the
+/// result of cloning a node given node with <b>document set to this</b>" — so the copy is created in this
+/// document, with the source's is value, and upgraded there.
+/// </summary>
+public sealed class CustomElementImportTests
+{
+    private static async Task<Page> PageWith(Browser browser, string body)
+    {
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(body);
+        return page;
+    }
+
+    [Test]
+    public async Task AnImportedAutonomousElementIsConstructedInThisDocument()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor:' + (this.ownerDocument === document)); }
+              }
+              customElements.define('x-thing', Thing);
+              const source = document.createElement('div');
+              source.innerHTML = '<x-thing id="deep"></x-thing>';
+              window.log.length = 0;
+              const copy = document.importNode(source, true);
+              const imported = copy.firstElementChild;
+              window.log.push(imported instanceof Thing, imported.ownerDocument === document);
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("ctor:true|true|true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AShallowImportUpgradesTheElementItselfAndCopiesNoChild()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              customElements.define('x-thing', Thing);
+              const source = document.createElement('x-thing');
+              source.appendChild(document.createElement('span'));
+              window.log.length = 0;
+              const shallow = document.importNode(source);
+              window.log.push(shallow instanceof Thing, shallow.childNodes.length);
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("ctor|true|0");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnImportedCustomizedBuiltInKeepsItsIsValue()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class FancyButton extends HTMLButtonElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              customElements.define('fancy-button', FancyButton, { extends: 'button' });
+              // The is value is a slot rather than a content attribute, so nothing about the markup carries it.
+              const source = document.createElement('button', { is: 'fancy-button' });
+              window.log.length = 0;
+              const imported = document.importNode(source);
+              window.log.push(imported instanceof FancyButton, imported.localName, String(imported.getAttribute('is')));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("ctor|true|button|null");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnElementImportedFromAParsedDocumentIsUpgradedByThisDocumentsRegistry()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+                connectedCallback() { window.log.push('connected'); }
+              }
+              customElements.define('x-thing', Thing);
+              const parsed = new DOMParser().parseFromString('<x-thing></x-thing>', 'text/html');
+              const source = parsed.querySelector('x-thing');
+              // A parsed document has no browsing context, so its own element is never upgraded.
+              window.log.push('parsed:' + (source instanceof Thing));
+              const imported = document.importNode(source, true);
+              window.log.push(imported instanceof Thing, imported.ownerDocument === document);
+              document.getElementById('host').appendChild(imported);
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("parsed:false|ctor|true|true|connected");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnOrdinaryImportOfANonCustomTreeIsUnchanged()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement { constructor() { super(); window.log.push('ctor'); } }
+              customElements.define('x-thing', Thing);
+              const source = document.createElement('section');
+              source.innerHTML = '<p class="a">text</p>';
+              window.log.length = 0;
+              const imported = document.importNode(source, true);
+              const ranNoConstructor = window.log.length === 0;
+              window.log.push(
+                imported.outerHTML,
+                imported.ownerDocument === document,
+                imported !== source,
+                ranNoConstructor);
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("<section><p class=\"a\">text</p></section>|true|true|true");
+        page.Errors.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## The mechanism

`document.importNode` is [DOM §4.5](https://dom.spec.whatwg.org/#dom-document-importnode): "return the
result of cloning a node given node with **document set to this**". And
[cloning a node](https://dom.spec.whatwg.org/#concept-node-clone) creates each copy through
[create an element](https://dom.spec.whatwg.org/#concept-create-element) given **node's is value**, with the
synchronous custom elements flag unset — which enqueues a custom element upgrade reaction.

`DomHostHooks.ImportNode` cloned through AngleSharp's `Import` and adopted the copy, and called neither
`CustomElementRegistry.SubtreeCreated` nor the `Cloned` that #4029 added. So:

* an **imported autonomous element was never constructed** — `document.importNode(x) instanceof MyElement`
  was `false`, and stayed a plain `HTMLElement` until something happened to insert it into the document;
* an **imported customized built-in lost its `is` value** — the is value is a *slot*, set by
  `createElement('button', { is })` and by `new FancyButton()`, and never the `is` content attribute
  AngleSharp's clone copies, so the copy had no way to find its definition.

This is #4029's defect on the other member. The fix is one call: `CustomElementRegistry.Cloned(realm, source,
imported)`, which is exactly what carries the slot down the two trees in lockstep and then upgrades.

**Why it runs after the adopt.** DOM creates the copy *in this document*, so the constructor has to see
`ownerDocument` already answering this one — the hook's `document.Adopt` is the step that gets it there.
That order is also what keeps the adopt silent: the copy is not custom yet when it is adopted, so it
enqueues no `adoptedCallback`, which is the answer DOM gives for a member that clones rather than moves.

## Premise validation

Reproduced on the unfixed tree at `23dda182f`. Both halves are real, and so is the third case the brief
asked about — an element imported *from* a `DOMParser` document, whose own document has no browsing context
and so upgrades nothing itself, must be upgraded by **this** document's registry on arrival.

One thing the brief expected that measurement did **not** support: nothing in the vendored corpus moves.
`custom-elements/upgrading/Document-importNode.html` and `Document-importNode-customized-builtins.html` are
`NotVendored` rows ("imports from an iframe's document") and stay exactly as they are, so this PR brings its
own tests, as the brief says it should.

## Failing-first

New file `Jint.Tests.Browser/CustomElements/CustomElementImportTests.cs`, five tests, run against the
**unfixed** `DomHostHooks.cs`:

```
Failed:     4, Passed:     1, Skipped:     0, Total:     5
```

with the actual/expected of each failure:

| test | unfixed actual | expected |
| --- | --- | --- |
| `AnImportedAutonomousElementIsConstructedInThisDocument` | `false\|true` | `ctor:true\|true\|true` |
| `AShallowImportUpgradesTheElementItselfAndCopiesNoChild` | `false\|0` | `ctor\|true\|0` |
| `AnImportedCustomizedBuiltInKeepsItsIsValue` | `false\|button\|null` | `ctor\|true\|button\|null` |
| `AnElementImportedFromAParsedDocumentIsUpgradedByThisDocumentsRegistry` | `parsed:false\|false\|true\|ctor\|connected` | `parsed:false\|ctor\|true\|true\|connected` |

The fifth, `AnOrdinaryImportOfANonCustomTreeIsUnchanged`, is the control: it passes on both trees, and asserts
that importing an ordinary subtree into a page that *has* definitions runs no constructor and produces the
same markup, same owner document, a distinct node.

Fixed tree: `Failed: 0, Passed: 5`.

## Exclusion delta

**None.** No row of `WptBrowserExclusions.cs` is added, removed or changed, and the census is untouched —
the two upstream `Document-importNode` documents are not vendored (they build a second document in an
iframe), so this change has no vendored document to move. The full browser Wpt lane still passes with the
table exactly as it is, which is the check that no currently-excluded row started passing.

## AngleSharp findings, recorded not filed

`Document.Import` copies attributes and children and has no notion of a custom element registry, an is value
or an upgrade. That is not a defect to report — AngleSharp does not implement custom elements at all, which
is why this package owns the algorithm — and `Jint.Browser/Dom/divergences.md` already carries the two
`importNode` rows for what `Import` *does* get wrong (the clone's node document, and its `deep` default).
No issue or PR was opened on any AngleSharp repository.

## Verification

* `Jint.Tests.Browser` Release, `-f net10.0`: `Failed: 0, Passed: 2763, Skipped: 38`
* `Jint.Tests.Browser` Release, `-f net8.0`: `Failed: 0, Passed: 2760, Skipped: 38`
* `Jint.Tests.Browser` Release, `-f net10.0`, `JINT_HOST_CONTRACT_VERIFICATION=1`: `Failed: 0, Passed: 2763, Skipped: 38`
* `Jint.Tests` `AgentInstructionFileTests` (the size budget, since `Jint.Browser/AGENTS.md` moved by two lines): `Passed: 5`

Base SHA: `23dda182f`

Refs #4013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
