### PR TITLE
adoptedCallback: DOM's adopt step 3.2, reached from document.adoptNode

### DIFF
--- a/Jint.Browser/CustomElements/CustomElementRecord.cs
+++ b/Jint.Browser/CustomElements/CustomElementRecord.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using AngleSharp.Dom;
 
 namespace Jint.Browser.CustomElements;
 
@@ -52,13 +53,26 @@ internal enum CustomElementReactionKind
 /// <param name="Name">The attribute's local name, for <see cref="CustomElementReactionKind.AttributeChanged"/>.</param>
 /// <param name="OldValue">The attribute's value before the change, or <see langword="null"/> when it was absent.</param>
 /// <param name="NewValue">The attribute's value after the change, or <see langword="null"/> when it was removed.</param>
+/// <param name="OldDocument">The node document the element left, for <see cref="CustomElementReactionKind.Adopted"/>.</param>
+/// <param name="NewDocument">The node document the element joined, for <see cref="CustomElementReactionKind.Adopted"/>.</param>
+/// <remarks>
+/// <b>The two documents are held strongly, and a reaction is the one place that may hold one</b>, because a
+/// reaction outlives nothing: it is enqueued and drained inside the DOM operation that caused it, or at the
+/// next microtask checkpoint when it arrived on the parser's thread, and the element queue already holds
+/// every element on it the same way for the same span. What must not happen is a document living on a
+/// <see cref="CustomElementRecord"/>, which is keyed on the element in a <c>ConditionalWeakTable</c> and
+/// lasts as long as the element does: a document parked there would be pinned by every element that ever
+/// left it.
+/// </remarks>
 [StructLayout(LayoutKind.Auto)]
 internal readonly record struct CustomElementReaction(
     CustomElementReactionKind Kind,
     CustomElementDefinition Definition,
     string? Name,
     string? OldValue,
-    string? NewValue);
+    string? NewValue,
+    IDocument? OldDocument = null,
+    IDocument? NewDocument = null);
 
 /// <summary>
 /// Everything one element carries because it is, or could become, a custom element: DOM's custom element

--- a/Jint.Browser/CustomElements/CustomElementRegistry.Reactions.cs
+++ b/Jint.Browser/CustomElements/CustomElementRegistry.Reactions.cs
@@ -115,7 +115,15 @@ internal sealed partial class CustomElementRegistry
     /// https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-callback-reaction,
     /// which is a no-op unless the element is custom and the definition has the callback.
     /// </summary>
-    private void EnqueueCallback(IElement element, CustomElementRecord record, CustomElementReactionKind kind, string? name = null, string? oldValue = null, string? newValue = null)
+    private void EnqueueCallback(
+        IElement element,
+        CustomElementRecord record,
+        CustomElementReactionKind kind,
+        string? name = null,
+        string? oldValue = null,
+        string? newValue = null,
+        IDocument? oldDocument = null,
+        IDocument? newDocument = null)
     {
         if (record.State != CustomElementState.Custom || record.Definition is not { } definition)
         {
@@ -140,7 +148,7 @@ internal sealed partial class CustomElementRegistry
             return;
         }
 
-        Enqueue(element, record, new CustomElementReaction(kind, definition, name, oldValue, newValue));
+        Enqueue(element, record, new CustomElementReaction(kind, definition, name, oldValue, newValue, oldDocument, newDocument));
     }
 
     /// <summary>
@@ -246,16 +254,7 @@ internal sealed partial class CustomElementRegistry
         }
 
         var wrapper = _runtime.Dom.WrapNode(element);
