### PR TITLE
Live DOM collections: one walk per read, and no allocation

### DIFF
--- a/Jint.Benchmark/BrowserHtmlCollectionBenchmark.cs
+++ b/Jint.Benchmark/BrowserHtmlCollectionBenchmark.cs
@@ -43,13 +43,13 @@ namespace Jint.Benchmark;
 /// children. Shallow, so it isolates the second walk from the cost of the walk itself.
 /// </description></item>
 /// <item><description>
-/// <see cref="LiveNodeList"/> — the identical loop over <c>childNodes</c>, whose elements are the same
-/// hundred nodes. It is a <c>NodeList</c>, so it reaches the generated accessor and a constant-time indexer,
-/// and nothing in this change touches that lane. <b>The control that must not move.</b>
+/// <see cref="LiveNodeList"/> — the same loop over <c>childNodes</c>, whose elements are the same hundred
+/// nodes. It is a <c>NodeList</c>, so it reaches the generated accessor and a constant-time indexer, and
+/// nothing in this change touches that lane. <b>The control that must not move.</b>
 /// </description></item>
 /// <item><description>
-/// <see cref="PlainArray"/> — the floor and the baseline: the identical loop over the <c>Array.from</c> of
-/// the same elements, so the gap is the price of the collection being a live projection.
+/// <see cref="PlainArray"/> — the floor and the baseline: the same loop over the <c>Array.from</c> of the
+/// same elements, so what a row has above it is the price of the collection being a live projection.
 /// </description></item>
 /// </list>
 /// <para>
@@ -59,8 +59,29 @@ namespace Jint.Benchmark;
 /// drives the same <c>ArrayLikeObject.TryGetIndex</c> call site, whose class profile holds one guess, and a
 /// shared engine would hand whichever row ran first a monomorphic read and the rest a cold indirect call.
 /// Page construction and the HTML parse stay outside the measurement; what the measured call adds over the
-/// loop itself is one mailbox round trip per operation, which is the same term in every row including the
-/// baseline.
+/// loop itself is one mailbox round trip per operation.
+/// </para>
+/// <para>
+/// <b>The pass counts differ per row, deliberately, and must not be tidied into one constant.</b> That
+/// round trip is an <i>additive</i> per-invocation cost with its own scheduling jitter, so it does not
+/// cancel against the baseline the way a multiplicative one does — see <b>"A row through
+/// <c>Page.EvaluateAsync</c> must amortise the mailbox round trip"</b> in
+/// <a href="AGENTS.md"><c>Jint.Benchmark/AGENTS.md</c></a>, which carries the rule and the paired run that
+/// established it. The four target rows walk the document and cost milliseconds at ten passes, so ten is
+/// all they need. The two <i>control</i> rows are the ones the rule bites: <c>childNodes</c> is indexed in
+/// constant time and a plain array more so, so at ten passes each was a few microseconds of work behind a
+/// round trip an order of magnitude larger — a row that could not have detected a regression in what it
+/// controls for, and that measured as multimodal (<c>MValue</c> 3.56 on <see cref="PlainArray"/>) because
+/// what it was mostly reporting was thread scheduling. Their counts are set so that every row is at least
+/// in the low milliseconds and the round trip is a per-cent-level term.
+/// </para>
+/// <para>
+/// <b>What that costs, and it is the one trap here: a row is comparable to itself across builds, and to no
+/// other row.</b> Because the counts differ, <c>Ratio</c> is not the price of a live projection per read —
+/// it is that price times a pass-count ratio. The counts are chosen so the six means land within about
+/// 1.7–2.5 ms of each other, which keeps the table readable, but that near-equality is arranged rather than
+/// measured and means nothing on its own. Read each row against the same row on the other build; a paired
+/// run (<c>measure-paired.ps1</c>) does exactly that and is the right instrument for this class.
 /// </para>
 /// </remarks>
 [MemoryDiagnoser]
@@ -74,60 +95,95 @@ public class BrowserHtmlCollectionBenchmark
     public int Count { get; set; }
 
     /// <summary>
-    /// 10 passes of the inner loop per operation. The read is quadratic in the collection's length by
-    /// construction — these collections are live, so nothing may memoize — so this is what keeps an
-    /// operation in the low milliseconds rather than the tens.
+    /// The four rows that walk the document. One pass is already milliseconds — the read is quadratic in the
+    /// collection's length by construction, because these collections are live and nothing may memoize — so
+    /// ten passes puts the row well clear of the round trip without making it absurd.
     /// </summary>
-    private const string Passes = "10";
+    private const int WalkPasses = 10;
+
+    /// <summary>
+    /// <see cref="Children"/> is the shallow one — element children of a single node rather than a walk of
+    /// the document — so it needs several times the passes of its siblings to sit in the same band.
+    /// </summary>
+    private const int ChildrenPasses = 60;
+
+    /// <summary>
+    /// <see cref="LiveNodeList"/> reads a <c>NodeList</c>, which is indexed in constant time, so a pass is
+    /// microseconds rather than milliseconds and it takes hundreds of them to amortise the round trip. This
+    /// is a <b>control</b> row, and a control that cannot resolve a change in what it controls for is worse
+    /// than no control at all.
+    /// </summary>
+    private const int NodeListPasses = 350;
+
+    /// <summary>
+    /// <see cref="PlainArray"/> is the floor, and its pass costs very nearly what
+    /// <see cref="NodeListPasses"/>' does — measured within about 10% of it, because at 51 iterations with a
+    /// <c>c.length</c> read apiece the interpreter's own loop dominates either element read. Sized to land
+    /// the floor in the same band as the rows it is a floor for, so the <c>Ratio</c> column means something.
+    /// </summary>
+    private const int ArrayPasses = 400;
 
     /// <summary>
     /// The loop, in shape from the wpt helper <see cref="BrowserNodeListBenchmark"/> takes it from: the match
     /// is at index 50, and the <c>break</c> is what makes an operation about half the collection.
     /// </summary>
