### PR TITLE
Custom elements: a definition is looked up for a document, and a document with no browsing context has none

### DIFF
--- a/Jint.Browser/CustomElements/CustomElementCreation.cs
+++ b/Jint.Browser/CustomElements/CustomElementCreation.cs
@@ -145,8 +145,10 @@ internal static class CustomElementCreation
         var lookupName = namespaced ? LocalNameOf(lowered) : lowered;
         // A definition is only ever in the HTML namespace, so the namespaced member looks up under the
         // namespace it was given — `createElementNS(null, 'x-thing')` is in *no* namespace and matches none —
-        // while `createElement` is the HTML one by definition.
-        var definition = registry.Lookup(namespaced ? namespaceUri : CustomElementRegistry.HtmlNamespace, lookupName, isValue);
+        // while `createElement` is the HTML one by definition. The document is create-an-element's own
+        // argument, and it is what makes the two members answer an uncustomized element for a document with
+        // no browsing context: see CustomElementRegistry.Lookup's step 1.
+        var definition = registry.Lookup(document, namespaced ? namespaceUri : CustomElementRegistry.HtmlNamespace, lookupName, isValue);
 
         if (definition is null)
         {

--- a/Jint.Browser/CustomElements/CustomElementRegistry.Reactions.cs
+++ b/Jint.Browser/CustomElements/CustomElementRegistry.Reactions.cs
@@ -46,6 +46,12 @@ internal sealed partial class CustomElementRegistry
     /// https://html.spec.whatwg.org/multipage/custom-elements.html#concept-try-upgrade — look up a definition
     /// for <paramref name="element"/> and, if there is one, enqueue an upgrade reaction.
     /// </summary>
+    /// <remarks>
+    /// The lookup is given the element's <b>node document</b>, which is the standard's own argument, and it
+    /// is what the one gate on a document with no browsing context is asked about: an element a parsed
+    /// document holds, or one a member just made in a <c>createHTMLDocument</c>, finds no definition however
+    /// many the page has defined. See <see cref="Lookup"/>.
+    /// </remarks>
     internal void TryUpgrade(IElement element)
     {
         if (_byName.Count == 0 || StateOf(element) != CustomElementState.Undefined)
@@ -53,7 +59,7 @@ internal sealed partial class CustomElementRegistry
             return;
         }
 
-        if (Lookup(element.NamespaceUri, element.LocalName, IsValueOf(element)) is { } definition)
+        if (Lookup(element.Owner, element.NamespaceUri, element.LocalName, IsValueOf(element)) is { } definition)
         {
             EnqueueUpgrade(element, definition);
         }

--- a/Jint.Browser/CustomElements/CustomElementRegistry.cs
+++ b/Jint.Browser/CustomElements/CustomElementRegistry.cs
@@ -265,13 +265,36 @@ internal sealed partial class CustomElementRegistry : ObjectInstance
     /// https://html.spec.whatwg.org/multipage/custom-elements.html#look-up-a-custom-element-definition.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// <b>Step 1 is "if document's browsing context is null, then return null", and it is here rather than at
+    /// each caller because that is where the standard puts it.</b> The document is DOM's create-an-element
+    /// argument where there is one, and the element's node document everywhere else. A document made by
+    /// <c>DOMParser</c>, <c>new Document()</c>, <c>DOMImplementation.createDocument</c> or
+    /// <c>createHTMLDocument</c> is the active document of nothing, so nothing it creates, clones, parses or
+    /// upgrades may consult a definition — <c>otherDocument.createElement('x-thing')</c> ran the page's
+    /// constructor and <c>otherDocument</c>'s own clone came back custom. Every path that consults one comes
+    /// through here: the two creation members, the customized-built-in upgrade, <c>cloneNode</c> and
+    /// <c>importNode</c>, the subtree creations (<c>innerHTML</c> and its siblings), insertion, and
+    /// <c>customElements.upgrade</c>. What is deliberately not gated is the <c>HTMLElement</c> constructor,
+    /// which HTML gives no document argument at all: it creates in "the current global object's associated
+    /// <c>Document</c>", which is the page's and always has a browsing context.
+    /// </para>
+    /// <para>
     /// The autonomous clause is tried first and the customized-built-in clause second, which is the order the
     /// standard gives: a name that is both a definition's name and a definition's local name cannot happen,
     /// since a valid custom element name may not be extended.
+    /// </para>
     /// </remarks>
-    internal CustomElementDefinition? Lookup(string? namespaceUri, string localName, string? isValue)
+    internal CustomElementDefinition? Lookup(IDocument? document, string? namespaceUri, string localName, string? isValue)
     {
         if (_byName.Count == 0)
+        {
+            return null;
+        }
+
+        // Step 1, asked after the "nothing is defined" test above because neither is observable and that one
+        // is a field read: a page with no definitions never asks a document anything.
+        if (DomBrowsingContext.Of(document) is null)
         {
             return null;
         }

--- a/Jint.Browser/Dom/DomBrowsingContext.cs
+++ b/Jint.Browser/Dom/DomBrowsingContext.cs
@@ -1,0 +1,43 @@
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Dom;
+
+/// <summary>
+/// <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#doc-bc">A document's browsing
+/// context</a>: the browsing context whose active document it is, and <see langword="null"/> when nothing is
+/// showing it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every document this package can build has an AngleSharp browsing context, and only one of them has
+/// HTML's.</b> <c>DOMParser</c>, <c>new Document()</c>, <c>DOMImplementation.createDocument</c> and
+/// <c>createHTMLDocument</c> each parse into a context of their own — <see cref="DomContentType"/> says why
+/// they have to — so <c>document.Context is not null</c> answers <see langword="true"/> for all four. What
+/// separates them from the page's document is the context's own <see cref="IBrowsingContext.Active"/>: it is
+/// the document being displayed, and nothing else.
+/// </para>
+/// <para>
+/// <b>It is here rather than on <see cref="DomHostHooks"/> because two unrelated algorithms name it.</b>
+/// HTML's <c>document.location</c> answers <see langword="null"/> for a document that is not fully active,
+/// and HTML §4.13.4's look-up-a-custom-element-definition returns null at step 1 for a document whose
+/// browsing context is null — so the same sentence gates a member of <c>Document</c> and every creation path
+/// that consults the registry. Two spellings of it is how one of them would come to answer about a document
+/// nobody can see.
+/// </para>
+/// <para>
+/// <b>It asks the document rather than the page</b>, which <c>PageRuntime.FindBrowsingContext</c> asks for
+/// the page's own browsing-context tree. The two agree on all four secondary spellings above — each gets a
+/// context that is not the page's — and this one needs no engine, so a binding installed without a page
+/// runtime still tells a displayed document from a manufactured one.
+/// </para>
+/// </remarks>
+internal static class DomBrowsingContext
+{
+    /// <summary>
+    /// The browsing context <paramref name="document"/> is the active document of, or
+    /// <see langword="null"/> when it is the active document of none.
+    /// </summary>
+    internal static IBrowsingContext? Of(IDocument? document)
+        => document?.Context is { } context && ReferenceEquals(context.Active, document) ? context : null;
+}

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -797,8 +797,11 @@ internal class DomHostHooks
     /// asks before answering with a <c>Location</c>, a <c>defaultView</c> or anything else a document only
     /// has while something is showing it.
     /// </summary>
-    private static bool HasBrowsingContext(IDocument document)
-        => document.Context is { } context && ReferenceEquals(context.Active, document);
+    /// <remarks>
+    /// <see cref="DomBrowsingContext"/> is the one definition of it, because HTML §4.13.4's
+    /// look-up-a-custom-element-definition asks the same question of the same documents.
+    /// </remarks>
+    private static bool HasBrowsingContext(IDocument document) => DomBrowsingContext.Of(document) is not null;
 
     // ---------------------------------------------------------------------------------------------------
     // HTML §4.8.4's image members. Every one of them answers from the page's own image lane rather than

--- a/Jint.Tests.Browser/CustomElements/CustomElementBrowsingContextTests.cs
+++ b/Jint.Tests.Browser/CustomElements/CustomElementBrowsingContextTests.cs
@@ -1,0 +1,345 @@
+using Jint.Browser;
+
+namespace Jint.Tests.Browser.CustomElements;
+
+// The test namespace sits under Jint.Tests.Browser, so the bare name Browser binds to that namespace rather
+// than to the type. The alias belongs inside the namespace declaration, where it wins that lookup.
+using Browser = global::Jint.Browser.Browser;
+
+/// <summary>
+/// <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#look-up-a-custom-element-definition">Look
+/// up a custom element definition</a> step 1 — "if document's browsing context is null, then return null" —
+/// which makes every creation, clone, parse and upgrade in a document nothing is showing answer "no
+/// definition", and the element come back uncustomized.
+/// </summary>
+/// <remarks>
+/// The four spellings of such a document are <c>DOMImplementation.createHTMLDocument</c>,
+/// <c>DOMImplementation.createDocument</c>, <c>new Document()</c> and <c>DOMParser</c>. Each is the active
+/// document of no browsing context, and the gate is one: it is at the lookup, so the six paths that consult
+/// a definition need no test of their own for it.
+/// </remarks>
+public sealed class CustomElementBrowsingContextTests
+{
+    private static async Task<Page> PageWith(Browser browser, string body)
+    {
+        var page = await browser.NewPageAsync();
+        await page.SetContentAsync(body);
+        return page;
+    }
+
+    [TestCase("document.implementation.createHTMLDocument('t')")]
+    [TestCase("document.implementation.createDocument(null, 'root', null)")]
+    [TestCase("new Document()")]
+    [TestCase("new DOMParser().parseFromString('<p></p>', 'text/html')")]
+    public async Task CreateElementAnswersAnUncustomizedElementForADocumentWithNoBrowsingContext(string spelling)
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              customElements.define('x-thing', Thing);
+              const other = SPELLING;
+              const el = other.createElement('x-thing');
+              window.log.push(
+                'instance=' + (el instanceof Thing),
+                'owner=' + (el.ownerDocument === other),
+                'name=' + el.localName);
+            </script>
+            """.Replace("SPELLING", spelling, StringComparison.Ordinal));
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("instance=false|owner=true|name=x-thing");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ACustomizedBuiltInIsNotUpgradedInADocumentWithNoBrowsingContext()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class FancyButton extends HTMLButtonElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              customElements.define('fancy-button', FancyButton, { extends: 'button' });
+              const other = document.implementation.createHTMLDocument('t');
+              const el = other.createElement('button', { is: 'fancy-button' });
+              window.log.push(
+                'instance=' + (el instanceof FancyButton),
+                'owner=' + (el.ownerDocument === other),
+                'name=' + el.localName);
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("instance=false|owner=true|name=button");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ACloneOfAnElementADocumentWithNoBrowsingContextHoldsIsNotUpgraded()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              customElements.define('x-thing', Thing);
+              const parsed = new DOMParser().parseFromString('<x-thing></x-thing>', 'text/html');
+              const source = parsed.querySelector('x-thing');
+              const copy = source.cloneNode(true);
+              window.log.push(
+                'source=' + (source instanceof Thing),
+                'copy=' + (copy instanceof Thing),
+                'owner=' + (copy.ownerDocument === parsed));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("source=false|copy=false|owner=true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task MarkupParsedIntoADocumentWithNoBrowsingContextIsNotUpgraded()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              customElements.define('x-thing', Thing);
+              const other = document.implementation.createHTMLDocument('t');
+              const host = other.createElement('div');
+              host.innerHTML = '<x-thing></x-thing>';
+              window.log.push('parsed=' + (host.firstElementChild instanceof Thing));
+              // Insertion into that document reaches no definition either, and neither does the member
+              // whose whole purpose is to upgrade a subtree.
+              other.body.appendChild(host);
+              window.log.push('inserted=' + (host.firstElementChild instanceof Thing));
+              customElements.upgrade(other.body);
+              window.log.push('upgraded=' + (host.firstElementChild instanceof Thing));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("parsed=false|inserted=false|upgraded=false");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnElementCreatedInSuchADocumentIsUndefinedRatherThanFailedAndUpgradesInThePage()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+                connectedCallback() { window.log.push('connected'); }
+              }
+              customElements.define('x-thing', Thing);
+              const other = document.implementation.createHTMLDocument('t');
+              const made = other.createElement('x-thing');
+              // The element is in DOM's "undefined" state and not the failed one, which is what lets the
+              // page upgrade it once it becomes the page's: a constructor that ran and produced the wrong
+              // element would have failed it for good.
+              const moved = document.adoptNode(made);
+              document.getElementById('host').appendChild(moved);
+              window.log.push('upgraded=' + (moved instanceof Thing));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("ctor|connected|upgraded=true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnAlreadyCustomElementAdoptedIntoSuchADocumentStillRunsAdoptedCallback()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+                adoptedCallback(from, to) { window.log.push('adopted:' + (from === document) + ':' + (to === window.other)); }
+              }
+              customElements.define('x-thing', Thing);
+              window.other = document.implementation.createHTMLDocument('t');
+              const custom = document.createElement('x-thing');
+              // https://dom.spec.whatwg.org/#concept-node-adopt step 3.2 has no browsing-context clause: it
+              // enqueues the callback for every element of the subtree that is *already* custom, and this
+              // one became custom in the page. The gate is on looking a definition up, not on a reaction
+              // for an element that already has one.
+              window.other.adoptNode(custom);
+              window.log.push('still=' + (custom instanceof Thing));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("ctor|adopted:true:true|still=true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AdoptingIntoADocumentWithNoBrowsingContextConstructsNothing()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              customElements.define('x-thing', Thing);
+              const other = document.implementation.createHTMLDocument('t');
+              // The node document is what the lookup is asked about, so an element the page made and this
+              // document adopted parses its own markup against no definition at all.
+              const adopted = other.adoptNode(document.createElement('span'));
+              adopted.innerHTML = '<x-thing></x-thing>';
+              window.log.push(
+                'owner=' + (adopted.ownerDocument === other),
+                'inner=' + (adopted.firstElementChild instanceof Thing));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("owner=true|inner=false");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AdoptingOutOfSuchADocumentUpgradesOnInsertionAsItDidBefore()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <div id="host"></div>
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+                connectedCallback() { window.log.push('connected'); }
+              }
+              customElements.define('x-thing', Thing);
+              const parsed = new DOMParser().parseFromString('<x-thing></x-thing>', 'text/html');
+              const source = parsed.querySelector('x-thing');
+              window.log.push('source=' + (source instanceof Thing));
+              const out = document.adoptNode(source);
+              // Adopting moves the node; DOM upgrades on insertion, and that is where the page's own
+              // definition is reached.
+              window.log.push('adopted=' + (out instanceof Thing), 'owner=' + (out.ownerDocument === document));
+              document.getElementById('host').appendChild(out);
+              window.log.push('inserted=' + (out instanceof Thing));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("source=false|adopted=false|owner=true|ctor|connected|inserted=true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AnImportedNodeFromSuchADocumentIsStillUpgradedInThePage()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              customElements.define('x-thing', Thing);
+              const parsed = new DOMParser().parseFromString('<div><x-thing></x-thing></div>', 'text/html');
+              const source = parsed.querySelector('div');
+              window.log.push('source=' + (source.firstElementChild instanceof Thing));
+              const copy = document.importNode(source, true);
+              window.log.push(
+                'copy=' + (copy.firstElementChild instanceof Thing),
+                'owner=' + (copy.ownerDocument === document));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("source=false|ctor|copy=true|owner=true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ThePagesOwnDocumentStillReachesEveryDefinitionItRegistered()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <x-parsed></x-parsed>
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {
+                constructor() { super(); window.log.push('ctor'); }
+              }
+              class Parsed extends HTMLElement {}
+              customElements.define('x-thing', Thing);
+              customElements.define('x-parsed', Parsed);
+              window.log.push('parsed=' + (document.querySelector('x-parsed') instanceof Parsed));
+              window.log.push('create=' + (document.createElement('x-thing') instanceof Thing));
+              window.log.push('createNS=' + (document.createElementNS('http://www.w3.org/1999/xhtml', 'x-thing') instanceof Thing));
+              window.log.push('new=' + (new Thing() instanceof Thing));
+              const host = document.createElement('div');
+              host.innerHTML = '<x-thing></x-thing>';
+              window.log.push('innerHTML=' + (host.firstElementChild instanceof Thing));
+              window.log.push('clone=' + (host.firstElementChild.cloneNode() instanceof Thing));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be(
+                "parsed=true|ctor|create=true|ctor|createNS=true|ctor|new=true|ctor|innerHTML=true|ctor|clone=true");
+        page.Errors.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task DefineIsUnaffectedBecauseItIsTheLookupThatGates()
+    {
+        await using var browser = new Browser();
+        var page = await PageWith(browser,
+            """
+            <script>
+              window.log = [];
+              class Thing extends HTMLElement {}
+              const other = document.implementation.createHTMLDocument('t');
+              const host = other.createElement('div');
+              host.innerHTML = '<x-thing></x-thing>';
+              customElements.define('x-thing', Thing);
+              customElements.whenDefined('x-thing').then(c => window.log.push('whenDefined=' + (c === Thing)));
+              window.log.push(
+                'get=' + (customElements.get('x-thing') === Thing),
+                'getName=' + customElements.getName(Thing),
+                'secondary=' + (host.firstElementChild instanceof Thing),
+                'page=' + (document.createElement('x-thing') instanceof Thing));
+            </script>
+            """);
+
+        (await page.EvaluateAsync<string>("window.log.join('|')"))
+            .Should().Be("get=true|getName=x-thing|secondary=false|page=true|whenDefined=true");
+        page.Errors.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## The defect

HTML's [look up a custom element definition](https://html.spec.whatwg.org/multipage/custom-elements.html#look-up-a-custom-element-definition)
begins:

> 1. If `document`'s browsing context is null, then return null.

That step was missing. Every path that consults a definition consulted the page's registry whatever
document it was creating in, so a document with **no browsing context** — one from
`document.implementation.createHTMLDocument()`, `createDocument()`, `new Document()` or `DOMParser` — ran
the page's constructors.

## Premise validation — measured on the unfixed tree

All four spellings, `otherDocument.createElement('x-thing')` with `x-thing` defined on the page:

```
--- createHTMLDocument      --- createDocument
ctor:true                   ctor:true
instanceof=false            instanceof=false
--- newDocument             --- DOMParser
ctor:true                   ctor:true
instanceof=false            instanceof=false

page.Errors:
custom element 'x-thing': NotSupportedError: Failed to execute 'createElement' on 'Document':
  the constructor of 'x-thing' did not produce a new, empty 'x-thing' element.   (x 4)
```

So the autonomous path was worse than "produces a custom element": the constructor ran (against the
**page's** document, because `NewElement` creates in `_runtime.Document`), the element it made was not the
one `createElement` was asked for, and the refusal was reported as a page error — leaving the requested
element in DOM's **failed** state, which is permanent. The other paths did produce a custom element:

| unfixed | result |
| --- | --- |
| `other.createElement('button', { is: 'fancy-button' })` | `ctor`, `instanceof=true`, owner is `other` |
| `parsedDoc.querySelector('x-thing').cloneNode(true)` | `ctor`, clone `instanceof=true` |
| `div.innerHTML = '<x-thing>'` on a `createHTMLDocument()` element | `ctor`, `instanceof=true` |
| `customElements.upgrade(other.body)` | upgrades |

And the predicate question the brief asked me to settle before relying on anything — measured from the loop
thread for each spelling:

```
page                 context=page's   active-is-this=True    findBrowsingContext=True
createHTMLDocument   context=own      active-is-this=False   findBrowsingContext=False
new Document()       context=own      active-is-this=False   findBrowsingContext=False
DOMParser html       context=own      active-is-this=False   findBrowsingContext=False
```

Each of the four gets an AngleSharp browsing context of its own (`DomContentType` says why they must), so
`Context is not null` separates nothing. Being that context's **active document** does, and so does
`PageRuntime.FindBrowsingContext`; the two agree on all four.

## The mechanism

`CustomElementRegistry.Lookup` takes the document as its first argument and returns null when that document
is the active document of no browsing context — one gate, where the standard puts it, so no consulting path
needs one of its own:

- `document.createElement` / `createElementNS` pass DOM's create-an-element argument;
- try-upgrade passes the element's **node document**, which is HTML's own argument for it, and that covers
  `cloneNode`, `importNode`, `innerHTML` and the other subtree creations, insertion, and
  `customElements.upgrade`.

Two things are **deliberately not** gated:

- the `HTMLElement` constructor — HTML gives it no document at all and it creates in "the current global
  object's associated `Document`", which is the page's and always has a browsing context, so `new MyEl()`
  is untouched;
- #4040's `adoptedCallback` — DOM's [adopt](https://dom.spec.whatwg.org/#concept-node-adopt) step 3.2 has no
  browsing-context clause and enqueues for an element that is *already* custom, asking no registry anything.
  Adopting a page-custom element into a `createHTMLDocument()` document still runs it, and there is a test
  for that here so the two changes stay honest about each other.

The predicate is a new `Jint.Browser/Dom/DomBrowsingContext`, promoted out of `DomHostHooks`' private
`HasBrowsingContext` so `document.location` and the definition lookup ask one question rather than two —
the reason `DomDocumentElements` gives for its own existence. It is the document-side question rather than
`PageRuntime.FindBrowsingContext`'s page-side one, so it needs no engine.

One consequence worth naming: an element created in such a document is now DOM's **undefined** state rather
than the failed one a wrong-element constructor left it in, so adopting it into the page and inserting it
upgrades it. `AnElementCreatedInSuchADocumentIsUndefinedRatherThanFailedAndUpgradesInThePage` is that,
and it read `ctor|upgraded=false` before.

## Failing-first

`Jint.Tests.Browser/CustomElements/CustomElementBrowsingContextTests.cs`, 14 cases, run against the
**unfixed** engine at the rebase base (`97a2c8bcb`): **9 failed, 5 passed**. The 5 that passed are the
interaction guards, and they are in the file on purpose:

| guard | what it pins |
| --- | --- |
| `AnImportedNodeFromSuchADocumentIsStillUpgradedInThePage` | #4038's `importNode` still upgrades a source that came from a parsed document |
| `AdoptingOutOfSuchADocumentUpgradesOnInsertionAsItDidBefore` | adopting back out into the page behaves as before |
| `AnAlreadyCustomElementAdoptedIntoSuchADocumentStillRunsAdoptedCallback` | #4040 is not over-gated |
| `ThePagesOwnDocumentStillReachesEveryDefinitionItRegistered` | `createElement`, `createElementNS`, `new`, the parser, `innerHTML` and #4029's `cloneNode` on the page |
| `DefineIsUnaffectedBecauseItIsTheLookupThatGates` | `define`, `get`, `getName`, `whenDefined` |

The 9 that failed, with what the unfixed tree answered:

```
CreateElementAnswersAnUncustomizedElement... x4  "ctor|instance=false|owner=true|name=x-thing"
ACustomizedBuiltInIsNotUpgraded...               "ctor|instance=true|owner=true|name=button"
ACloneOfAnElement...IsNotUpgraded                "ctor|source=false|copy=true|owner=true"
MarkupParsedInto...IsNotUpgraded                 "ctor|parsed=true|inserted=true|upgraded=true"
AdoptingInto...ConstructsNothing                 "ctor|owner=true|inner=true"
AnElementCreatedInSuchADocumentIsUndefined...    "ctor|upgraded=false"
```

All 14 pass with the change.

## Exclusion delta

**None**, measured rather than assumed. `JINT_WPT_BROWSER_CENSUS=1` over the full
`FullyQualifiedName~Jint.Tests.Browser.Wpt` filter passes on the rebased base: **461 passed, 0 skipped**,
so neither census table moved and no exclusion row retired. No re-census was needed and neither
`Jint.Tests.Browser/Wpt/README.md` nor `WptBrowserExclusions.cs` is touched — this PR's whole footprint is
four `Jint.Browser` files and one new test file.

The ten `custom-elements/reactions/` rows about a second *observed* document are a different cause and are
untouched.

## Verification

| leg | result |
| --- | --- |
| `Jint.Tests.Browser` `-f net8.0` | 2788 passed, 38 skipped, 0 failed |
| `Jint.Tests.Browser` `-f net10.0` | 2791 passed, 38 skipped, 0 failed |
| `Jint.Tests.Browser` `-f net10.0`, `JINT_HOST_CONTRACT_VERIFICATION=1` | 2791 passed, 38 skipped, 0 failed |
| `JINT_WPT_BROWSER_CENSUS=1`, full Wpt filter | 461 passed, 0 skipped, 0 failed |
| `dotnet build -c Release` (solution) | 0 errors, 0 new warnings |

## What I could not reach

- **`connectedCallback` does not fire for an insertion into a document with no browsing context.** A browser
  fires it — DOM's "connected" is "shadow-including root is a document", and such a document is one — but the
  registry observes only the page's document, so no mutation record arrives. Pre-existing, unchanged by this
  PR, and not tested here so as not to pin the wrong answer.
- **A template's contents have no owner document of their own** in AngleSharp (measured:
  `template.content.firstElementChild.ownerDocument === document` is `true`), so
  `customElements.upgrade(template.content)` still upgrades where a browser, whose template contents owner
  has no browsing context, does not. That is the same AngleSharp fact `non-active-document.html`'s
  `<template>` case is excluded for, and correcting it is a change of its own.
- **Base SHA**: `97a2c8bcbc7c832e881debdf1ca42a6b28e9520f`.

Refs #4013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKytThti6mniJepuE8P691