-
-        JsValue[] arguments = reaction.Kind == CustomElementReactionKind.AttributeChanged
-            ?
-            [
-                JsString.Create(reaction.Name!),
-                reaction.OldValue is null ? JsValue.Null : JsString.Create(reaction.OldValue),
-                reaction.NewValue is null ? JsValue.Null : JsString.Create(reaction.NewValue),
-                JsValue.Null,
-            ]
-            : [];
+        var arguments = ArgumentsFor(reaction);
 
         try
         {
@@ -265,6 +264,43 @@ internal sealed partial class CustomElementRegistry
         {
             Report(exception, reaction.Definition.Name);
         }
+    }
+
+    /// <summary>
+    /// The arguments HTML gives each callback: none for <c>connectedCallback</c> and
+    /// <c>disconnectedCallback</c>, the four of
+    /// <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-element-attributes-change-ext">an
+    /// attribute change</a>, and — the arm that had none until now —
+    /// <a href="https://dom.spec.whatwg.org/#concept-node-adopt">adopt</a>'s
+    /// <c>« oldDocument, newDocument »</c>.
+    /// </summary>
+    /// <remarks>
+    /// The two documents are wrapped here rather than when the reaction was enqueued, because a wrapper is
+    /// an object in the engine's realm and the enqueue may have happened on the parser's thread.
+    /// </remarks>
+    private JsValue[] ArgumentsFor(in CustomElementReaction reaction)
+    {
+        if (reaction.Kind == CustomElementReactionKind.AttributeChanged)
+        {
+            return
+            [
+                JsString.Create(reaction.Name!),
+                reaction.OldValue is null ? JsValue.Null : JsString.Create(reaction.OldValue),
+                reaction.NewValue is null ? JsValue.Null : JsString.Create(reaction.NewValue),
+                JsValue.Null,
+            ];
+        }
+
+        if (reaction.Kind == CustomElementReactionKind.Adopted)
+        {
+            return
+            [
+                _runtime.Dom.WrapNodeValue(reaction.OldDocument),
+                _runtime.Dom.WrapNodeValue(reaction.NewDocument),
+            ];
+        }
+
+        return [];
     }
 
     /// <summary>

--- a/Jint.Browser/CustomElements/CustomElementRegistry.Tree.cs
+++ b/Jint.Browser/CustomElements/CustomElementRegistry.Tree.cs
@@ -110,6 +110,68 @@ internal sealed partial class CustomElementRegistry
     }
 
     /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-document-adoptnode: <c>Adopt</c>, and then