-    private const string Loop = $$"""
+    /// <remarks>
+    /// The result accumulates the index found on <i>every</i> pass rather than overwriting one variable, so
+    /// no pass is dead code — the interpreter hoists nothing today, but a row whose answer does not depend
+    /// on its own loop is one runtime change away from measuring nothing.
+    /// </remarks>
+    private static string Loop(int passes) => $$"""
         (function () {
-            var index = -1;
-            for (var i = 0; i < {{Passes}}; i++) {
+            var total = 0;
+            for (var i = 0; i < {{passes}}; i++) {
                 for (var j = 0; j < c.length; j++) {
-                    if (c[j] === el) { index = j; break; }
+                    if (c[j] === el) { total += j; break; }
                 }
             }
-            return index;
+            return total;
         })()
         """;
 
     private Browser.Browser _browser = null!;
-    private Page _className = null!;
-    private Page _tagName = null!;
-    private Page _formElements = null!;
-    private Page _children = null!;
-    private Page _liveNodeList = null!;
-    private Page _plainArray = null!;
+    private CollectionRow _className = null!;
+    private CollectionRow _tagName = null!;
+    private CollectionRow _formElements = null!;
+    private CollectionRow _children = null!;
+    private CollectionRow _liveNodeList = null!;
+    private CollectionRow _plainArray = null!;
 
     [GlobalSetup]
     public async Task Setup()
     {
         _browser = new Browser.Browser();
 
-        _className = await CreatePageAsync("var c = document.getElementsByClassName('foo');");
-        _tagName = await CreatePageAsync("var c = document.getElementsByTagName('span');");
-        _formElements = await CreatePageAsync("var c = document.getElementById('form').elements;");
-        _children = await CreatePageAsync("var c = document.getElementById('root').children;");
-        _liveNodeList = await CreatePageAsync("var c = document.getElementById('root').childNodes;");
-        _plainArray = await CreatePageAsync("var c = Array.from(document.getElementsByClassName('foo'));");
+        _className = await CreateRowAsync("var c = document.getElementsByClassName('foo');", WalkPasses);
+        _tagName = await CreateRowAsync("var c = document.getElementsByTagName('span');", WalkPasses);
+        _formElements = await CreateRowAsync("var c = document.getElementById('form').elements;", WalkPasses);
+        _children = await CreateRowAsync("var c = document.getElementById('root').children;", ChildrenPasses);
+        _liveNodeList = await CreateRowAsync("var c = document.getElementById('root').childNodes;", NodeListPasses);
+        _plainArray = await CreateRowAsync(
+            "var c = Array.from(document.getElementsByClassName('foo'));", ArrayPasses);
+    }
+
+    /// <summary>One row's page and the script it is measured with, whose pass count is this row's own.</summary>
+    private sealed class CollectionRow(Page page, string script)
+    {
+        internal Task<double> Run() => page.EvaluateAsync<double>(script);
     }
 
     /// <summary>
     /// One page holding <paramref name="bind"/>'s <c>c</c> and the element the loop looks for, warmed with
-    /// this row's own loop and nothing else.
+    /// this row's own loop — at this row's own pass count — and nothing else.
     /// </summary>
-    private async Task<Page> CreatePageAsync(string bind)
+    private async Task<CollectionRow> CreateRowAsync(string bind, int passes)
     {
         var page = await _browser.NewPageAsync();
+        var script = Loop(passes);
         await page.SetContentAsync(Document(Count));
         await page.EvaluateAsync<double>(bind + " var el = c[50]; 0;");
-        await page.EvaluateAsync<double>(Loop);
-        return page;
+        await page.EvaluateAsync<double>(script);
+        return new CollectionRow(page, script);
     }
 
     /// <summary>
@@ -155,22 +211,22 @@ public class BrowserHtmlCollectionBenchmark
     }
 
     [Benchmark]
-    public Task<double> ClassName() => _className.EvaluateAsync<double>(Loop);
+    public Task<double> ClassName() => _className.Run();
 
     [Benchmark]
-    public Task<double> TagName() => _tagName.EvaluateAsync<double>(Loop);
+    public Task<double> TagName() => _tagName.Run();
 
     [Benchmark]
-    public Task<double> FormElements() => _formElements.EvaluateAsync<double>(Loop);
+    public Task<double> FormElements() => _formElements.Run();
 
     [Benchmark]
-    public Task<double> Children() => _children.EvaluateAsync<double>(Loop);
+    public Task<double> Children() => _children.Run();
 
     [Benchmark]
-    public Task<double> LiveNodeList() => _liveNodeList.EvaluateAsync<double>(Loop);
+    public Task<double> LiveNodeList() => _liveNodeList.Run();
 
     [Benchmark(Baseline = true)]
-    public Task<double> PlainArray() => _plainArray.EvaluateAsync<double>(Loop);
+    public Task<double> PlainArray() => _plainArray.Run();
 
     [GlobalCleanup]
     public async Task Cleanup() => await _browser.DisposeAsync();

--- a/Jint.Benchmark/BrowserHtmlCollectionBenchmark.cs
+++ b/Jint.Benchmark/BrowserHtmlCollectionBenchmark.cs
@@ -1,0 +1,177 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Jint.Browser;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The same loop <see cref="BrowserNodeListBenchmark"/> measures over a <c>NodeList</c> —
+/// <c>for (j = 0; j &lt; c.length; j++) if (c[j] === el)</c> — over the four <b>live
+/// <c>HTMLCollection</c></b> shapes a page actually reaches: <c>getElementsByClassName</c>,
+/// <c>getElementsByTagName</c>, <c>form.elements</c> and <c>children</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the suite needed it.</b> There was no row for an <c>HTMLCollection</c> at all, and an
+/// <c>HTMLCollection</c> is not a <c>NodeList</c> with a different name: a <c>NodeList</c> arrives at the
+/// binding as something that can be indexed in constant time, while every <c>HTMLCollection</c> AngleSharp
+/// hands over is a lazy view over a tree walk — <c>Length</c> is a <c>Count()</c> of that walk and the
+/// indexer is a linear scan of it. A profile of this loop on a 1,500-element document put
+/// <c>NodeExtensions.GetDescendantsAndSelf.MoveNext</c> at 33.6% inclusive of the page thread, split three
+/// ways between the loop's own <c>c.length</c>, the element read, and a bounds pre-check that ran the whole
+/// query a second time before each element read. The rows below are what makes that visible; none of the
+/// existing browser rows touched it.
+/// </para>
+/// <para>
+/// <b>What each row is.</b>
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="ClassName"/> — <c>getElementsByClassName</c>, whose filter the binding owns because DOM makes
+/// its comparison ASCII case-insensitive in quirks mode and AngleSharp offers no seam for that.
+/// </description></item>
+/// <item><description>
+/// <see cref="TagName"/> — <c>getElementsByTagName</c>, the same live shape with a cheaper per-element test.
+/// </description></item>
+/// <item><description>
+/// <see cref="FormElements"/> — <c>form.elements</c>, which is AngleSharp's own
+/// <c>HtmlFormControlsCollection</c>: a <c>Where</c> over the form controls of the whole document, re-run per
+/// read. The binding cannot make that walk cheaper, only stop asking for it twice.
+/// </description></item>
+/// <item><description>
+/// <see cref="Children"/> — <c>children</c>, AngleSharp's <c>HtmlCollection</c> over one node's element
+/// children. Shallow, so it isolates the second walk from the cost of the walk itself.
+/// </description></item>
+/// <item><description>
+/// <see cref="LiveNodeList"/> — the identical loop over <c>childNodes</c>, whose elements are the same
+/// hundred nodes. It is a <c>NodeList</c>, so it reaches the generated accessor and a constant-time indexer,
+/// and nothing in this change touches that lane. <b>The control that must not move.</b>
+/// </description></item>
+/// <item><description>
+/// <see cref="PlainArray"/> — the floor and the baseline: the identical loop over the <c>Array.from</c> of
+/// the same elements, so the gap is the price of the collection being a live projection.
+/// </description></item>
+/// </list>
+/// <para>
+/// <b>Engine isolation.</b> One <see cref="Page"/> — and therefore one engine and one document — per row,
+/// built in <c>[GlobalSetup]</c> and given only that row's own fixture and its own warm-up, so a row's number
+/// never depends on which sibling warmed which lane first. That matters more here than usual: every row
+/// drives the same <c>ArrayLikeObject.TryGetIndex</c> call site, whose class profile holds one guess, and a
+/// shared engine would hand whichever row ran first a monomorphic read and the rest a cold indirect call.
+/// Page construction and the HTML parse stay outside the measurement; what the measured call adds over the
+/// loop itself is one mailbox round trip per operation, which is the same term in every row including the
+/// baseline.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class BrowserHtmlCollectionBenchmark
+{
+    /// <summary>
+    /// 100 matching elements, the size <see cref="BrowserNodeListBenchmark"/> uses, in a document of about
+    /// twice that many nodes so that a deep collection's filter rejects as well as accepts.
+    /// </summary>
+    [Params(100)]
+    public int Count { get; set; }
+
+    /// <summary>
+    /// 10 passes of the inner loop per operation. The read is quadratic in the collection's length by
+    /// construction — these collections are live, so nothing may memoize — so this is what keeps an
+    /// operation in the low milliseconds rather than the tens.
+    /// </summary>
+    private const string Passes = "10";
+
+    /// <summary>
+    /// The loop, in shape from the wpt helper <see cref="BrowserNodeListBenchmark"/> takes it from: the match
+    /// is at index 50, and the <c>break</c> is what makes an operation about half the collection.
+    /// </summary>
+    private const string Loop = $$"""
+        (function () {
+            var index = -1;
+            for (var i = 0; i < {{Passes}}; i++) {
+                for (var j = 0; j < c.length; j++) {
+                    if (c[j] === el) { index = j; break; }
+                }
+            }
+            return index;
+        })()
+        """;
+
+    private Browser.Browser _browser = null!;
+    private Page _className = null!;
+    private Page _tagName = null!;
+    private Page _formElements = null!;
+    private Page _children = null!;
+    private Page _liveNodeList = null!;
+    private Page _plainArray = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _browser = new Browser.Browser();
+
+        _className = await CreatePageAsync("var c = document.getElementsByClassName('foo');");
+        _tagName = await CreatePageAsync("var c = document.getElementsByTagName('span');");
+        _formElements = await CreatePageAsync("var c = document.getElementById('form').elements;");
+        _children = await CreatePageAsync("var c = document.getElementById('root').children;");
+        _liveNodeList = await CreatePageAsync("var c = document.getElementById('root').childNodes;");
+        _plainArray = await CreatePageAsync("var c = Array.from(document.getElementsByClassName('foo'));");
+    }
+
+    /// <summary>
+    /// One page holding <paramref name="bind"/>'s <c>c</c> and the element the loop looks for, warmed with
+    /// this row's own loop and nothing else.
+    /// </summary>
+    private async Task<Page> CreatePageAsync(string bind)
+    {
+        var page = await _browser.NewPageAsync();
+        await page.SetContentAsync(Document(Count));
+        await page.EvaluateAsync<double>(bind + " var el = c[50]; 0;");
+        await page.EvaluateAsync<double>(Loop);
+        return page;
+    }
+
+    /// <summary>
+    /// <paramref name="count"/> spans under one parent and <paramref name="count"/> controls in one form, so
+    /// that every row's collection holds the same number of elements and every deep filter has as many
+    /// non-matching elements to walk past as matching ones.
+    /// </summary>
+    private static string Document(int count)
+    {
+        var html = new StringBuilder("<!doctype html><html><body><div id=\"root\">");
+
+        for (var i = 0; i < count; i++)
+        {
+            html.Append("<span class=\"foo\"></span>");
+        }
+
+        html.Append("</div><form id=\"form\">");
+
+        for (var i = 0; i < count; i++)
+        {
+            html.Append("<input type=\"text\">");
+        }
+
+        return html.Append("</form></body></html>").ToString();
+    }
+
+    [Benchmark]
+    public Task<double> ClassName() => _className.EvaluateAsync<double>(Loop);
+
+    [Benchmark]
+    public Task<double> TagName() => _tagName.EvaluateAsync<double>(Loop);
+
+    [Benchmark]
+    public Task<double> FormElements() => _formElements.EvaluateAsync<double>(Loop);
+
+    [Benchmark]
+    public Task<double> Children() => _children.EvaluateAsync<double>(Loop);
+
+    [Benchmark]
+    public Task<double> LiveNodeList() => _liveNodeList.EvaluateAsync<double>(Loop);
+
+    [Benchmark(Baseline = true)]
+    public Task<double> PlainArray() => _plainArray.EvaluateAsync<double>(Loop);
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _browser.DisposeAsync();
+}

--- a/Jint.Browser/Dom/Collections/DomCollectionObject.cs
+++ b/Jint.Browser/Dom/Collections/DomCollectionObject.cs
@@ -248,10 +248,7 @@ internal sealed class DomCollectionObject : DomCollectionBase, INamedPropertySup
             return names;
         }
 
-        var lowercaseOnly = DomTarget is INamedNodeMap { Length: > 0 } map
-                            && map[0] is { OwnerElement: { } owner }
-                            && string.Equals(owner.NamespaceUri, NamespaceNames.HtmlUri, StringComparison.Ordinal)
-                            && owner.Owner is IHtmlDocument;
+        var lowercaseOnly = LowercaseNamesOnly();
 
         var supported = new List<string>(names.Count);
 
@@ -271,6 +268,16 @@ internal sealed class DomCollectionObject : DomCollectionBase, INamedPropertySup
         return supported;
     }
 
+    /// <summary>
+    /// DOM §4.9.1's second step: whether this map's names are restricted to their own ASCII lowercase,
+    /// which they are exactly while the owning element is in the HTML namespace in an HTML document.
+    /// </summary>
+    private bool LowercaseNamesOnly()
+        => DomTarget is INamedNodeMap { Length: > 0 } map
+           && map[0] is { OwnerElement: { } owner }
+           && string.Equals(owner.NamespaceUri, NamespaceNames.HtmlUri, StringComparison.Ordinal)
+           && owner.Owner is IHtmlDocument;
+
     /// <summary>Whether <paramref name="name"/> ASCII-lowercased is <paramref name="name"/>.</summary>
     private static bool IsAsciiLowercase(string name)
     {
@@ -285,17 +292,32 @@ internal sealed class DomCollectionObject : DomCollectionBase, INamedPropertySup
         return true;
     }
 
+    /// <summary>
+    /// Whether <paramref name="name"/> is a supported property name — the membership question, asked on the
+    /// <b>read</b> path by <see cref="TryGetNamedValue"/> and by WebIDL's legacy <c>[[DefineOwnProperty]]</c>.
+    /// </summary>
+    /// <remarks>
+    /// It scans rather than asking <see cref="SupportedNames"/>, whose job is to <em>list</em>: for
+    /// <c>el.attributes.foo</c> that materialized every attribute name into a <c>List&lt;string&gt;</c>, then
+    /// a second filtered list, and then scanned it with a comparer overload that allocated an enumerator per
+    /// candidate — three allocations and a full walk of the map to answer a question about one member.
+    /// Membership is the same either way: duplicate removal cannot change it, and the one filter that can is
+    /// <see cref="LowercaseNamesOnly"/>, applied here to the name asked about instead of to every name there
+    /// is.
+    /// </remarks>
     private bool HasSupportedName(string name)
     {
-        foreach (var supportedName in SupportedNames())
+        if (!_accessor.HasNamedGetter)
         {
-            if (string.Equals(supportedName, name, StringComparison.Ordinal))
-            {
-                return true;
-            }
+            return false;
         }
 
-        return false;
+        if (ReferenceEquals(Definition, DomInterfaces.NamedNodeMap) && !IsAsciiLowercase(name) && LowercaseNamesOnly())
+        {
+            return false;
+        }
+
+        return _accessor.HasSupportedName(DomTarget, name);
     }
 
     bool INamedPropertySupport.HasSupportedName(string name) => HasSupportedName(name);

--- a/Jint.Browser/Dom/Collections/DomElementFilter.cs
+++ b/Jint.Browser/Dom/Collections/DomElementFilter.cs
@@ -1,0 +1,48 @@
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Dom.Collections;
+
+/// <summary>
+/// The membership test of a <see cref="DomLiveHtmlCollection"/> — the "filter" of DOM's
+/// <a href="https://dom.spec.whatwg.org/#concept-collection">collection</a> concept.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It is an object with a method rather than a <c>Func&lt;IElement, bool&gt;</c> so that a read costs one
+/// virtual call per element and <b>no allocation</b>. A closure would be allocated per read wherever the
+/// predicate depends on something read from the tree at the moment of the read — which is every one of them:
+/// <c>getElementsByClassName</c>'s comparison is ASCII case-insensitive exactly while the root's node
+/// document is in quirks mode, and a root adopted into another document takes that document's mode with it.
+/// <see cref="BeginRead"/> is where such state is refreshed, once per read rather than once per element.
+/// </para>
+/// <para>
+/// A filter is owned by exactly one collection, and a collection is owned by one page's engine on one
+/// thread. Nothing between <see cref="BeginRead"/> and the end of the walk it opens can run script or mutate
+/// the document, so state a filter carries across that span is not shared state.
+/// </para>
+/// </remarks>
+internal abstract class DomElementFilter
+{
+    /// <summary>The filter of an empty collection, which DOM still requires to be a collection.</summary>
+    internal static DomElementFilter None { get; } = new NothingFilter();
+
+    /// <summary>
+    /// Whether this filter can never match, which lets a read answer without walking the tree at all.
+    /// </summary>
+    internal virtual bool MatchesNothing => false;
+
+    /// <summary>Refreshes whatever the filter reads from the tree once per read, before the walk begins.</summary>
+    internal virtual void BeginRead()
+    {
+    }
+
+    /// <summary>Whether <paramref name="element"/> is in the collection.</summary>
+    internal abstract bool Matches(IElement element);
+
+    private sealed class NothingFilter : DomElementFilter
+    {
+        internal override bool MatchesNothing => true;
+
+        internal override bool Matches(IElement element) => false;
+    }
+}

--- a/Jint.Browser/Dom/Collections/DomElementWalker.cs
+++ b/Jint.Browser/Dom/Collections/DomElementWalker.cs
@@ -1,0 +1,185 @@
+using System.Runtime.CompilerServices;
+using AngleSharp.Dom;
+
+namespace Jint.Browser.Dom.Collections;
+
+/// <summary>
+/// A depth-first pre-order walk over the <b>element</b> descendants of one node, in tree order, allocating
+/// nothing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the binding has one at all.</b> The obvious spelling of a live collection's filter is
+/// <c>root.Descendants&lt;IElement&gt;().Where(…)</c>, and that is what these collections used to be. It costs,
+/// per read: a <c>Stack&lt;INode&gt;</c> and its backing array, which grows to the <i>width</i> of the tree
+/// even when the very first element matches; a covariance store check on every push, because the stack holds
+/// a reference type; three chained iterators (<c>GetDescendantsAndSelf</c>, <c>Skip(1)</c>,
+/// <c>OfType</c>) plus the <c>Where</c>, so four virtual <c>MoveNext</c> calls and an interface type test per
+/// node; and a delegate invocation per element. A profile of
+/// <c>for (i = 0; i &lt; c.length; i++) c[i]</c> over four live collections on a 1,500-element document put
+/// <c>NodeExtensions.GetDescendantsAndSelf.MoveNext</c> at 33.6% inclusive of the page thread, with the array
+/// covariance helper alone at 6.1% self.
+/// </para>
+/// <para>
+/// <b>Why an index stack and not a node stack.</b> This is the design AngleSharp's own internal
+/// <c>ElementTreeEnumerator</c> arrived at, for the reason its comment gives: walking parent links and
+/// keeping a stack of <i>child indices</i> stores value types, needs no covariance check, and is bounded by
+/// the <i>depth</i> of the tree rather than its width. That type is internal to AngleSharp and cannot be
+/// referenced, so this is the same shape written against the public <c>INode</c> surface —
+/// <c>ChildNodes</c>, the indexer and <c>Parent</c> — and rooted at a node that need not itself be an
+/// element, because <c>getElementsByTagName</c> is called on documents and fragments too.
+/// </para>
+/// <para>
+/// <b>Why the index stack allocates nothing.</b> The first <see cref="InlineDepth"/> levels live in an
+/// inline array inside this struct, which is where every real document's element depth fits; a deeper tree
+/// copies them once into a heap array and grows that. The root is never yielded — these collections are over
+/// <i>descendants</i> — and only elements are descended into, which is equivalent to visiting every
+/// descendant and keeping the elements, since no non-element node has element descendants.
+/// </para>
+/// <para>
+/// The walk reads the tree as it goes, so it must not be suspended across anything that can mutate the
+/// document. Nothing between a caller's first <see cref="MoveNext"/> and its last runs script: the element
+/// wrapper a read answers with is created after the walk has found it.
+/// </para>
+/// </remarks>
+internal struct DomElementWalker
+{
+    /// <summary>Element depths at or below this cost no allocation at all.</summary>
+    private const int InlineDepth = 16;
+
+    private INode _current;
+    private IndexBuffer _inline;
+    private int[]? _overflow;
+    private int _depth;
+    private bool _finished;
+
+    internal DomElementWalker(INode root)
+    {
+        _current = root;
+        _inline = default;
+        _overflow = null;
+        _depth = 0;
+        _finished = false;
+    }
+
+    /// <summary>The element the walk is positioned on. Undefined before the first <see cref="MoveNext"/>.</summary>
+    internal readonly IElement Current => (IElement) _current;
+
+    /// <summary>Advances to the next element descendant in tree order.</summary>
+    internal bool MoveNext()
+    {
+        if (_finished)
+        {
+            return false;
+        }
+
+        var child = FirstElementFrom(_current, 0, out var childIndex);
+
+        if (child is not null)
+        {
+            Push(childIndex);
+            _current = child;
+            return true;
+        }
+
+        while (_depth > 0)
+        {
+            // Only elements are ever descended into and the walk never leaves the root, so the parent of the
+            // node it is positioned on is always the element it descended from -- unless the tree moved under
+            // the walk, which ends it rather than dereferencing null.
+            var parent = _current.Parent;
+
+            if (parent is null)
+            {
+                break;
+            }
+
+            var sibling = FirstElementFrom(parent, TopIndex() + 1, out var siblingIndex);
+
+            if (sibling is not null)
+            {
+                SetTopIndex(siblingIndex);
+                _current = sibling;
+                return true;
+            }
+
+            _depth--;
+            _current = parent;
+        }
+
+        _finished = true;
+        return false;
+    }
+
+    /// <summary>The first element child of <paramref name="parent"/> at or after <paramref name="start"/>.</summary>
+    private static IElement? FirstElementFrom(INode parent, int start, out int index)
+    {
+        var children = parent.ChildNodes;
+        var length = children.Length;
+
+        for (var i = start; i < length; i++)
+        {
+            if (children[i] is IElement element)
+            {
+                index = i;
+                return element;
+            }
+        }
+
+        index = -1;
+        return null;
+    }
+
+    private readonly int TopIndex() => _overflow is null ? _inline[_depth - 1] : _overflow[_depth - 1];
+
+    private void SetTopIndex(int index)
+    {
+        if (_overflow is null)
+        {
+            _inline[_depth - 1] = index;
+        }
+        else
+        {
+            _overflow[_depth - 1] = index;
+        }
+    }
+
+    private void Push(int index)
+    {
+        var depth = _depth;
+
+        if (_overflow is null)
+        {
+            if (depth < InlineDepth)
+            {
+                _inline[depth] = index;
+                _depth = depth + 1;
+                return;
+            }
+
+            var promoted = new int[InlineDepth * 2];
+            for (var i = 0; i < InlineDepth; i++)
+            {
+                promoted[i] = _inline[i];
+            }
+
+            _overflow = promoted;
+        }
+        else if (depth == _overflow.Length)
+        {
+            Array.Resize(ref _overflow, depth * 2);
+        }
+
+        _overflow[depth] = index;
+        _depth = depth + 1;
+    }
+
+    /// <summary>The inline half of the index stack: <see cref="InlineDepth"/> child indices, no allocation.</summary>
+    [InlineArray(InlineDepth)]
+    private struct IndexBuffer
+    {
+#pragma warning disable CS0169, IDE0051 // The inline array's single field is reached through the indexer.
+        private int _element0;
+#pragma warning restore CS0169, IDE0051
+    }
+}

--- a/Jint.Browser/Dom/Collections/DomHtmlAllCollectionObject.cs
+++ b/Jint.Browser/Dom/Collections/DomHtmlAllCollectionObject.cs
@@ -73,20 +73,46 @@ internal sealed class DomHtmlAllCollectionObject : DomCollectionBase, ICallable
     /// https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#concept-get-all-indexed — the
     /// <c>index</c>th element, or nothing at all when there is no such element.
     /// </summary>
+    /// <remarks>
+    /// One walk, not two: AngleSharp's <c>HtmlAllCollection</c> is a lazy view over the document's element
+    /// descendants, so <c>Length</c> runs the whole query and the indexer runs it again. Running out of
+    /// elements <i>is</i> the bounds answer, which is the same reason
+    /// <see cref="DomHtmlCollectionObject{T}.TryGetIndex"/> stopped asking for a length first.
+    /// </remarks>
     public override bool TryGetIndex(uint index, out JsValue value)
     {
-        if (index >= (uint) _collection.Length)
+        var element = ElementAt(index);
+
+        if (element is null)
         {
             value = JsValue.Undefined;
             return false;
         }
 
-        value = DomRealm.Wrap(_collection[(int) index]);
+        value = DomRealm.Wrap(element);
         return true;
     }
 
     /// <inheritdoc />
-    protected override bool HasIndex(uint index) => index < (uint) _collection.Length;
+    protected override bool HasIndex(uint index) => ElementAt(index) is not null;
+
+    /// <summary>The <paramref name="index"/>th element of the collection, in one pass, or <see langword="null"/>.</summary>
+    private IElement? ElementAt(uint index)
+    {
+        var remaining = index;
+
+        foreach (var candidate in _collection)
+        {
+            if (remaining == 0)
+            {
+                return candidate;
+            }
+
+            remaining--;
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// The supported property names: every element's non-empty <c>id</c> and every "all"-named element's
@@ -241,18 +267,18 @@ internal sealed class DomHtmlAllCollectionObject : DomCollectionBase, ICallable
         return _memoizedCollection;
     }
 
+    /// <remarks>
+    /// The source is this collection rather than a tree root, which is the one live collection in the
+    /// surface that is not "the element descendants of a node": <c>document.all</c>'s own membership is
+    /// already the filter's domain, and the wrapper has no reference to the document to root a walk at.
+    /// </remarks>
     private JsValue NewSubCollection(string name)
-        => DomRealm.WrapCollection<IElement>(new DomLiveHtmlCollection(() => Filtered(name)));
+        => DomRealm.WrapCollection<IElement>(new DomLiveHtmlCollection(_collection, new AllNamedFilter(name)));
 
-    private IEnumerable<IElement> Filtered(string name)
+    /// <summary>The filter of the sub-collection above: an id always, a <c>name</c> only on an "all"-named element.</summary>
+    private sealed class AllNamedFilter(string name) : DomElementFilter
     {
-        foreach (var element in _collection)
-        {
-            if (Matches(element, name))
-            {
-                yield return element;
-            }
-        }
+        internal override bool Matches(IElement element) => DomHtmlAllCollectionObject.Matches(element, name);
     }
 
     private static bool Matches(IElement element, string name)
@@ -262,9 +288,16 @@ internal sealed class DomHtmlAllCollectionObject : DomCollectionBase, ICallable
     private static bool IsAllNamed(IElement element)
         => element is IHtmlElement && _allNamed.Contains(element.LocalName);
 
+    /// <remarks>
+    /// The duplicate check is a set for the reason <c>DomHtmlCollectionObject.VisibleNames</c> gives: the
+    /// <c>Contains</c> overload taking a comparer is LINQ's, linear and one enumerator per candidate, and
+    /// <c>document.all</c> is the collection with the most of them.
+    /// </remarks>
     private List<string> VisibleNames()
     {
         var names = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
         foreach (var element in _collection)
         {
             Add(names, element.Id);
@@ -280,7 +313,7 @@ internal sealed class DomHtmlAllCollectionObject : DomCollectionBase, ICallable
         void Add(List<string> names, string? candidate)
         {
             if (string.IsNullOrEmpty(candidate)
-                || names.Contains(candidate!, StringComparer.Ordinal)
+                || !seen.Add(candidate!)
                 // A supported name that spells a canonical array index is unreachable as a property — the
                 // indexed half answers first and stops — so WebIDL leaves it out of [[OwnPropertyKeys]] and
                 // ArrayLikeObject refuses to advertise it. namedItem still finds it.

--- a/Jint.Browser/Dom/Collections/DomHtmlCollectionObject.cs
+++ b/Jint.Browser/Dom/Collections/DomHtmlCollectionObject.cs
@@ -20,12 +20,18 @@ namespace Jint.Browser.Dom.Collections;
 internal sealed class DomHtmlCollectionObject<T> : DomCollectionBase where T : class, IElement
 {
     private readonly IHtmlCollection<T> _collection;
+    // The collection when it is the binding's own live one, and null when it is AngleSharp's -- read on
+    // every indexed access, so it is a field rather than a type test, the same shape and for the same reason
+    // as DomCollectionObject's static-NodeList branch.
+    private readonly DomLiveHtmlCollection? _live;
+
     private List<string> _names = [];
 
     internal DomHtmlCollectionObject(DomRealm realm, DomInterfaceDefinition definition, IHtmlCollection<T> collection)
         : base(realm, definition, collection)
     {
         _collection = collection;
+        _live = collection as DomLiveHtmlCollection;
     }
 
     /// <inheritdoc />
@@ -37,18 +43,66 @@ internal sealed class DomHtmlCollectionObject<T> : DomCollectionBase where T : c
     /// <inheritdoc />
     public override bool TryGetIndex(uint index, out JsValue value)
     {
-        if (index >= (uint) _collection.Length)
+        var element = ElementAt(index);
+
+        if (element is null)
         {
             value = JsValue.Undefined;
             return false;
         }
 
-        value = DomRealm.Wrap(_collection[(int) index]);
+        value = DomRealm.Wrap(element);
         return true;
     }
 
     /// <inheritdoc />
-    protected override bool HasIndex(uint index) => index < (uint) _collection.Length;
+    protected override bool HasIndex(uint index) => ElementAt(index) is not null;
+
+    /// <summary>
+    /// The <paramref name="index"/>th element, in <b>one</b> pass over the collection, or
+    /// <see langword="null"/> when it has none there.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why no <c>Length</c> check stands in front of it.</b> Every implementation of
+    /// <c>IHtmlCollection&lt;T&gt;</c> this wrapper is given is a lazy view over a tree walk rather than a
+    /// list. AngleSharp's <c>HtmlCollection&lt;T&gt;</c> — <c>children</c>, and the snapshot collections —
+    /// holds an <c>IEnumerable&lt;T&gt;</c> whose <c>Length</c> is <c>Count()</c> and whose indexer is a
+    /// linear <c>GetItemByIndex</c>; its <c>HtmlFormControlsCollection</c> (<c>form.elements</c>) is a
+    /// <c>Where</c> over the document's form-control descendants; and the binding's own
+    /// <see cref="DomLiveHtmlCollection"/> re-runs its filter. So the bounds pre-check this method replaced
+    /// ran the entire query a second time on every element read — 36.3% of the <c>GetDescendantsAndSelf</c>
+    /// subtree in the profile on
+    /// <a href="https://github.com/sebastienros/jint/issues/4013">sebastienros/jint#4013</a>. Running out of
+    /// elements <i>is</i> the bounds answer, and it comes free with the walk that had to happen anyway.
+    /// </para>
+    /// <para>
+    /// The collections that really can be indexed in constant time — <c>childNodes</c>, <c>attributes</c>, a
+    /// token list — are not these. They reach <see cref="DomCollectionObject"/> and its generated accessor,
+    /// whose length probe is a field read, and it stays where it is.
+    /// </para>
+    /// </remarks>
+    private IElement? ElementAt(uint index)
+    {
+        if (_live is { } live)
+        {
+            return live.TryGetElementAt(index, out var element) ? element : null;
+        }
+
+        var remaining = index;
+
+        foreach (var candidate in _collection)
+        {
+            if (remaining == 0)
+            {
+                return candidate;
+            }
+
+            remaining--;
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// https://dom.spec.whatwg.org/#interface-htmlcollection — the supported property names are every
@@ -142,9 +196,17 @@ internal sealed class DomHtmlCollectionObject<T> : DomCollectionBase where T : c
         return JsValue.Null;
     }
 
+    /// <remarks>
+    /// The duplicate check is a set rather than <c>names.Contains(…, StringComparer.Ordinal)</c>, which is
+    /// the LINQ overload: it is linear in the names found so far <em>and</em> allocates an enumerator per
+    /// candidate, so listing the names of a collection of <i>n</i> named elements cost O(n²) comparisons and
+    /// 2n allocations. The list is still what carries the order, which is the one thing the set cannot.
+    /// </remarks>
     private List<string> VisibleNames()
     {
         var names = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
         foreach (var element in _collection)
         {
             Add(names, element.Id);
@@ -162,7 +224,7 @@ internal sealed class DomHtmlCollectionObject<T> : DomCollectionBase where T : c
             // The base class lists an ordinary own property itself, in property-bag order. Do not also
             // advertise a projected name for it, or enumeration and lookup would disagree.
             if (!string.IsNullOrEmpty(candidate)
-                && !names.Contains(candidate!, StringComparer.Ordinal)
+                && seen.Add(candidate!)
                 // A supported name spelling a canonical array index is unreachable as a property: the indexed
                 // half of the model answers that key and stops, which is why WebIDL leaves such a name out of
                 // [[OwnPropertyKeys]] and why ArrayLikeObject refuses to advertise one. namedItem still finds

--- a/Jint.Browser/Dom/Collections/DomLiveHtmlCollection.cs
+++ b/Jint.Browser/Dom/Collections/DomLiveHtmlCollection.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using AngleSharp.Dom;
 
 namespace Jint.Browser.Dom.Collections;
@@ -7,16 +8,134 @@ namespace Jint.Browser.Dom.Collections;
 /// An <see cref="IHtmlCollection{T}"/> whose filter is evaluated against the current tree for every read.
 /// </summary>
 /// <remarks>
+/// <para>
 /// DOM collections are live unless their defining algorithm says otherwise. AngleSharp's tag-name and
-/// class-name queries materialize a snapshot, so the binding supplies this small adapter for those operations. Keeping the
-/// target as an <see cref="IHtmlCollection{T}"/> lets the ordinary HTMLCollection wrapper retain the one
-/// indexed and named-property implementation used by every other collection.
+/// class-name queries materialize a snapshot, so the binding supplies this small adapter for those
+/// operations. Keeping the target as an <see cref="IHtmlCollection{T}"/> lets the ordinary HTMLCollection
+/// wrapper retain the one indexed and named-property implementation used by every other collection.
+/// </para>
+/// <para>
+/// <b>Every read is one walk, and it allocates nothing.</b> The element at an index is found by walking until
+/// the walk has passed that many matches — so running out <i>is</i> the bounds answer and no separate
+/// <see cref="Length"/> probe precedes it — and the walk itself is <see cref="DomElementWalker"/>, whose
+/// remarks carry the measurement that motivated both. Nothing here memoizes: these collections are live by
+/// specification, so a second read re-runs the filter against whatever the tree now is.
+/// </para>
+/// <para>
+/// <b>Two sources.</b> Nearly every live collection in the surface is "the element descendants of a root that
+/// match a filter", which is the <see cref="DomElementWalker"/> form. The exception is <c>document.all</c>'s
+/// named sub-collection, whose source is another live collection rather than a tree and which therefore
+/// filters a sequence; it is reached only from a named read of <c>document.all</c> that several elements
+/// match, and is deliberately left on that shape rather than given a wrapper of its own.
+/// </para>
 /// </remarks>
-internal sealed class DomLiveHtmlCollection(Func<IEnumerable<IElement>> current) : IHtmlCollection<IElement>
+internal sealed class DomLiveHtmlCollection : IHtmlCollection<IElement>
 {
-    public int Length => current().Count();
+    private readonly INode? _root;
+    private readonly IEnumerable<IElement>? _source;
+    private readonly DomElementFilter _filter;
+
+    /// <summary>The element descendants of <paramref name="root"/> that <paramref name="filter"/> matches.</summary>
+    internal DomLiveHtmlCollection(INode root, DomElementFilter filter)
+    {
+        _root = root;
+        _filter = filter;
+    }
+
+    /// <summary>The members of <paramref name="source"/> that <paramref name="filter"/> matches.</summary>
+    internal DomLiveHtmlCollection(IEnumerable<IElement> source, DomElementFilter filter)
+    {
+        _source = source;
+        _filter = filter;
+    }
+
+    public int Length
+    {
+        get
+        {
+            if (_filter.MatchesNothing)
+            {
+                return 0;
+            }
+
+            var count = 0;
+
+            if (_root is { } root)
+            {
+                _filter.BeginRead();
+                var walker = new DomElementWalker(root);
+                while (walker.MoveNext())
+                {
+                    if (_filter.Matches(walker.Current))
+                    {
+                        count++;
+                    }
+                }
+
+                return count;
+            }
+
+            foreach (var unused in Filtered())
+            {
+                count++;
+            }
+
+            return count;
+        }
+    }
 
     public int Count => Length;
+
+    /// <summary>
+    /// The element at <paramref name="index"/>, and <see langword="false"/> when the collection has none —
+    /// which is the authoritative bounds answer, taken from the one walk rather than from a
+    /// <see cref="Length"/> that would have had to run the whole query again.
+    /// </summary>
+    internal bool TryGetElementAt(uint index, [NotNullWhen(true)] out IElement? element)
+    {
+        if (!_filter.MatchesNothing)
+        {
+            var remaining = index;
+
+            if (_root is { } root)
+            {
+                _filter.BeginRead();
+                var walker = new DomElementWalker(root);
+                while (walker.MoveNext())
+                {
+                    var candidate = walker.Current;
+                    if (!_filter.Matches(candidate))
+                    {
+                        continue;
+                    }
+
+                    if (remaining == 0)
+                    {
+                        element = candidate;
+                        return true;
+                    }
+
+                    remaining--;
+                }
+            }
+            else
+            {
+                foreach (var candidate in Filtered())
+                {
+                    if (remaining == 0)
+                    {
+                        element = candidate;
+                        return true;
+                    }
+
+                    remaining--;
+                }
+            }
+        }
+
+        element = null;
+        return false;
+    }
 
     public IElement this[int index]
     {
@@ -24,15 +143,12 @@ internal sealed class DomLiveHtmlCollection(Func<IEnumerable<IElement>> current)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(index);
 
-            foreach (var element in Current())
+            if (!TryGetElementAt((uint) index, out var element))
             {
-                if (index-- == 0)
-                {
-                    return element;
-                }
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            throw new ArgumentOutOfRangeException(nameof(index));
+            return element;
         }
     }
 
@@ -45,13 +161,32 @@ internal sealed class DomLiveHtmlCollection(Func<IEnumerable<IElement>> current)
     {
         get
         {
-            foreach (var element in Current())
+            if (_filter.MatchesNothing)
             {
-                if (string.Equals(element.Id, id, StringComparison.Ordinal)
-                    || (element is AngleSharp.Html.Dom.IHtmlElement
-                        && string.Equals(element.GetAttribute("name"), id, StringComparison.Ordinal)))
+                return null;
+            }
+
+            if (_root is { } root)
+            {
+                _filter.BeginRead();
+                var walker = new DomElementWalker(root);
+                while (walker.MoveNext())
                 {
-                    return element;
+                    var candidate = walker.Current;
+                    if (_filter.Matches(candidate) && IsNamed(candidate, id))
+                    {
+                        return candidate;
+                    }
+                }
+
+                return null;
+            }
+
+            foreach (var candidate in Filtered())
+            {
+                if (IsNamed(candidate, id))
+                {
+                    return candidate;
                 }
             }
 
@@ -59,9 +194,50 @@ internal sealed class DomLiveHtmlCollection(Func<IEnumerable<IElement>> current)
         }
     }
 
-    public IEnumerator<IElement> GetEnumerator() => Current().GetEnumerator();
+    private static bool IsNamed(IElement element, string id)
+        => string.Equals(element.Id, id, StringComparison.Ordinal)
+           || (element is AngleSharp.Html.Dom.IHtmlElement
+               && string.Equals(element.GetAttribute("name"), id, StringComparison.Ordinal));
+
+    public IEnumerator<IElement> GetEnumerator() => Filtered().GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    private IEnumerable<IElement> Current() => current();
+    /// <summary>
+    /// The matching elements as a sequence, for the callers that really do visit all of them — the named
+    /// half of <c>HTMLCollection</c>, and the sequence-sourced form. The indexed lane does not come through
+    /// here, because a state machine is an allocation and it reads one element.
+    /// </summary>
+    private IEnumerable<IElement> Filtered()
+    {
+        if (_filter.MatchesNothing)
+        {
+            yield break;
+        }
+
+        _filter.BeginRead();
+
+        if (_root is { } root)
+        {
+            var walker = new DomElementWalker(root);
+            while (walker.MoveNext())
+            {
+                var candidate = walker.Current;
+                if (_filter.Matches(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+
+            yield break;
+        }
+
+        foreach (var candidate in _source!)
+        {
+            if (_filter.Matches(candidate))
+            {
+                yield return candidate;
+            }
+        }
+    }
 }

--- a/Jint.Browser/Dom/DomCollectionAccessor.cs
+++ b/Jint.Browser/Dom/DomCollectionAccessor.cs
@@ -50,6 +50,19 @@ internal abstract class DomCollectionAccessor
     internal virtual IReadOnlyList<string> SupportedNames(object target) => [];
 
     /// <summary>
+    /// Whether <paramref name="name"/> is one of the supported property names, without materializing them.
+    /// </summary>
+    /// <remarks>
+    /// It is the membership half of <see cref="SupportedNames"/> and answers exactly what a linear scan of
+    /// that list would, which is what WebIDL's
+    /// <a href="https://webidl.spec.whatwg.org/#dfn-named-property-visibility">named property visibility</a>
+    /// check asks. It exists because that check is on the <b>read</b> path — <c>el.attributes.foo</c> asks it
+    /// before the named getter runs — where building a list of every name in order to look at one of them is
+    /// a list allocation and a walk of the whole collection for a question about a single member.
+    /// </remarks>
+    internal virtual bool HasSupportedName(object target, string name) => false;
+
+    /// <summary>
     /// Whether the supported property names enumerate. WebIDL's
     /// <a href="https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties">[LegacyUnenumerableNamedProperties]</a>
     /// answers <see langword="false"/>, and every named getter in the generated surface but

--- a/Jint.Browser/Dom/DomHostHooks.cs
+++ b/Jint.Browser/Dom/DomHostHooks.cs
@@ -236,15 +236,24 @@ internal class DomHostHooks
         {
             // "If classes is the empty set, return an empty HTMLCollection" - and an empty one that is still
             // a collection, because a page holds it and reads its length.
-            return realm.WrapCollection<IElement>(new DomLiveHtmlCollection(static () => []));
+            return realm.WrapCollection<IElement>(new DomLiveHtmlCollection(root, DomElementFilter.None));
         }
 
-        return realm.WrapCollection<IElement>(new DomLiveHtmlCollection(() =>
-        {
-            // DOM §4.5: compatMode is "BackCompat" exactly while the node document's mode is "quirks".
-            var quirks = string.Equals((root as IDocument ?? root.Owner)?.CompatMode, "BackCompat", StringComparison.Ordinal);
-            return root.Descendants<IElement>().Where(element => HasEveryClass(element, classes, quirks));
-        }));
+        return realm.WrapCollection<IElement>(new DomLiveHtmlCollection(root, new ClassNameFilter(root, classes)));
+    }
+
+    /// <summary>
+    /// The filter of https://dom.spec.whatwg.org/#concept-getelementsbyclassname. A <see cref="DomElementFilter"/>
+    /// rather than a lambda so that a read allocates neither a closure nor an iterator; see that type.
+    /// </summary>
+    private sealed class ClassNameFilter(INode root, string[] classes) : DomElementFilter
+    {
+        private bool _quirks;
+
+        internal override void BeginRead()
+            => _quirks = string.Equals((root as IDocument ?? root.Owner)?.CompatMode, "BackCompat", StringComparison.Ordinal);
+
+        internal override bool Matches(IElement element) => HasEveryClass(element, classes, _quirks);
     }
 
     /// <summary>https://dom.spec.whatwg.org/#concept-getelementsbytagname</summary>
@@ -252,21 +261,26 @@ internal class DomHostHooks
     {
         var qualifiedName = DomConvert.RequiredText(arguments, 0, Member(root, "getElementsByTagName"));
         var htmlDocument = (root as IDocument ?? root.Owner) is IHtmlDocument;
-        var htmlName = AsciiLowercase(qualifiedName);
 
-        return realm.WrapCollection<IElement>(new DomLiveHtmlCollection(() =>
-            root.Descendants<IElement>().Where(element =>
+        return realm.WrapCollection<IElement>(
+            new DomLiveHtmlCollection(root, new TagNameFilter(qualifiedName, AsciiLowercase(qualifiedName), htmlDocument)));
+    }
+
+    /// <summary>The filter of https://dom.spec.whatwg.org/#concept-getelementsbytagname.</summary>
+    private sealed class TagNameFilter(string qualifiedName, string htmlName, bool htmlDocument) : DomElementFilter
+    {
+        internal override bool Matches(IElement element)
+        {
+            if (qualifiedName == "*")
             {
-                if (qualifiedName == "*")
-                {
-                    return true;
-                }
+                return true;
+            }
 
-                var candidate = QualifiedName(element);
-                return htmlDocument && string.Equals(element.NamespaceUri, NamespaceNames.HtmlUri, StringComparison.Ordinal)
-                    ? string.Equals(candidate, htmlName, StringComparison.Ordinal)
-                    : string.Equals(candidate, qualifiedName, StringComparison.Ordinal);
-            })));
+            var candidate = QualifiedName(element);
+            return htmlDocument && string.Equals(element.NamespaceUri, NamespaceNames.HtmlUri, StringComparison.Ordinal)
+                ? string.Equals(candidate, htmlName, StringComparison.Ordinal)
+                : string.Equals(candidate, qualifiedName, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>https://dom.spec.whatwg.org/#concept-getelementsbynamespacename</summary>
@@ -280,16 +294,20 @@ internal class DomHostHooks
         }
 
         var localName = DomConvert.RequiredText(arguments, 1, member);
-        IEnumerable<IElement> Current()
-        {
-            // AngleSharp 1.8.1 preserves HTML local-name case, so the same DOM comparison now
-            // works in every namespace. Its native HTML namespace query still folds case.
-            return root.Descendants<IElement>().Where(element =>
-                (namespaceUri == "*" || string.Equals(NullIfEmpty(element.NamespaceUri), namespaceUri, StringComparison.Ordinal))
-                && (localName == "*" || string.Equals(element.LocalName, localName, StringComparison.Ordinal)));
-        }
 
-        return realm.WrapCollection<IElement>(new DomLiveHtmlCollection(Current));
+        return realm.WrapCollection<IElement>(new DomLiveHtmlCollection(root, new TagNameNSFilter(namespaceUri, localName)));
+    }
+
+    /// <summary>The filter of https://dom.spec.whatwg.org/#concept-getelementsbynamespacename.</summary>
+    /// <remarks>
+    /// AngleSharp 1.8.1 preserves HTML local-name case, so the same DOM comparison now works in every
+    /// namespace. Its native HTML namespace query still folds case.
+    /// </remarks>
+    private sealed class TagNameNSFilter(string? namespaceUri, string localName) : DomElementFilter
+    {
+        internal override bool Matches(IElement element)
+            => (namespaceUri == "*" || string.Equals(NullIfEmpty(element.NamespaceUri), namespaceUri, StringComparison.Ordinal))
+               && (localName == "*" || string.Equals(element.LocalName, localName, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -327,13 +345,27 @@ internal class DomHostHooks
 
     /// <summary>Whether <paramref name="element"/>'s classes contain every one of <paramref name="classes"/>.</summary>
     /// <remarks>
+    /// <para>
     /// The element's own token set is scanned in place rather than split: this runs once per descendant per
     /// read of a live collection, and a page that keeps one and reads its <c>length</c> in a loop would
     /// otherwise allocate an array per element per read.
+    /// </para>
+    /// <para>
+    /// <b>The attribute is read by namespace and local name, not by qualified name.</b> DOM's
+    /// <a href="https://dom.spec.whatwg.org/#concept-class">classes</a> are the token set of
+    /// <c>classList</c>, and DOM §7.1 reads that attribute by "getting an attribute value given null
+    /// namespace and the local name <c>class</c>" — whereas <c>getAttribute("class")</c> is the
+    /// <i>qualified</i>-name lookup, which also finds an attribute someone put in a namespace under that
+    /// spelling and would answer its value in preference to the real one when an element carries both.
+    /// <c>className</c> and <c>classList</c> already read the content attribute, so the qualified-name form
+    /// made this algorithm the one reader of an element's classes that disagreed with them. It is also the
+    /// cheaper of the two on the hot path, because the qualified form ASCII-folds the name it is given on
+    /// every call for an element in the HTML namespace.
+    /// </para>
     /// </remarks>
     private static bool HasEveryClass(IElement element, string[] classes, bool quirks)
     {
-        var declared = element.GetAttribute("class");
+        var declared = element.GetAttribute(null, AttributeNames.Class);
 
         if (string.IsNullOrEmpty(declared))
         {

--- a/Jint.Browser/Dom/DomObsoleteMembers.cs
+++ b/Jint.Browser/Dom/DomObsoleteMembers.cs
@@ -30,12 +30,12 @@ internal static class DomObsoleteMembers
     /// rooted at the document whose filter matches nothing, which is to say permanently empty.
     /// </summary>
     /// <remarks>
-    /// It is a <see cref="DomLiveHtmlCollection"/> over an empty sequence rather than a snapshot type, so the
-    /// ordinary <c>HTMLCollection</c> wrapper — its indexed access, its named access, its <c>length</c> — is
-    /// the one every other collection uses, and <c>document.applets</c> is a real <c>HTMLCollection</c>
-    /// instead of an object that merely looks like one.
+    /// It is a <see cref="DomLiveHtmlCollection"/> with the filter that matches nothing rather than a
+    /// snapshot type, so the ordinary <c>HTMLCollection</c> wrapper — its indexed access, its named access,
+    /// its <c>length</c> — is the one every other collection uses, and <c>document.applets</c> is a real
+    /// <c>HTMLCollection</c> instead of an object that merely looks like one.
     /// </remarks>
     internal static JsValue Applets(DomRealm realm, IDocument document)
         => realm.WrapCollection<IElement>(
-            _applets.GetValue(document, static _ => new DomLiveHtmlCollection(static () => [])));
+            _applets.GetValue(document, static key => new DomLiveHtmlCollection(key, DomElementFilter.None)));
 }

--- a/Jint.Browser/Dom/Generated/DomCollectionAccessors.g.cs
+++ b/Jint.Browser/Dom/Generated/DomCollectionAccessors.g.cs
@@ -139,6 +139,19 @@ internal sealed class DomAccessorDOMStringMap : DomCollectionAccessor
         return names;
     }
 
+    internal override bool HasSupportedName(object target, string name)
+    {
+        foreach (var entry in (global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<global::System.String, global::System.String>>) target)
+        {
+            if (entry.Value is not null && string.Equals(entry.Key, name, global::System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     internal override bool TryGetNamed(DomRealm realm, object target, string name, out global::Jint.Native.JsValue value)
     {
         var item = ((global::AngleSharp.Dom.IStringMap) target)[name];
@@ -234,8 +247,9 @@ internal sealed class DomAccessorHTMLFormElement : DomCollectionAccessor
     internal override global::System.Collections.Generic.IReadOnlyList<string> SupportedNames(object target)
     {
         var collection = (global::AngleSharp.Html.Dom.IHtmlFormElement) target;
-        var names = new global::System.Collections.Generic.List<string>(collection.Length);
-        for (var i = 0; i < collection.Length; i++)
+        var length = collection.Length;
+        var names = new global::System.Collections.Generic.List<string>(length);
+        for (var i = 0; i < length; i++)
         {
             var item = collection[i];
             if (item is null)
@@ -256,6 +270,29 @@ internal sealed class DomAccessorHTMLFormElement : DomCollectionAccessor
                 names.Add(name!);
             }
         }
+    }
+
+    internal override bool HasSupportedName(object target, string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        var collection = (global::AngleSharp.Html.Dom.IHtmlFormElement) target;
+        var length = collection.Length;
+        for (var i = 0; i < length; i++)
+        {
+            var item = collection[i];
+            if (item is not null
+                && (string.Equals(item.GetAttribute("name"), name, global::System.StringComparison.Ordinal)
+                    || string.Equals(item.Id, name, global::System.StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal override bool TryGetNamed(DomRealm realm, object target, string name, out global::Jint.Native.JsValue value)
@@ -339,13 +376,29 @@ internal sealed class DomAccessorNamedNodeMap : DomCollectionAccessor
     internal override global::System.Collections.Generic.IReadOnlyList<string> SupportedNames(object target)
     {
         var collection = (global::AngleSharp.Dom.INamedNodeMap) target;
-        var names = new global::System.Collections.Generic.List<string>(collection.Length);
-        for (var i = 0; i < collection.Length; i++)
+        var length = collection.Length;
+        var names = new global::System.Collections.Generic.List<string>(length);
+        for (var i = 0; i < length; i++)
         {
             names.Add(collection[i]!.Name);
         }
 
         return names;
+    }
+
+    internal override bool HasSupportedName(object target, string name)
+    {
+        var collection = (global::AngleSharp.Dom.INamedNodeMap) target;
+        var length = collection.Length;
+        for (var i = 0; i < length; i++)
+        {
+            if (string.Equals(collection[i]!.Name, name, global::System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal override bool AreNamesEnumerable => false;

--- a/Jint.Tests.Browser/Dom/ClassNameCollectionTests.cs
+++ b/Jint.Tests.Browser/Dom/ClassNameCollectionTests.cs
@@ -141,6 +141,47 @@ public sealed class ClassNameCollectionTests
         fixture.Text("[...document.getElementsByClassName('match')].map(x => x.id).join(',')").Should().Be("own");
     }
 
+    /// <summary>
+    /// The element walk behind a live collection keeps a stack of child indices whose first levels live
+    /// inside the walker and which spills to the heap below that, so a document deeper than the inline part
+    /// is the case that exercises the spill — and, on the way back up, the case that reads a level recorded
+    /// before it. Matches at every depth, and in tree order, is what says both halves of that stack agree.
+    /// </summary>
+    [Test]
+    public void DeeplyNestedDocumentIsWalkedInTreeOrderPastTheInlineIndexStack()
+    {
+        using var fixture = DomTestFixture.Create("<!doctype html><body><main id='root'></main></body>");
+        fixture.Execute("""
+            var depth = 40;
+            var parent = document.getElementById('root');
+            for (var i = 0; i < depth; i++) {
+                var child = document.createElement('div');
+                child.id = 'd' + i;
+                child.className = 'match';
+                // A sibling at every level, so unwinding has somewhere to go rather than running straight
+                // back to the root.
+                var sibling = document.createElement('span');
+                sibling.id = 's' + i;
+                sibling.className = 'match';
+                parent.appendChild(child);
+                parent.appendChild(sibling);
+                parent = child;
+            }
+            var items = document.getElementsByClassName('match');
+            // Pre-order: down the whole chain of divs first, then every span on the way back up, each one
+            // reached from the level its own index was pushed at.
+            var expected = [];
+            for (var i = 0; i < depth; i++) { expected.push('d' + i); }
+            for (var i = depth - 1; i >= 0; i--) { expected.push('s' + i); }
+            """);
+
+        fixture.Number("items.length").Should().Be(80);
+        fixture.Bool("[...items].map(x => x.id).join(',') === expected.join(',')").Should().BeTrue();
+        fixture.Bool("items[39].id === 'd39' && items.item(40).id === 's39' && items[79].id === 's0'").Should().BeTrue();
+        fixture.Bool("items.namedItem('s39') === document.getElementById('s39')").Should().BeTrue();
+        fixture.Bool("items[80] === undefined").Should().BeTrue();
+    }
+
     /// <summary>An XML document is never in quirks mode, so its comparison is exact from both roots.</summary>
     [Test]
     public void XmlDocumentRemainsCaseSensitive()

--- a/Jint.Tests.Browser/Dom/ClassNameCollectionTests.cs
+++ b/Jint.Tests.Browser/Dom/ClassNameCollectionTests.cs
@@ -108,6 +108,39 @@ public sealed class ClassNameCollectionTests
         fixture.Number("items.length").Should().Be(1);
     }
 
+    /// <summary>
+    /// https://dom.spec.whatwg.org/#concept-getelementsbyclassname matches "descendant elements that have
+    /// all their classes in classes", and an element's
+    /// <a href="https://dom.spec.whatwg.org/#concept-class">classes</a> are the token set of
+    /// <c>classList</c>, whose associated attribute DOM §7.1 reads by <b>getting an attribute value given
+    /// null namespace and the local name <c>class</c></b>. That is not
+    /// <a href="https://dom.spec.whatwg.org/#dom-element-getattribute"><c>getAttribute("class")</c></a>,
+    /// which matches a <i>qualified</i> name — so an attribute placed in a namespace under the qualified
+    /// name <c>class</c> is reachable through <c>getAttribute</c> and is still not the class content
+    /// attribute, exactly as <c>className</c> and <c>classList</c> already say it is not.
+    /// </summary>
+    [Test]
+    public void NamespacedAttributeSpelledClassIsNotOneOfTheElementsClasses()
+    {
+        using var fixture = DomTestFixture.Create(
+            "<!doctype html><body><span id='namespaced'></span><span id='own'></span></body>");
+        fixture.Execute("""
+            document.getElementById('namespaced').setAttributeNS('http://example.test/ns', 'class', 'match');
+            document.getElementById('own').setAttribute('class', 'match');
+            """);
+
+        // It is an attribute, and the qualified-name lookup finds it.
+        fixture.Text("document.getElementById('namespaced').getAttribute('class')").Should().Be("match");
+
+        // It is not the class content attribute, which is what every other reader of the element's classes
+        // already agrees about.
+        fixture.Text("document.getElementById('namespaced').className").Should().BeEmpty();
+        fixture.Number("document.getElementById('namespaced').classList.length").Should().Be(0);
+
+        // ... so the collection has to agree with them rather than with getAttribute.
+        fixture.Text("[...document.getElementsByClassName('match')].map(x => x.id).join(',')").Should().Be("own");
+    }
+
     /// <summary>An XML document is never in quirks mode, so its comparison is exact from both roots.</summary>
     [Test]
     public void XmlDocumentRemainsCaseSensitive()

--- a/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
+++ b/tools/dom-bindings/Jint.Browser.BindingGenerator/ModelBuilder.cs
@@ -1455,6 +1455,11 @@ internal sealed class ModelBuilder
             builder.Append("            // same instant, and TryGetNamed reads null as an authoritative miss. Otherwise a key could\n");
             builder.Append("            // enumerate while reading as undefined — the exact incoherence host verification catches.\n");
             builder.Append("            if (entry.Value is not null)\n            {\n                names.Add(entry.Key);\n            }\n        }\n\n        return names;\n    }\n\n");
+
+            builder.Append("    internal override bool HasSupportedName(object target, string name)\n    {\n");
+            builder.Append("        foreach (var entry in (").Append(CSharpNames.Render(pair)).Append(") target)\n        {\n");
+            builder.Append("            if (entry.Value is not null && string.Equals(entry.Key, name, global::System.StringComparison.Ordinal))\n");
+            builder.Append("            {\n                return true;\n            }\n        }\n\n        return false;\n    }\n\n");
         }
         else
         {
@@ -1473,18 +1478,34 @@ internal sealed class ModelBuilder
             var elementItems = FindIndexedGetter(model.ClrType) is { } indexedGetter
                 && Closure(indexedGetter.PropertyType).Any(t => t.FullName == "AngleSharp.Dom.IElement");
 
+            // The collection's count is read once into a local rather than left in the loop condition. It
+            // reads like a field on most of these interfaces and is one on several, but IHtmlFormElement's
+            // Length is its form-control collection's, which is a Count() over a filtered walk of the
+            // document: leaving it in the condition ran that query once per element listed.
             if (length is not null && itemName is null && elementItems)
             {
                 builder.Append("    internal override global::System.Collections.Generic.IReadOnlyList<string> SupportedNames(object target)\n    {\n");
                 builder.Append("        var collection = (").Append(target).Append(") target;\n");
-                builder.Append("        var names = new global::System.Collections.Generic.List<string>(collection.").Append(length.Name).Append(");\n");
-                builder.Append("        for (var i = 0; i < collection.").Append(length.Name).Append("; i++)\n        {\n");
+                builder.Append("        var length = collection.").Append(length.Name).Append(";\n");
+                builder.Append("        var names = new global::System.Collections.Generic.List<string>(length);\n");
+                builder.Append("        for (var i = 0; i < length; i++)\n        {\n");
                 builder.Append("            var item = collection[i];\n");
                 builder.Append("            if (item is null)\n            {\n                continue;\n            }\n\n");
                 builder.Append("            Add(names, item.GetAttribute(\"name\"));\n");
                 builder.Append("            Add(names, item.Id);\n        }\n\n        return names;\n\n");
                 builder.Append("        static void Add(global::System.Collections.Generic.List<string> names, string? name)\n        {\n");
                 builder.Append("            if (!string.IsNullOrEmpty(name) && !names.Contains(name!))\n            {\n                names.Add(name!);\n            }\n        }\n    }\n\n");
+
+                builder.Append("    internal override bool HasSupportedName(object target, string name)\n    {\n");
+                builder.Append("        if (string.IsNullOrEmpty(name))\n        {\n            return false;\n        }\n\n");
+                builder.Append("        var collection = (").Append(target).Append(") target;\n");
+                builder.Append("        var length = collection.").Append(length.Name).Append(";\n");
+                builder.Append("        for (var i = 0; i < length; i++)\n        {\n");
+                builder.Append("            var item = collection[i];\n");
+                builder.Append("            if (item is not null\n");
+                builder.Append("                && (string.Equals(item.GetAttribute(\"name\"), name, global::System.StringComparison.Ordinal)\n");
+                builder.Append("                    || string.Equals(item.Id, name, global::System.StringComparison.Ordinal)))\n");
+                builder.Append("            {\n                return true;\n            }\n        }\n\n        return false;\n    }\n\n");
             }
             else if (length is null || itemName is null)
             {
@@ -1494,9 +1515,17 @@ internal sealed class ModelBuilder
             {
                 builder.Append("    internal override global::System.Collections.Generic.IReadOnlyList<string> SupportedNames(object target)\n    {\n");
                 builder.Append("        var collection = (").Append(target).Append(") target;\n");
-                builder.Append("        var names = new global::System.Collections.Generic.List<string>(collection.").Append(length.Name).Append(");\n");
-                builder.Append("        for (var i = 0; i < collection.").Append(length.Name).Append("; i++)\n        {\n");
+                builder.Append("        var length = collection.").Append(length.Name).Append(";\n");
+                builder.Append("        var names = new global::System.Collections.Generic.List<string>(length);\n");
+                builder.Append("        for (var i = 0; i < length; i++)\n        {\n");
                 builder.Append("            names.Add(collection[i]!.").Append(itemName.Name).Append(");\n        }\n\n        return names;\n    }\n\n");
+
+                builder.Append("    internal override bool HasSupportedName(object target, string name)\n    {\n");
+                builder.Append("        var collection = (").Append(target).Append(") target;\n");
+                builder.Append("        var length = collection.").Append(length.Name).Append(";\n");
+                builder.Append("        for (var i = 0; i < length; i++)\n        {\n");
+                builder.Append("            if (string.Equals(collection[i]!.").Append(itemName.Name).Append(", name, global::System.StringComparison.Ordinal))\n");
+                builder.Append("            {\n                return true;\n            }\n        }\n\n        return false;\n    }\n\n");
             }
 
             // https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties, which NamedNodeMap and


### PR DESCRIPTION
## What the profile said

A workload looping `for (i = 0; i < c.length; i++) c[i]` over four live collections —
`getElementsByClassName`, `getElementsByTagName`, `form.elements`, `children` — on a 1,500-element
document, profiled under ultra at 8190 Hz on `net10.0`:

`AngleSharp.Dom.NodeExtensions.GetDescendantsAndSelf.MoveNext` is **33.6 % inclusive** of the page-loop
thread, and the inverted call tree splits its callers three ways — three whole document walks per loop
iteration:

| caller | share of that subtree | what it is |
| --- | ---: | --- |
| `JintMemberExpression.GetValue` (direct) | 36.3 % | the `_collection.Length` **bounds pre-check** inside `DomHtmlCollectionObject.TryGetIndex` |
| `NumericConstantComparisonLane.TryReadLengthBound` | 35.3 % | the loop's own `i < c.length` |
| `DomLiveHtmlCollection.get_Item` | 28.3 % | the actual `c[i]` |

Around it, `CastHelpers.IsInstanceOfAny` + `StelemRef_Helper` + `IsInstanceOfInterface` +
`ChkCastInterface` were 19.3 % self — `StelemRef_Helper` alone 6.1 %, which is the array-covariance store
check on `Stack<INode>.Push` inside `GetDescendantsAndSelf`. That is the exact cost AngleSharp's own
internal `ElementTreeEnumerator` was written to avoid, and which `GetDescendantsAndSelf` does not use.

## The mechanism

**Nothing here memoizes.** These collections are live by specification and every read still re-runs the
filter against whatever the tree now is. What changes is that a read is **one** walk rather than two or
three, and that the walk **allocates nothing**. A generation-keyed memo is a different change that depends
on an AngleSharp change landing first, and it is not this one.

### 1. Stop asking for `Length` before indexing

`DomHtmlCollectionObject.TryGetIndex` read `_collection.Length` for a bounds check and then
`_collection[index]`. Every `IHtmlCollection<T>` that wrapper is handed is a **lazy view over a tree walk**,
not a list:

* AngleSharp's `HtmlCollection<T>` (`children`, and the snapshot collections) holds an `IEnumerable<T>`
  whose `Length` is `_elements.Count()` and whose indexer is `GetItemByIndex`, a linear scan;
* its `HtmlFormControlsCollection` (`form.elements`) is a `Where` over the form-control descendants of the
  **whole document**, re-run per read;
* the binding's own `DomLiveHtmlCollection` re-runs its filter.

So the pre-check ran the entire query a second time on every element read. It is gone: the index walk
already knows when it ran out, and running out **is** the bounds answer. `HasIndex` follows, and
`DomHtmlAllCollectionObject` (`document.all`, also a lazy view) gets the same treatment.

### 2. Make the walk itself cheap

`DomElementWalker` is a **struct** depth-first pre-order walk over the public `INode` surface —
`ChildNodes`, its indexer, and `Parent` — with an index stack whose first 16 levels live in an
`[InlineArray]` inside the struct. It is the design AngleSharp's internal `ElementTreeEnumerator` arrived
at, and its comment gives the reason: an index stack stores value types, pays no covariance check, and is
bounded by the tree's *depth* rather than its *width*. That type is internal to AngleSharp and cannot be
referenced, so this is the same shape written against the public surface, and rooted at a node that need
not itself be an element (these queries are called on documents and fragments too).

It replaces `root.Descendants<IElement>().Where(…)`, which per read was a `Stack<INode>` plus its backing
array, a covariance store per push, three chained iterators (`GetDescendantsAndSelf`, `Skip(1)`, `OfType`)
plus the `Where` — four virtual `MoveNext` calls and an interface type test per node — and a delegate
invocation per element.

`DomElementFilter` is the membership test as an object with a method rather than a `Func<IElement, bool>`.
That is not tidiness: the predicate depends on something read from the tree *at the moment of the read* —
`getElementsByClassName`'s comparison is ASCII case-insensitive exactly while the root's node document is
in quirks mode, and a root adopted into another document takes that document's mode with it — so a lambda
was a closure allocated per read. `BeginRead` refreshes that state once per read instead of once per
element, which is the same answer the closure gave.

### 3. Stop the named lane building three lists per read

`DomCollectionAccessor` gains `HasSupportedName(target, name)` — the membership half of `SupportedNames`,
which the generated accessors now implement as a scan. It is on the **read** path: `el.attributes.foo` asks
WebIDL's named-property-visibility question before the named getter runs, and answering it meant
materializing every attribute name into a `List<string>`, then a second filtered list, then scanning that
with the `Contains` overload taking a comparer — which is LINQ's, so it allocated an enumerator per
candidate. Three allocations and a walk of the whole map for a question about one member.

Two more things in the same area:

* the generated `SupportedNames` re-evaluated `collection.Length` **in the loop condition** and indexed
  inside the loop. For `HTMLFormElement` that `Length` is its form-control collection's, a `Count()` over a
  filtered walk of the document — so listing *n* names ran that query *n* times. The count is now read once
  into a local.
* the duplicate check in both `VisibleNames` (`HTMLCollection` and `HTMLAllCollection`) is a
  `HashSet<string>` rather than the same LINQ `Contains`: O(n²) comparisons and 2n allocations became O(n)
  and one.

## A spec fix that came with it

`HasEveryClass` read `element.GetAttribute("class")`. DOM's
[classes](https://dom.spec.whatwg.org/#concept-class) are `classList`'s token set, and DOM §7.1 reads that
attribute by *"getting an attribute value given null namespace and the local name `class`"* —
whereas [`getAttribute`](https://dom.spec.whatwg.org/#dom-element-getattribute) matches a **qualified**
name. So an attribute put in a namespace under the spelling `class` was one of the element's classes as far
as this algorithm was concerned, while `className` and `classList` both said it was not, and an element
carrying both would have answered the namespaced one's value. It now reads
`element.GetAttribute(null, AttributeNames.Class)`, which is what the standard asks for and what every
other reader of an element's classes already used.

`ClassNameCollectionTests.NamespacedAttributeSpelledClassIsNotOneOfTheElementsClasses` is the test.
**It fails on the old lookup** — and only on its last assertion: `getAttribute('class')` finding the
attribute, `className` being empty and `classList.length` being 0 all passed before the fix, which is
precisely the disagreement. The vendored wpt corpus does not cover the distinction (no
`getElementsByClassName` document uses `setAttributeNS`), so the test is ours.

It is also the cheaper read — the qualified form ASCII-folds the name it is given on every call for an
element in the HTML namespace — but correctness is why it changed.

## What did not change, and why

* **No cache and no invalidation signal.** Live means live; each read re-queries.
* **No second wrapper class.** `Jint.Browser/Dom/AGENTS.md` records why
  ([#4027](https://github.com/sebastienros/jint/pull/4027)): every `list[i]` reaches the interpreter as one
  virtual `ArrayLikeObject.TryGetIndex` devirtualized from a class profile holding one guess. The different
  read strategy is a field and a branch inside the class that already serves the interface, the same shape
  `DomCollectionObject` uses for the static `NodeList`.
* **The generated `TryGetIndex` keeps its `Length` pre-check.** It was checked. The interfaces that reach
  it are either indexable in constant time (`INodeList`, `INamedNodeMap`, `ITokenList`, `ICssRuleList` …),
  where a length probe is a field read and the cheapest possible bounds answer, or — `IHtmlFormElement`,
  `IHtmlSelectElement` — walk-backed but **not enumerable at all** on their public surface, so there is no
  one-pass form to emit. A blanket "enumerate instead" rule would turn `childNodes[i]` from O(1) into
  O(i), which is the `LiveNodeList` control row below. The walk-backed collections all arrive at the
  hand-written `DomHtmlCollectionObject`, which is where the change went.
* `Jint.Browser/Layout/**`, `Dom/Views/CssCascade.cs`, `ReadOnlyStyleDeclaration.cs`, `ResolvedStyle.cs`
  and `Accessibility/**` are untouched.

## Tests

* `dotnet build -c Release` — clean, `TreatWarningsAsErrors` on.
* `dotnet test -c Release Jint.Tests.Browser/Jint.Tests.Browser.csproj` — 2852 / 2849 passed (net10.0 /
  net8.0), 0 failed, 38 skipped. That includes the web-platform-tests browser lane and its census, and the
  generator round-trip (`DomBindingsStalenessTests`). **The wpt census figures did not move**: no exclusion
  or census file changed, and the pass count rose by exactly the one test added here.
* `dotnet test -c Release Jint.Tests/Jint.Tests.csproj` — 12426 / 12426 / 8516 passed (net10.0 / net8.0 /
  net472), 0 failed.
* The generated file was regenerated with `JINT_DOM_BINDINGS=update`; no `.g.cs` was hand-edited.

Failing before the fix: `NamespacedAttributeSpelledClassIsNotOneOfTheElementsClasses`, as described above.

## To be measured

`Jint.Benchmark/BrowserHtmlCollectionBenchmark` is new — the suite had **no** row for an `HTMLCollection`,
for `getElementsBy*`, for `form.elements` or for `children`. One `Page` per row built in `[GlobalSetup]`
and warmed with only its own script, `[MemoryDiagnoser]`, a `childNodes` control row the change does not
touch, and an `Array.from` floor as `[Benchmark(Baseline = true)]`.

```
dotnet run -c Release --project Jint.Benchmark\Jint.Benchmark.csproj -- --filter "*BrowserHtmlCollectionBenchmark*"
```

`ClassName`, `TagName`, `FormElements` and `Children` are the rows this change is about;
`LiveNodeList` is the control that must not move, and `PlainArray` is the floor.

**No figure is quoted here.** The rows were executed once on a contended machine purely to prove they run
end to end; those numbers are not reportable and are not repeated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQwq9NqYqG3kk9M8CKdfdJ