+    /// <a href="https://dom.spec.whatwg.org/#concept-node-adopt">adopt</a>'s step 3.2 — "for each
+    /// inclusiveDescendant ... that is custom, enqueue a custom element callback reaction with callback name
+    /// <c>adoptedCallback</c> and « oldDocument, document »".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The member is the door because a mutation record is not one.</b> The obvious alternative was to
+    /// read an adoption off the removal channel — a node that left the observed document and now belongs
+    /// to another one has been adopted — and it does not work: measured against the pinned AngleSharp, a
+    /// removal record is delivered <i>before</i> the node's owner changes, so at the moment the record
+    /// arrives the node is still this document's and there is nothing to report. The old document has to be
+    /// read before the call, which only the member can do.
+    /// </para>
+    /// <para>
+    /// <b>What that leaves is the adoption a page performs by inserting</b> —
+    /// <c>otherDocument.body.appendChild(el)</c> and its siblings, where DOM's pre-insert adopts on the way
+    /// past. Those enqueue no reaction here, and it is half of a larger gap rather than a hole of its own:
+    /// an element inserted into a document this page does not observe gets no <c>connectedCallback</c>
+    /// either, so the sequence <c>custom-elements/reactions/</c> asks for — disconnected, adopted,
+    /// connected — needs a second observed document and not a second reaction. Ten rows of
+    /// <c>WptBrowserExclusions</c>'s "one [CEReactions] member per file" group are that sequence, and they
+    /// stay excluded.
+    /// </para>
+    /// <para>
+    /// The removal that adopting a <i>connected</i> node performs still reports itself the ordinary way, so
+    /// <c>disconnectedCallback</c> runs from the record — inside <c>Adopt</c> — and
+    /// <c>adoptedCallback</c> is enqueued after it returns, which is DOM's own order.
+    /// </para>
+    /// </remarks>
+    internal static INode Adopt(Dom.DomRealm realm, IDocument document, INode node)
+    {
+        if (Of(realm.Engine) is not { HasDefinitions: true } registry)
+        {
+            return document.Adopt(node);
+        }
+
+        var oldDocument = node.Owner;
+        var adopted = document.Adopt(node);
+
+        if (oldDocument is not null && !ReferenceEquals(oldDocument, document))
+        {
+            registry.Adopted(adopted, oldDocument, document);
+            registry.Drain();
+        }
+
+        return adopted;
+    }
+
+    /// <summary>Step 3.2 itself, over the adopted node's subtree in tree order.</summary>
+    private void Adopted(INode root, IDocument oldDocument, IDocument newDocument)
+    {
+        Walk(root, element =>
+        {
+            if (TryGetRecord(element) is { State: CustomElementState.Custom } record)
+            {
+                EnqueueCallback(element, record, CustomElementReactionKind.Adopted, oldDocument: oldDocument, newDocument: newDocument);
+            }
+        });
+    }
+
+    /// <summary>
     /// https://dom.spec.whatwg.org/#handle-attribute-changes — what AngleSharp's <c>IAttributeObserver</c>
     /// reports, turned into an <c>attributeChangedCallback</c> reaction for an observed name.
     /// </summary>

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -509,6 +509,25 @@ internal class DomHostHooks
         CustomElements.CustomElementRegistry.SubtreeCreated(realm, element.Parent ?? element);
     }
 
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#dom-document-adoptnode — the same AngleSharp call, bracketed so that
+    /// <a href="https://dom.spec.whatwg.org/#concept-node-adopt">adopt</a>'s step 3.2 happens: "for each
+    /// inclusiveDescendant ... that is custom, enqueue a custom element callback reaction with callback name
+    /// <c>adoptedCallback</c> and « oldDocument, document »".
+    /// </summary>
+    /// <remarks>
+    /// It is the member's own door because a mutation record cannot be one: the removal a connected node's
+    /// adoption performs is delivered <i>before</i> the node's owner changes, so the old document has to be
+    /// read before the call. What that leaves — the adoption DOM's pre-insert performs on the way into a
+    /// parent in another document — is argued in <c>CustomElements/CustomElementRegistry.Tree.cs</c>.
+    /// </remarks>
+    internal virtual JsValue AdoptNode(DomRealm realm, IDocument document, JsValue[] arguments)
+        => realm.WrapNodeValue(
+            CustomElements.CustomElementRegistry.Adopt(
+                realm,
+                document,
+                DomBindings.Argument<INode>(arguments, 0, "Document.adoptNode")));
+
     /// <summary>https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-write</summary>
     internal virtual void Write(DomRealm realm, IDocument document, JsValue[] arguments)
     {

--- a/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
+++ b/Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs
@@ -701,7 +701,7 @@ internal static partial class DomInterfaces
                 global::Jint.Browser.Dom.DomFailures.Guard("Document.adoptNode", static (thisObj, args) =>
                 {
                     var self = global::Jint.Browser.Dom.DomBindings.Bind<global::AngleSharp.Dom.IDocument>(thisObj, "Document.adoptNode");
-                    return self.Realm.WrapNodeValue(self.Target.Adopt(global::Jint.Browser.Dom.DomBindings.Argument<global::AngleSharp.Dom.INode>(args, 0, "Document.adoptNode")));
+                    return self.Realm.Hooks.AdoptNode(self.Realm, self.Target, args);
                 }),
                 length: 1)
             .Accessor("alinkColor",

--- a/Jint.Tests.Browser/CustomElements/CustomElementAdoptionTests.cs
+++ b/Jint.Tests.Browser/CustomElements/CustomElementAdoptionTests.cs
@@ -1,0 +1,235 @@
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.CustomElements;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <c>adoptedCallback</c>: https://dom.spec.whatwg.org/#concept-node-adopt step 3.2 enqueues one for every
+/// custom element in an adopted subtree, with « oldDocument, newDocument ».
+/// </summary>
+public sealed class CustomElementAdoptionTests
+{
+    private static async Task<Page> PageWith(Browser browser, string body)
+    {
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(body);
+        return page;
+    }
+
+    [Test]
+    public async Task AdoptingADetachedElementRunsTheCallbackWithBothDocuments()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('constructed'); }
+                adoptedCallback(oldDocument, newDocument) {
+                  window.log.push('adopted:' + arguments.length + ':' + (oldDocument === document) + ':' + (newDocument === window.other));
+                }
+              }
+              customElements.define('x-thing', Thing);
+              const other = document.implementation.createHTMLDocument();
+              window.other = other;
+              const instance = document.createElement('x-thing');
+              window.log.push('--created--');
+              other.adoptNode(instance);
+              window.log.push('owner:' + (instance.ownerDocument === other));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("constructed|--created--|adopted:2:true:true|owner:true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AdoptingAConnectedElementDisconnectsItFirst()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                connectedCallback() { window.log.push('connected'); }
+                disconnectedCallback() { window.log.push('disconnected'); }
+                adoptedCallback() { window.log.push('adopted'); }
+              }
+              customElements.define('x-thing', Thing);
+              const other = document.implementation.createHTMLDocument();
+              const instance = document.createElement('x-thing');
+              document.getElementById('host').appendChild(instance);
+              other.adoptNode(instance);
+              window.log.push('parent:' + (instance.parentNode === null));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("connected|disconnected|adopted|parent:true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AdoptingBackIntoThisDocumentReversesTheTwoArguments()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                adoptedCallback(oldDocument, newDocument) {
+                  window.log.push((oldDocument === window.other) + ':' + (newDocument === document));
+                }
+              }
+              customElements.define('x-thing', Thing);
+              const other = document.implementation.createHTMLDocument();
+              window.other = other;
+              const instance = document.createElement('x-thing');
+              other.adoptNode(instance);
+              window.log.length = 0;
+              document.adoptNode(instance);
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("true:true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task EveryCustomElementOfTheAdoptedSubtreeRunsItInTreeOrder()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                adoptedCallback() { window.log.push('adopted:' + this.id); }
+              }
+              customElements.define('x-thing', Thing);
+              const other = document.implementation.createHTMLDocument();
+              const root = document.createElement('div');
+              root.innerHTML = '<x-thing id="a"></x-thing><div><x-thing id="b"></x-thing></div><x-thing id="c"></x-thing>';
+              other.adoptNode(root);
+              window.log.push('owner:' + (root.firstElementChild.ownerDocument === other));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("adopted:a|adopted:b|adopted:c|owner:true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AdoptingIntoTheDocumentTheNodeAlreadyBelongsToRunsNothing()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                adoptedCallback() { window.log.push('adopted'); }
+              }
+              customElements.define('x-thing', Thing);
+              const instance = document.createElement('x-thing');
+              window.log.length = 0;
+              const same = document.adoptNode(instance);
+              window.log.push('same:' + (same === instance), 'silent:' + (window.log.length === 0));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("same:true|silent:true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task TheDefinitionHoldsTheCallbackSoDeletingItFromThePrototypeChangesNothing()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                adoptedCallback() { window.log.push('adopted'); }
+              }
+              customElements.define('x-thing', Thing);
+              // HTML reads the four callbacks once, when the definition is created.
+              delete Thing.prototype.adoptedCallback;
+              const other = document.implementation.createHTMLDocument();
+              other.adoptNode(document.createElement('x-thing'));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')")).Should().Be("adopted");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnOrdinaryElementAndAnUndefinedNameAdoptSilently()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                adoptedCallback() { window.log.push('adopted'); }
+              }
+              customElements.define('x-thing', Thing);
+              const other = document.implementation.createHTMLDocument();
+              const plain = document.createElement('div');
+              const undefinedName = document.createElement('x-other');
+              other.adoptNode(plain);
+              other.adoptNode(undefinedName);
+              window.log.push(
+                'silent:' + (window.log.length === 0),
+                'plain:' + (plain.ownerDocument === other),
+                'undefined:' + (undefinedName.ownerDocument === other));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("silent:true|plain:true|undefined:true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ImportNodeEnqueuesNoAdoptedReaction()
+    {
+        // https://dom.spec.whatwg.org/#dom-document-importnode is "the result of cloning a node given node
+        // with document set to this": the copy is created in this document rather than moved into it, so a
+        // member that clones enqueues no adoptedCallback however the copy is then upgraded.
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                adoptedCallback() { window.log.push('adopted'); }
+              }
+              customElements.define('x-thing', Thing);
+              const other = new DOMParser().parseFromString('<x-thing></x-thing>', 'text/html');
+              const source = other.querySelector('x-thing');
+              const imported = document.importNode(source, true);
+              window.log.push(
+                'silent:' + (window.log.length === 0),
+                'owner:' + (imported.ownerDocument === document),
+                'sourceOwner:' + (source.ownerDocument === other));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("silent:true|owner:true|sourceOwner:true");
+        page.Errors.Should().BeEmpty();
+    }
+}

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -38,17 +38,11 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `html/webappapis/scripting/processing-model-2/` | 25 | 0 | 44 | 5 |
 | `html/semantics/embedded-content/the-img-element/` | 4 | 0 | 99 | 0 |
 | `html/semantics/selectors/pseudo-classes/` | 27 | 0 | 122 | 22 |
-| `custom-elements/` | 16 | 0 | 513 | 10 |
-| `custom-elements/parser/` | 8 | 0 | 20 | 11 |
-| `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
-| `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
-| **total** | **392** | **9** | **66,916** | **869** |
-| `html/semantics/selectors/pseudo-classes/` | 27 | 0 | 122 | 34 |
 | `custom-elements/` | 16 | 0 | 513 | 9 |
 | `custom-elements/parser/` | 8 | 0 | 20 | 11 |
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
-| **total** | **392** | **9** | **66,916** | **880** |
+| **total** | **392** | **9** | **66,916** | **868** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes

--- a/Jint.Tests.Browser/Wpt/README.md
+++ b/Jint.Tests.Browser/Wpt/README.md
@@ -43,6 +43,12 @@ vendored here yet. Its plugin is [`tools/wpt-scoreboard/`](../../tools/wpt-score
 | `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
 | `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
 | **total** | **392** | **9** | **66,916** | **869** |
+| `html/semantics/selectors/pseudo-classes/` | 27 | 0 | 122 | 34 |
+| `custom-elements/` | 16 | 0 | 513 | 9 |
+| `custom-elements/parser/` | 8 | 0 | 20 | 11 |
+| `custom-elements/reactions/` | 14 | 0 | 255 | 52 |
+| `custom-elements/upgrading/` | 2 | 0 | 7 | 0 |
+| **total** | **392** | **9** | **66,916** | **880** |
 
 *Measured on Windows.* **Documents** are `.html` files in this repository; **Synthesized** are the
 `<name>.any.html` wrappers `WptServerWrappers` manufactures for a suite's `.any.js` files, which are bytes

--- a/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
+++ b/Jint.Tests.Browser/Wpt/WptBrowserExclusions.cs
@@ -1016,8 +1016,6 @@ internal static class WptBrowserExclusions
     // ---------------------------------------------------------------- the registry, the constructor and the two creation members
     private static readonly WptExclusion[] _theRegistryTheConstructorAndTheTwoCreationMembers =
     [
-        new("custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly.html", "adoptedCallback", WptDivergence.NeedsTriage),
-
         // DOM's create-an-element sets the namespace prefix on the element the constructor produced, after
         // it returns; AngleSharp's `Prefix` has no setter, so the element is created carrying it instead and
         // a constructor reading `this.prefix` sees it one step early. That is the whole of what is left of

--- a/tools/dom-bindings/overrides.json
+++ b/tools/dom-bindings/overrides.json
@@ -1825,6 +1825,14 @@
     },
     {
       "interface": "Document",
+      "member": "adoptNode",
+      "half": "operation",
+      "hook": "AdoptNode",
+      "returns": true,
+      "reason": "The same AngleSharp call, bracketed by the reaction step DOM's adopt takes: \"for each inclusiveDescendant ... that is custom, enqueue a custom element callback reaction with callback name adoptedCallback and « oldDocument, document »\". A detached node's adoption mutates no tree and so queues no mutation record, and an adoption into this document removes the node from a document this page does not observe -- so adoptNode is the only door those two can come through."
+    },
+    {
+      "interface": "Document",
       "member": "importNode",
       "half": "operation",
       "hook": "ImportNode",


### PR DESCRIPTION
## The mechanism

`CustomElementReactionKind.Adopted` and its arm in `CustomElementRegistry.Invoke` both existed and were
**unreachable**: nothing anywhere enqueued one. And `Invoke` handed an empty argument array to every
non-attribute reaction, so even once enqueued the callback would have been called with no
`(oldDocument, newDocument)`.

[DOM's adopt](https://dom.spec.whatwg.org/#concept-node-adopt) step 3.2 is the missing enqueue: "for each
inclusiveDescendant in node's shadow-including inclusive descendants **that is custom**, enqueue a custom
element callback reaction with inclusiveDescendant, callback name `adoptedCallback`, and
« oldDocument, document »".

Three pieces:

* **`Document.adoptNode` is a hook entry** in `tools/dom-bindings/overrides.json`, and
  `CustomElementRegistry.Adopt` brackets AngleSharp's `Adopt` with step 3.2 over the adopted subtree in tree
  order.
* **`CustomElementReaction` carries the two documents.** They are held strongly, which a *reaction* may do:
  it is enqueued and drained inside the operation that caused it (or at the next microtask checkpoint when it
  arrived on the parser's thread), and the element queue already holds each element the same way for the same
  span. What must not happen — and does not — is a document living on a `CustomElementRecord`, which is keyed
  on the element in a `ConditionalWeakTable` and would then be pinned by every element that ever left it.
* **`ArgumentsFor` gives each kind its arguments**, including the two document wrappers, which are built at
  invoke time because a wrapper is an object in the engine's realm and the enqueue may have been on the
  parser's thread.

**Why the member is the door and a mutation record is not.** The obvious cheaper trigger was the removal
channel the registry already has — a node that left the observed document and now belongs to another one has
been adopted. Measured against the pinned AngleSharp, that does not work: **the removal record is delivered
before the node's owner changes**, so at the moment the record arrives the node is still this document's and
there is nothing to report. The old document has to be read *before* the call, which only the member can do.
The removal still reports itself the ordinary way, so `disconnectedCallback` runs from the record — inside
`Adopt` — and `adoptedCallback` is enqueued after it returns, which is DOM's own order.

**`importNode` enqueues none**, which is the other half of the brief's question and is correct:
[importNode](https://dom.spec.whatwg.org/#dom-document-importnode) is "the result of cloning a node given
node with document set to this", so the copy is *created* in this document rather than moved into it, and it
is not custom at the moment it is adopted. There is a test for it.

## Premise validation

The brief said neither of this stream's two gaps has a vendored document failing on it today. **That half of
the premise is wrong**, and measurement is what found it. Eleven `NeedsTriage` rows in
`WptBrowserExclusions.cs` are about this:

* `CustomElementRegistry-constructor-and-callbacks-are-held-strongly.html` "adoptedCallback", which does
  `emptyIframe.contentDocument.adoptNode(document.createElement(tagName))` — a **detached** custom element
  adopted into another document. This one **now passes**.
* ten rows across `reactions/ChildNode.html`, `Element.html`, `Node.html` and `ParentNode.html`, each named
  "…must enqueue a disconnected reaction, an adopted reaction, and a connected reaction when the custom
  element was in another document". Their helper is `document.implementation.createHTMLDocument()`, not an
  iframe, so they are in-lane — and they **stay excluded**, because the adopted reaction is only half of what
  they ask for. The other half is `connectedCallback` for an insertion into a document this page does not
  observe, which is a second observed document rather than a second reaction, and is deliberately not in this
  PR.

Reproduced on the unfixed tree at `23dda182f`: `otherDoc.adoptNode(el)` fired `disconnectedCallback` and
nothing else, for both a connected and a detached element, in either direction.

## Failing-first

New file `Jint.Tests.Browser/CustomElements/CustomElementAdoptionTests.cs`, eight tests, run against the
**unfixed** tree:

```
Failed:     5, Passed:     3, Skipped:     0, Total:     8
```

| test | unfixed actual | expected |
| --- | --- | --- |
| `AdoptingADetachedElementRunsTheCallbackWithBothDocuments` | `constructed\|--created--\|owner:true` | `constructed\|--created--\|adopted:2:true:true\|owner:true` |
| `AdoptingAConnectedElementDisconnectsItFirst` | `connected\|disconnected\|parent:true` | `connected\|disconnected\|adopted\|parent:true` |
| `AdoptingBackIntoThisDocumentReversesTheTwoArguments` | `` (empty) | `true:true` |
| `EveryCustomElementOfTheAdoptedSubtreeRunsItInTreeOrder` | `owner:true` | `adopted:a\|adopted:b\|adopted:c\|owner:true` |
| `TheDefinitionHoldsTheCallbackSoDeletingItFromThePrototypeChangesNothing` | `` (empty) | `adopted` |

The three that pass on both trees are the controls: adopting into the document a node already belongs to runs
nothing, an ordinary element and an undefined name adopt silently, and `importNode` enqueues no adopted
reaction.

Fixed tree: `Failed: 0, Passed: 8`.

## Exclusion delta

**Exactly one row removed**, from the `the registry, the constructor and the two creation members` group:

```csharp
new("custom-elements/CustomElementRegistry-constructor-and-callbacks-are-held-strongly.html", "adoptedCallback", WptDivergence.NeedsTriage),
```

It was the lane itself that named it: with the fix and the table untouched, that document failed with
`1 exclusion(s) that no longer apply — remove or narrow them: "adoptedCallback" (NeedsTriage) covers 1
test(s) that pass`. Nothing else moved — the full browser Wpt filter is `Failed: 0, Passed: 459` with the row
gone, so no other exclusion started passing and none stopped failing.

Census re-run with `JINT_WPT_BROWSER_CENSUS=update` over `FullyQualifiedName~Jint.Tests.Browser.Wpt`, then
the verdict run:

```
| `custom-elements/` | 16 | 0 | 513 | 10 |   ->   | `custom-elements/` | 16 | 0 | 513 | 9 |
| **total** | **392** | **9** | **66,916** | **881** |   ->   ... **880** |
```

`JINT_WPT_BROWSER_CENSUS=1` over the full filter afterwards: `Failed: 0, Passed: 461, Skipped: 0` — both the
census table and the cause table check green. The README cause table needed no prose change: it covers the six
DOM suites and `custom-elements/` is not one of them, and the section that *is* about custom elements does not
name this row.

## AngleSharp findings, recorded not filed

* `Document.Adopt` has no notion of a custom element, which is not a defect to report — AngleSharp does not
  implement custom elements at all, which is why this package owns the algorithm.
* **The removal record's delivery order is the load-bearing observation** and is recorded in
  `CustomElementRegistry.Tree.cs` beside the code that depends on it: a removal record reaches the observer
  *before* the node's owner changes. It is the reason the member is hooked rather than the record read.
* One thing found on the way that is **not** fixed here and is not AngleSharp's:
  `otherDocument.createElement('x-thing')` on a document with **no browsing context** runs the definition's
  constructor. HTML's "look up a custom element definition" step 2 is "if document's browsing context is null,
  return null", so it should create a plain element; today it constructs one and the construction then fails
  with a `NotSupportedError` because the constructor built its element in the *page* document. It is a
  separate defect in `CustomElementCreation.Create`, out of this PR's scope, and it is reported to the lead.

No issue or PR was opened on any AngleSharp repository.

## Verification

* `Jint.Tests.Browser` Release, `-f net10.0`: `Failed: 0, Passed: 2766, Skipped: 38`
* `Jint.Tests.Browser` Release, `-f net8.0`: `Failed: 0, Passed: 2763, Skipped: 38`
* `Jint.Tests.Browser` Release, `-f net10.0`, `JINT_HOST_CONTRACT_VERIFICATION=1`: `Failed: 0, Passed: 2766, Skipped: 38`
* `DomBindingsStalenessTests` green: `Jint.Browser/Dom/Generated/DomShapes.Dom.g.cs` was regenerated by the
  generator, not hand-edited, and its whole diff is one line.

Base SHA: `23dda182f`

Refs #4013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
